### PR TITLE
Improve mobile dashboard

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -994,6 +994,7 @@
 									width={2}
 									height={Math.max(item.h, 2)}
 									oneventsclick={() => handleEventsClick(tile.stats!.id)}
+									showStacksBreakdown={false}
 								/>
 							</div>
 						{/if}

--- a/src/routes/dashboard/EnvironmentTile.svelte
+++ b/src/routes/dashboard/EnvironmentTile.svelte
@@ -26,9 +26,10 @@
 		width?: number;
 		height?: number;
 		oneventsclick?: () => void;
+		showStacksBreakdown?: boolean;
 	}
 
-	let { stats, width = 1, height = 1, oneventsclick }: Props = $props();
+	let { stats, width = 1, height = 1, oneventsclick, showStacksBreakdown = true }: Props = $props();
 
 	const EnvIcon = $derived(getIconComponent(stats.icon));
 
@@ -340,7 +341,7 @@
 					{#if stats.collectMetrics && stats.metrics}
 						<DashboardCpuMemoryBars metrics={stats.metrics} collectMetrics={stats.collectMetrics} />
 					{/if}
-					<DashboardResourceStats images={stats.images} volumes={stats.volumes} networks={stats.networks} stacks={stats.stacks} loading={stats.loading} />
+					<DashboardResourceStats images={stats.images} volumes={stats.volumes} networks={stats.networks} stacks={stats.stacks} loading={stats.loading} showStacksBreakdown={showStacksBreakdown} />
 					<DashboardEventsSummary today={stats.events.today} total={stats.events.total} />
 				</div>
 			{:else}
@@ -439,7 +440,7 @@
 					{#if stats.collectMetrics && stats.metrics}
 						<DashboardCpuMemoryBars metrics={stats.metrics} collectMetrics={stats.collectMetrics} />
 					{/if}
-					<DashboardResourceStats images={stats.images} volumes={stats.volumes} networks={stats.networks} stacks={stats.stacks} loading={stats.loading} />
+					<DashboardResourceStats images={stats.images} volumes={stats.volumes} networks={stats.networks} stacks={stats.stacks} loading={stats.loading} showStacksBreakdown={showStacksBreakdown} />
 					<DashboardEventsSummary today={stats.events.today} total={stats.events.total} />
 					{#if stats.recentEvents}
 						<DashboardRecentEvents events={stats.recentEvents} limit={8} onclick={oneventsclick} />
@@ -541,7 +542,7 @@
 					{#if stats.collectMetrics && stats.metrics}
 						<DashboardCpuMemoryBars metrics={stats.metrics} collectMetrics={stats.collectMetrics} />
 					{/if}
-					<DashboardResourceStats images={stats.images} volumes={stats.volumes} networks={stats.networks} stacks={stats.stacks} loading={stats.loading} />
+					<DashboardResourceStats images={stats.images} volumes={stats.volumes} networks={stats.networks} stacks={stats.stacks} loading={stats.loading} showStacksBreakdown={showStacksBreakdown} />
 					<DashboardEventsSummary today={stats.events.today} total={stats.events.total} />
 					{#if stats.recentEvents}
 						<DashboardRecentEvents events={stats.recentEvents} limit={8} onclick={oneventsclick} />
@@ -586,7 +587,7 @@
 						{#if stats.metrics}
 							<DashboardCpuMemoryBars metrics={stats.metrics} collectMetrics={stats.collectMetrics} />
 						{/if}
-						<DashboardResourceStats images={stats.images} volumes={stats.volumes} networks={stats.networks} stacks={stats.stacks} loading={stats.loading} />
+						<DashboardResourceStats images={stats.images} volumes={stats.volumes} networks={stats.networks} stacks={stats.stacks} loading={stats.loading} showStacksBreakdown={showStacksBreakdown} />
 						<DashboardEventsSummary today={stats.events.today} total={stats.events.total} />
 					</div>
 					<!-- Right column -->
@@ -632,7 +633,7 @@
 						{#if stats.metrics}
 							<DashboardCpuMemoryBars metrics={stats.metrics} collectMetrics={stats.collectMetrics} />
 						{/if}
-						<DashboardResourceStats images={stats.images} volumes={stats.volumes} networks={stats.networks} stacks={stats.stacks} loading={stats.loading} />
+						<DashboardResourceStats images={stats.images} volumes={stats.volumes} networks={stats.networks} stacks={stats.stacks} loading={stats.loading} showStacksBreakdown={showStacksBreakdown} />
 						<DashboardEventsSummary today={stats.events.today} total={stats.events.total} />
 						{#if stats.recentEvents}
 							<DashboardRecentEvents events={stats.recentEvents} limit={5} onclick={oneventsclick} />
@@ -684,7 +685,7 @@
 						{#if stats.metrics}
 							<DashboardCpuMemoryBars metrics={stats.metrics} collectMetrics={stats.collectMetrics} />
 						{/if}
-						<DashboardResourceStats images={stats.images} volumes={stats.volumes} networks={stats.networks} stacks={stats.stacks} loading={stats.loading} />
+						<DashboardResourceStats images={stats.images} volumes={stats.volumes} networks={stats.networks} stacks={stats.stacks} loading={stats.loading} showStacksBreakdown={showStacksBreakdown} />
 						<DashboardEventsSummary today={stats.events.today} total={stats.events.total} />
 						{#if stats.recentEvents}
 							<DashboardRecentEvents events={stats.recentEvents} limit={10} onclick={oneventsclick} />

--- a/src/routes/dashboard/dashboard-resource-stats.svelte
+++ b/src/routes/dashboard/dashboard-resource-stats.svelte
@@ -14,9 +14,10 @@
 		networks: { total: number };
 		stacks: { total: number; running: number; partial: number; stopped: number };
 		loading?: LoadingStates;
+		showStacksBreakdown?: boolean;
 	}
 
-	let { images, volumes, networks, stacks, loading }: Props = $props();
+	let { images, volumes, networks, stacks, loading, showStacksBreakdown = true }: Props = $props();
 
 	// Only show skeleton if loading AND we don't have data yet
 	// This prevents blinking when refreshing with existing data
@@ -46,7 +47,7 @@
 		{:else}
 			<span class="font-medium">
 				{stacks.total}
-				{#if stacks.total > 0}
+				{#if showStacksBreakdown && stacks.total > 0}
 					<span class="text-emerald-500">{stacks.running}</span>/<span class="text-amber-500">{stacks.partial}</span>/<span class="text-red-500">{stacks.stopped}</span>
 				{/if}
 			</span>


### PR DESCRIPTION
This PR introduces some changes to the way the Environment is shown **on mobile** devices only.
We do not touch the grid layout on desktop browser, but utilize a list view for mobile devices and ensure that each tile make use of the maximum width.

We also limit the detailed view of Stacks to just the total number of stacks due to space constraints.

This is a fairly small change that should ease some of the complaints seen in https://github.com/Finsys/dockhand/issues/33

See attached screenshot:

<img width="660" height="1434" alt="Dockhand - Docker Management" src="https://github.com/user-attachments/assets/40ba129e-bb71-4af2-b645-18cbca9a96c6" />
