### PR TITLE
Honor DATA_DIR env var in sqlite operations related to hawser connections

### DIFF
--- a/scripts/patch-build.ts
+++ b/scripts/patch-build.ts
@@ -105,7 +105,7 @@ function _getDb() {
 			_db = new _SQL(dbUrl);
 			_isPostgres = true;
 		} else {
-			const _dbPath = _join(process.cwd(), 'data', 'db', 'dockhand.db');
+			const dbPath = process.env.DATA_DIR ? _join(process.env.DATA_DIR, 'db', 'dockhand.db') : _join(process.cwd(), 'data', 'db', 'dockhand.db');
 			if (_existsSync(_dbPath)) {
 				_db = new _Database(_dbPath);
 			}


### PR DESCRIPTION
When using sqlite and relative path mappings the sqlite database is created in the `DATA_DIR/db` directory. However the index.js patcher uses the default path (`/app/data/db`) ignoring the `DATA_DIR` environment variable, so the `_getDb` function fails to load the database file. As a result `_validateHawserToken` function always returns `false` so the hawser edge connections fail with `[Hawser] Invalid token` regardless whether the token is valid or not.

Relates to #96