### PR TITLE
feat: add Mattermost notification support

### DIFF
--- a/src/lib/server/notifications.ts
+++ b/src/lib/server/notifications.ts
@@ -113,6 +113,9 @@ async function sendToAppriseUrl(url: string, payload: NotificationPayload): Prom
 			case 'slack':
 			case 'slacks':
 				return await sendSlack(url, payload);
+			case 'mmost':
+			case 'mmosts':
+				return await sendMattermost(url, payload);
 			case 'tgram':
 				return await sendTelegram(url, payload);
 			case 'gotify':
@@ -179,6 +182,54 @@ async function sendSlack(appriseUrl: string, payload: NotificationPayload): Prom
 		body: JSON.stringify({
 			text: `*${payload.title}*${envTag}\n${payload.message}`
 		})
+	});
+
+	return response.ok;
+}
+
+// Mattermost webhook
+async function sendMattermost(appriseUrl: string, payload: NotificationPayload): Promise<boolean> {
+	// mmost://[botname@]hostname[:port][/path]/token or mmosts://...
+	const isSecure = appriseUrl.startsWith('mmosts');
+	const protocol = isSecure ? 'https' : 'http';
+
+	// Remove the scheme
+	let urlPart = appriseUrl.replace(/^mmosts?:\/\//, '');
+
+	// Check for botname (username@hostname format)
+	let username: string | undefined;
+	const atIndex = urlPart.indexOf('@');
+	if (atIndex !== -1) {
+		username = urlPart.substring(0, atIndex);
+		urlPart = urlPart.substring(atIndex + 1);
+	}
+
+	// The token is the last segment, everything else is hostname[:port][/path]
+	const lastSlashIndex = urlPart.lastIndexOf('/');
+	if (lastSlashIndex === -1) {
+		console.error('[Notifications] Invalid Mattermost URL format. Expected: mmost://[botname@]hostname[:port][/path]/token');
+		return false;
+	}
+
+	const token = urlPart.substring(lastSlashIndex + 1);
+	const hostAndPath = urlPart.substring(0, lastSlashIndex);
+
+	// Build the webhook URL: {protocol}://{hostname}[:{port}][/{path}]/hooks/{token}
+	const url = `${protocol}://${hostAndPath}/hooks/${token}`;
+
+	const envTag = payload.environmentName ? ` \`${payload.environmentName}\`` : '';
+	const body: Record<string, string> = {
+		text: `*${payload.title}*${envTag}\n${payload.message}`
+	};
+
+	if (username) {
+		body.username = username;
+	}
+
+	const response = await fetch(url, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body)
 	});
 
 	return response.ok;

--- a/src/routes/settings/notifications/NotificationModal.svelte
+++ b/src/routes/settings/notifications/NotificationModal.svelte
@@ -414,14 +414,15 @@
 							placeholder="gotify://hostname/app-token
 discord://webhook_id/webhook_token
 slack://token_a/token_b/token_c
+mmost://hostname/webhook-token
 tgram://bot_token/chat_id
 ntfy://my-topic
 pushover://user_key/api_token
 jsons://hostname/webhook/path"
-							class="flex min-h-[220px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-						></textarea>
-						<p class="text-xs text-muted-foreground">
-							Supports Gotify (gotify:// or gotifys:// for HTTPS), Discord, Slack, Telegram, ntfy, Pushover, and generic JSON webhooks.
+						class="flex min-h-[220px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+					></textarea>
+					<p class="text-xs text-muted-foreground">
+						Supports Gotify (gotify:// or gotifys:// for HTTPS), Discord, Slack, Mattermost (mmost:// or mmosts://), Telegram, ntfy, Pushover, and generic JSON webhooks.
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary

Add support for Mattermost webhooks via `mmost://` and `mmosts://` (secure) Apprise URL schemes. Supports optional botname override, custom ports, and custom paths.

Addresses [this comment](https://github.com/Finsys/dockhand/issues/15#issuecomment-3797796197) in #15.

## Changes

- Add `sendMattermost()` function in `src/lib/server/notifications.ts` following existing notification patterns
- Update `src/routes/settings/notifications/NotificationModal.svelte` to include Mattermost in examples and description

## URL Format

```
mmost://[botname@]hostname[:port][/path]/token
mmosts://[botname@]hostname[:port][/path]/token (HTTPS)
```

## Testing

| Test | Result |
|------|--------|
| Test notification button | ✅ Working |
| With custom botname (`mybot@hostname/token`) | ✅ Working |
| Without botname (`hostname/token`) | ✅ Working |
| Container events (kill, stop, die, start) | ✅ All send correctly |
| Markdown formatting in messages | ✅ Renders correctly |
| Invalid URL (missing token/slash) | ✅ Graceful error with log message |
| Built and tested Docker image on production server | ✅ Verified end-to-end |

---

Created with the assistance of AI (Claude Opus 4.5)