### PR TITLE
Prevent stack deployment from timing out

### DIFF
--- a/src/lib/server/docker.ts
+++ b/src/lib/server/docker.ts
@@ -467,7 +467,7 @@ export async function dockerFetch(
 				body,
 				headers,
 				streaming || false,
-				streaming ? 300000 : 30000 // 5 min for streaming, 30s for normal requests
+				streaming ? 300000 : 120000 // 5 min for streaming, 2 min for normal requests
 			);
 			const elapsed = Date.now() - startTime;
 			// Only warn for slow requests, but skip /stats which is expected to be slow (5-10s)


### PR DESCRIPTION
When deploying stacks on machines that are either slow/low resource or have slow internet connection, the deployment step often takes longer than 10 seconds. When that happens the deploy progress popover will show an error `TypeError: Error in input stream`.

This happens because the connection to `deploy-stream` endpoint gets eventually timed out either by any proxies in between or bun as it uses the default IDLE_TIMEOUT env var value of 10 seconds. Then the response reader errors out and produces the error `TypeError: Error in input stream`.

This PR adds a heartbeat to the deploy-stream API that fires every 5 seconds. The frontend will filter it out as the actual message doesn't start with `data: `. As such this is purely to keep the connection open and doesn't change or add anything visible to the user. The implementation is very similar to how e.g. merged-logs API already does it.

Additionally the hawser edge requests' timeout has been extended from 30 seconds to 2 minutes (when non-streaming). 30 seconds in mentioned scenarios is not enough and the popover would show error `Connection timeout`. 2 minutes is something that worked in my scenario, but happy to change to a more optimal value if needed.

I think this potentially addresses #329