### PR TITLE
Chore: update gitignore, add contributing docs, bug, feature request and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Something is not working
+title: "[BUG] Concise description of the issue"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        #### Thank you for taking the time to report a bug!
+        #### Have a question? 👉 [Start a new discussion](https://github.com/Finsys/dockhand/discussions/new).
+
+        #### Before opening an issue, please double check:
+
+        - [The troubleshooting documentation](https://dockhand.pro/manual/#troubleshooting).
+        - [The installation instructions](https://dockhand.pro/manual/#quick-start).
+        - [Existing issues and discussions](https://github.com/Finsys/dockhand/search?q=&type=issues).
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is. If applicable, add screenshots to help explain your problem.
+      placeholder: |
+        Currently Dockhand does not work when...
+
+        [Screenshot if applicable]
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Logs related to your issue.
+      render: bash
+    validations:
+      required: true
+  - type: textarea
+    id: logs_browser
+    attributes:
+      label: Browser logs
+      description: Logs from the web browser related to your issue, if needed
+      render: bash
+  - type: input
+    id: version
+    attributes:
+      label: Dockhand version
+      description: Check the 'About' section in Settings for the version number
+      placeholder: e.g. 1.0.14 352a295 (Jan 30, 2026)
+    validations:
+      required: true
+  - type: checkboxes
+    id: required-checks
+    attributes:
+      label: Please confirm the following
+      options:
+        - label: I have already searched for relevant existing issues and discussions before opening this report.
+          required: true
+        - label: I have updated the title field above with a concise description.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🤔 Questions and Help
+    url: https://github.com/Finsys/dockhand/discussions
+    about: General questions or support for using Dockhand.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest an idea for improving Dockhand
+title: "[Feature Request] Concise description of the feature"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a feature!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this feature solve?
+      placeholder: Describe the problem you’re facing.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like it to work?
+      placeholder: Describe your proposed solution.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or features you considered?
+      placeholder: List alternatives if any.
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots here.
+      placeholder: Optional details.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Proposed change
+
+<!--
+Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
+-->
+
+Closes #(issue or discussion)
+
+## Type of change
+
+<!--
+What type of change does your PR introduce to Dockhand?
+NOTE: Please check only one box!
+-->
+
+- [ ] Bug fix: non-breaking change which fixes an issue.
+- [ ] New feature / Enhancement: non-breaking change which adds functionality.
+- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
+- [ ] Other. Please explain:
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea/
 .DS_Store
+node_modules/
+.svelte-kit/
+bun.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+Dockhand welcomes all contributions so thank you for considering contributing!
+
+## How to Contribute
+1. Fork the repository on GitHub.
+2. Clone your forked repository to your local machine.
+3. Create a new branch for your feature or bug fix.
+4. Make your changes and commit them with clear messages.
+5. Push your changes to your forked repository.
+6. Open a pull request against the main repository's main branch.
+
+## Tech Stack
+
+- Base: own OS layer built from scratch using [Wolfi packages](https://github.com/wolfi-dev/os) via apko. Every package is explicitly declared in the Dockerfile.
+- Frontend: [SvelteKit 2](https://svelte.dev/docs/kit/introduction), [Svelte 5](https://svelte.dev), [shadcn-svelte](https://www.shadcn-svelte.com), [TailwindCSS](https://tailwindcss.com)
+- Backend: [Bun](https://bun.sh/) runtime with SvelteKit API routes
+- Database: SQLite or PostgreSQL via [Drizzle ORM](https://orm.drizzle.team)
+- Docker: direct docker API calls.
+
+## Getting Started
+
+1. Ensure you have Bun installed. You can download it from [Bun's official website](https://bun.sh/).
+2. Clone the repository (or your fork):
+   ```bash
+   git clone https://github.com/your-username/dockhand.git
+   cd dockhand
+   ```
+3. Install dependencies using Bun:
+   ```bash
+   bun install
+   ```
+4. Start the development server:
+   ```bash
+   bun dev
+   ```
+5. Open your browser and navigate to `http://localhost:5173` (or the port specified in the Bun output) to see the application running.
+
+## CLA Agreement
+
+When contributing to Dockhand, you will be asked to sign a Contributor License Agreement (CLA) to ensure that all contributions are properly licensed. This helps protect both you and the project. The agreement can be found [here](https://cla-assistant.io/Finsys/dockhand).


### PR DESCRIPTION
I added these all as separate commits in case you dont want any (/all 😅) of them:

- Ignore node_modules/, .svelte-kit/, and bun.lock from git
- Adds a basic CONTRIBUTING.md
- Adds a basic PR template
- Adds a basic bug report and feature request form template, and a [config](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) to choose between them

Obviously feel free to change whatever, and / or squash the PR.