### PR TITLE
chore(mfa): autofocus on the mfa code field on login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 node_modules/
 .svelte-kit/
 bun.lock
+data/db
+data/.encryption_key

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -294,6 +294,7 @@
 								required
 								disabled={loading}
 								autocomplete="one-time-code"
+								autofocus
 							/>
 							<p class="text-xs text-muted-foreground">
 								Enter the 6-digit code from your authenticator app, or use a backup code

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -264,6 +264,7 @@
 								required
 								disabled={loading}
 								autocomplete="username"
+								autofocus
 							/>
 						</div>
 


### PR DESCRIPTION
After logging in with user/pass, it'd be nice for the MFA code field to autofocus so you don't have to manually click it to paste. (Bitwarden has a nice feature to auto-copy the MFA code after entering user/pass, so all I need to do is paste)