### PR TITLE
Add --build flag for git stack deploys

### DIFF
--- a/drizzle-pg/0004_add_build_on_deploy.sql
+++ b/drizzle-pg/0004_add_build_on_deploy.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "git_stacks" ADD COLUMN "build_on_deploy" boolean DEFAULT true;

--- a/drizzle-pg/meta/_journal.json
+++ b/drizzle-pg/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1767687362730,
       "tag": "0003_add_stack_paths",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1767900000000,
+      "tag": "0004_add_build_on_deploy",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/0004_add_build_on_deploy.sql
+++ b/drizzle/0004_add_build_on_deploy.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `git_stacks` ADD `build_on_deploy` integer DEFAULT 1;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1767689000000,
       "tag": "0003_add_stack_paths",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1767900000000,
+      "tag": "0004_add_build_on_deploy",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -2049,6 +2049,7 @@ export interface GitStackData {
 	autoUpdateCron: string;
 	webhookEnabled: boolean;
 	webhookSecret: string | null;
+	buildOnDeploy: boolean;
 	lastSync: string | null;
 	lastCommit: string | null;
 	syncStatus: GitSyncStatus;
@@ -2402,6 +2403,7 @@ export async function createGitStack(data: {
 	autoUpdateCron?: string;
 	webhookEnabled?: boolean;
 	webhookSecret?: string | null;
+	buildOnDeploy?: boolean;
 }): Promise<GitStackWithRepo> {
 	const result = await db.insert(gitStacks).values({
 		stackName: data.stackName,
@@ -2413,7 +2415,8 @@ export async function createGitStack(data: {
 		autoUpdateSchedule: data.autoUpdateSchedule || 'daily',
 		autoUpdateCron: data.autoUpdateCron || '0 3 * * *',
 		webhookEnabled: data.webhookEnabled || false,
-		webhookSecret: data.webhookSecret || null
+		webhookSecret: data.webhookSecret || null,
+		buildOnDeploy: data.buildOnDeploy ?? true
 	}).returning();
 	return getGitStack(result[0].id) as Promise<GitStackWithRepo>;
 }
@@ -2430,6 +2433,7 @@ export async function updateGitStack(id: number, data: Partial<GitStackData>): P
 	if (data.autoUpdateCron !== undefined) updateData.autoUpdateCron = data.autoUpdateCron;
 	if (data.webhookEnabled !== undefined) updateData.webhookEnabled = data.webhookEnabled;
 	if (data.webhookSecret !== undefined) updateData.webhookSecret = data.webhookSecret;
+	if (data.buildOnDeploy !== undefined) updateData.buildOnDeploy = data.buildOnDeploy;
 	if (data.lastSync !== undefined) updateData.lastSync = data.lastSync;
 	if (data.lastCommit !== undefined) updateData.lastCommit = data.lastCommit;
 	if (data.syncStatus !== undefined) updateData.syncStatus = data.syncStatus;

--- a/src/lib/server/db/schema/index.ts
+++ b/src/lib/server/db/schema/index.ts
@@ -315,6 +315,7 @@ export const gitStacks = sqliteTable('git_stacks', {
 	autoUpdateCron: text('auto_update_cron').default('0 3 * * *'),
 	webhookEnabled: integer('webhook_enabled', { mode: 'boolean' }).default(false),
 	webhookSecret: text('webhook_secret'),
+	buildOnDeploy: integer('build_on_deploy', { mode: 'boolean' }).default(true),
 	lastSync: text('last_sync'),
 	lastCommit: text('last_commit'),
 	syncStatus: text('sync_status').default('pending'),

--- a/src/lib/server/db/schema/pg-schema.ts
+++ b/src/lib/server/db/schema/pg-schema.ts
@@ -318,6 +318,7 @@ export const gitStacks = pgTable('git_stacks', {
 	autoUpdateCron: text('auto_update_cron').default('0 3 * * *'),
 	webhookEnabled: boolean('webhook_enabled').default(false),
 	webhookSecret: text('webhook_secret'),
+	buildOnDeploy: boolean('build_on_deploy').default(true),
 	lastSync: timestamp('last_sync', { mode: 'string' }),
 	lastCommit: text('last_commit'),
 	syncStatus: text('sync_status').default('pending'),

--- a/src/lib/server/git.ts
+++ b/src/lib/server/git.ts
@@ -853,7 +853,8 @@ export async function deployGitStack(stackId: number, options?: { force?: boolea
 		sourceDir: syncResult.composeDir, // Copy entire directory from git repo
 		composeFileName: syncResult.composeFileName, // Use original compose filename from repo
 		envFileName: syncResult.envFileName, // Env file relative to compose dir (for --env-file flag, optional)
-		forceRecreate
+		forceRecreate,
+		build: gitStack.buildOnDeploy !== false // default true
 	});
 
 	console.log(`${logPrefix} ----------------------------------------`);
@@ -1093,7 +1094,8 @@ export async function deployGitStackWithProgress(
 			name: gitStack.stackName,
 			compose: composeContent,
 			envId: gitStack.environmentId,
-			sourceDir: composeDir // Copy entire directory from git repo
+			sourceDir: composeDir, // Copy entire directory from git repo
+			build: gitStack.buildOnDeploy !== false // default true
 		});
 
 		if (result.success) {

--- a/src/routes/api/git/stacks/+server.ts
+++ b/src/routes/api/git/stacks/+server.ts
@@ -118,7 +118,8 @@ export const POST: RequestHandler = async (event) => {
 			autoUpdateSchedule: data.autoUpdateSchedule || 'daily',
 			autoUpdateCron: data.autoUpdateCron || '0 3 * * *',
 			webhookEnabled: data.webhookEnabled || false,
-			webhookSecret: webhookSecret
+			webhookSecret: webhookSecret,
+			buildOnDeploy: data.buildOnDeploy
 		});
 
 		// Create stack_sources entry so the stack appears in the list immediately

--- a/src/routes/api/git/stacks/[id]/+server.ts
+++ b/src/routes/api/git/stacks/[id]/+server.ts
@@ -71,7 +71,8 @@ export const PUT: RequestHandler = async (event) => {
 			autoUpdateSchedule: data.autoUpdateSchedule,
 			autoUpdateCron: data.autoUpdateCron,
 			webhookEnabled: data.webhookEnabled,
-			webhookSecret: data.webhookSecret
+			webhookSecret: data.webhookSecret,
+			buildOnDeploy: data.buildOnDeploy
 		});
 
 		// If stack name changed, update related records

--- a/src/routes/stacks/GitStackModal.svelte
+++ b/src/routes/stacks/GitStackModal.svelte
@@ -6,7 +6,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Input } from '$lib/components/ui/input';
 	import { TogglePill } from '$lib/components/ui/toggle-pill';
-	import { Loader2, GitBranch, RefreshCw, Webhook, Rocket, RefreshCcw, Copy, Check, FolderGit2, Github, Key, KeyRound, Lock, FileText, HelpCircle, GripVertical, X, Download } from 'lucide-svelte';
+	import { Loader2, GitBranch, RefreshCw, Webhook, Rocket, RefreshCcw, Copy, Check, FolderGit2, Github, Key, KeyRound, Lock, FileText, HelpCircle, GripVertical, X, Download, Hammer } from 'lucide-svelte';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import CronEditor from '$lib/components/cron-editor.svelte';
 	import StackEnvVarsPanel from '$lib/components/StackEnvVarsPanel.svelte';
@@ -84,6 +84,7 @@
 	let formAutoUpdateCron = $state('0 3 * * *');
 	let formWebhookEnabled = $state(false);
 	let formWebhookSecret = $state('');
+	let formBuildOnDeploy = $state(true);
 	let formDeployNow = $state(false);
 	let formError = $state('');
 	let formSaving = $state(false);
@@ -345,6 +346,7 @@
 			formAutoUpdateCron = gitStack.autoUpdateCron || '0 3 * * *';
 			formWebhookEnabled = gitStack.webhookEnabled;
 			formWebhookSecret = gitStack.webhookSecret || '';
+			formBuildOnDeploy = gitStack.buildOnDeploy !== false;
 			formDeployNow = false;
 			// Load env files and overrides for editing (async - will populate envFiles, envVars, fileEnvVars)
 			loadEnvFiles();
@@ -367,6 +369,7 @@
 			formAutoUpdateCron = '0 3 * * *';
 			formWebhookEnabled = false;
 			formWebhookSecret = '';
+			formBuildOnDeploy = true;
 			formDeployNow = false;
 		}
 	}
@@ -423,6 +426,7 @@
 				autoUpdateCron: formAutoUpdateCron,
 				webhookEnabled: formWebhookEnabled,
 				webhookSecret: formWebhookEnabled ? formWebhookSecret : null,
+				buildOnDeploy: formBuildOnDeploy,
 				deployNow: deployAfterSave,
 				envVars: overrideVars.map(v => ({
 					key: v.key.trim(),
@@ -850,6 +854,20 @@
 						</p>
 					{/if}
 				{/if}
+			</div>
+
+			<!-- Build on deploy option -->
+			<div class="space-y-3 p-3 bg-muted/50 rounded-md">
+				<div class="flex items-center gap-3">
+					<div class="flex items-center gap-2 flex-1">
+						<Hammer class="w-4 h-4 text-muted-foreground" />
+						<Label class="text-sm font-normal">Build images on deploy</Label>
+					</div>
+					<TogglePill bind:checked={formBuildOnDeploy} />
+				</div>
+				<p class="text-xs text-muted-foreground">
+					Rebuild Docker images when deploying. Required for stacks that use <code>build:</code> in their compose file.
+				</p>
 			</div>
 
 			<!-- Deploy now option (only for new stacks) -->

--- a/tests/stack-git-flow.test.ts
+++ b/tests/stack-git-flow.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Git Stack Flow Tests
+ *
+ * Tests the buildOnDeploy feature for git stacks, verifying that
+ * the --build flag is correctly propagated through the deploy chain.
+ *
+ * These tests require a running Dockhand instance (default: http://localhost:3000).
+ * Set DOCKHAND_URL environment variable to override.
+ */
+import { describe, test, expect, beforeAll } from 'bun:test';
+
+const BASE_URL = process.env.DOCKHAND_URL || 'http://localhost:3000';
+
+// Helper to make authenticated API requests
+async function api(path: string, options: RequestInit = {}) {
+	const url = `${BASE_URL}${path}`;
+	const res = await fetch(url, {
+		...options,
+		headers: {
+			'Content-Type': 'application/json',
+			...(options.headers || {})
+		}
+	});
+	return { status: res.status, data: await res.json().catch(() => null) };
+}
+
+describe('Git Stack - buildOnDeploy', () => {
+	let testStackId: number | null = null;
+	let testRepoId: number | null = null;
+
+	// Cleanup after tests
+	async function cleanup() {
+		if (testStackId) {
+			await api(`/api/git/stacks/${testStackId}`, { method: 'DELETE' });
+			testStackId = null;
+		}
+		if (testRepoId) {
+			await api(`/api/git/repositories/${testRepoId}`, { method: 'DELETE' });
+			testRepoId = null;
+		}
+	}
+
+	test('GET /api/git/stacks returns buildOnDeploy in stack data', async () => {
+		const { status, data } = await api('/api/git/stacks');
+		// Even if no stacks exist, the endpoint should work
+		expect(status).toBe(200);
+		expect(Array.isArray(data)).toBe(true);
+
+		// If stacks exist, verify buildOnDeploy is present
+		if (data.length > 0) {
+			expect(data[0]).toHaveProperty('buildOnDeploy');
+		}
+	});
+
+	test('POST /api/git/stacks creates stack with buildOnDeploy=true by default', async () => {
+		// First, create a test repository
+		const repoRes = await api('/api/git/repositories', {
+			method: 'POST',
+			body: JSON.stringify({
+				name: `test-repo-build-${Date.now()}`,
+				url: 'https://github.com/example/test.git',
+				branch: 'main'
+			})
+		});
+
+		if (repoRes.status !== 200) {
+			console.log('Skipping: cannot create test repository (auth required?)');
+			return;
+		}
+
+		testRepoId = repoRes.data.id;
+
+		const { status, data } = await api('/api/git/stacks', {
+			method: 'POST',
+			body: JSON.stringify({
+				stackName: `test-build-default-${Date.now()}`,
+				repositoryId: testRepoId,
+				composePath: 'compose.yaml'
+			})
+		});
+
+		if (status !== 200) {
+			console.log('Skipping: cannot create test stack');
+			await cleanup();
+			return;
+		}
+
+		testStackId = data.id;
+
+		// buildOnDeploy should default to true
+		expect(data.buildOnDeploy).toBe(true);
+
+		await cleanup();
+	});
+
+	test('POST /api/git/stacks respects explicit buildOnDeploy=false', async () => {
+		const repoRes = await api('/api/git/repositories', {
+			method: 'POST',
+			body: JSON.stringify({
+				name: `test-repo-nobuild-${Date.now()}`,
+				url: 'https://github.com/example/test.git',
+				branch: 'main'
+			})
+		});
+
+		if (repoRes.status !== 200) {
+			console.log('Skipping: cannot create test repository (auth required?)');
+			return;
+		}
+
+		testRepoId = repoRes.data.id;
+
+		const { status, data } = await api('/api/git/stacks', {
+			method: 'POST',
+			body: JSON.stringify({
+				stackName: `test-nobuild-${Date.now()}`,
+				repositoryId: testRepoId,
+				composePath: 'compose.yaml',
+				buildOnDeploy: false
+			})
+		});
+
+		if (status !== 200) {
+			console.log('Skipping: cannot create test stack');
+			await cleanup();
+			return;
+		}
+
+		testStackId = data.id;
+
+		expect(data.buildOnDeploy).toBe(false);
+
+		await cleanup();
+	});
+
+	test('PUT /api/git/stacks/:id can toggle buildOnDeploy', async () => {
+		const repoRes = await api('/api/git/repositories', {
+			method: 'POST',
+			body: JSON.stringify({
+				name: `test-repo-toggle-${Date.now()}`,
+				url: 'https://github.com/example/test.git',
+				branch: 'main'
+			})
+		});
+
+		if (repoRes.status !== 200) {
+			console.log('Skipping: cannot create test repository (auth required?)');
+			return;
+		}
+
+		testRepoId = repoRes.data.id;
+
+		// Create with buildOnDeploy=true (default)
+		const createRes = await api('/api/git/stacks', {
+			method: 'POST',
+			body: JSON.stringify({
+				stackName: `test-toggle-${Date.now()}`,
+				repositoryId: testRepoId,
+				composePath: 'compose.yaml'
+			})
+		});
+
+		if (createRes.status !== 200) {
+			console.log('Skipping: cannot create test stack');
+			await cleanup();
+			return;
+		}
+
+		testStackId = createRes.data.id;
+		expect(createRes.data.buildOnDeploy).toBe(true);
+
+		// Update to buildOnDeploy=false
+		const updateRes = await api(`/api/git/stacks/${testStackId}`, {
+			method: 'PUT',
+			body: JSON.stringify({
+				buildOnDeploy: false
+			})
+		});
+
+		expect(updateRes.status).toBe(200);
+		expect(updateRes.data.buildOnDeploy).toBe(false);
+
+		// Update back to buildOnDeploy=true
+		const updateRes2 = await api(`/api/git/stacks/${testStackId}`, {
+			method: 'PUT',
+			body: JSON.stringify({
+				buildOnDeploy: true
+			})
+		});
+
+		expect(updateRes2.status).toBe(200);
+		expect(updateRes2.data.buildOnDeploy).toBe(true);
+
+		await cleanup();
+	});
+});


### PR DESCRIPTION
## Summary

- Adds per-stack **"Build images on deploy"** toggle (default: `true`) so `docker compose up` includes `--build` when deploying git stacks via webhook, auto-update, or manual deploy
- Fixes the issue where containers with `build:` directives in their compose file were recreated from cached images — code changes were never deployed
- Flag threads through the entire deploy chain: DB → API → `deployGitStack` → `deployStack` → `executeComposeCommand` → `executeLocalCompose` / `executeComposeViaHawser`

## Changes

| Area | Files | What |
|------|-------|------|
| DB Schema | `schema/index.ts`, `schema/pg-schema.ts` | `build_on_deploy` column (default true) |
| Migrations | `drizzle/0004_*`, `drizzle-pg/0004_*` | ALTER TABLE for SQLite + PostgreSQL |
| DB Functions | `db.ts` | `GitStackData`, `createGitStack`, `updateGitStack` |
| Deploy Chain | `stacks.ts` | `--build` in compose args + Hawser JSON body |
| Git Deploy | `git.ts` | Both `deployGitStack` and `deployGitStackWithProgress` |
| API | `api/git/stacks/+server.ts`, `[id]/+server.ts` | POST + PUT accept `buildOnDeploy` |
| Frontend | `GitStackModal.svelte` | TogglePill UI with Hammer icon |
| Tests | `tests/stack-git-flow.test.ts` | API-level tests for buildOnDeploy CRUD |

## Non-git stacks are unaffected

The `build` option only flows through when `DeployStackOptions.build` is explicitly set. Git stacks read it from `gitStack.buildOnDeploy`; all other stack types leave it `undefined` → no `--build` flag.

## Test plan

- [ ] Create a git stack with default settings → verify `buildOnDeploy: true` in response
- [ ] Toggle "Build images on deploy" OFF → verify `buildOnDeploy: false` persists
- [ ] Deploy a git stack with `build:` in compose file → verify `--build` appears in compose command
- [ ] Deploy a git stack with `buildOnDeploy: false` → verify `--build` is absent
- [ ] Deploy a non-git stack → verify no `--build` flag (no regression)
- [ ] Test Hawser deploy path → verify JSON body includes `build: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)