### PR TITLE
feat: notifications support Telegram topics in supergroups

### DIFF
--- a/src/lib/server/notifications.ts
+++ b/src/lib/server/notifications.ts
@@ -209,19 +209,21 @@ async function sendSlack(appriseUrl: string, payload: NotificationPayload): Prom
 
 // Telegram
 async function sendTelegram(appriseUrl: string, payload: NotificationPayload): Promise<NotificationResult> {
-	// tgram://bot_token/chat_id
-	const match = appriseUrl.match(/^tgram:\/\/([^/]+)\/(.+)/);
+	// tgram://bot_token/chat_id:topic_id?
+	const match = appriseUrl.match(/^tgram:\/\/([^/]+)\/([^:\/]+)(?::(\d+))?$/);
 	if (!match) {
-		return { success: false, error: 'Invalid Telegram URL format. Expected: tgram://bot_token/chat_id' };
+		return { success: false, error: 'Invalid Telegram URL format. Expected: tgram://bot_token/chat_id or tgram://bot_token/chat_id:topic_id' };
 	}
 
-	const [, botToken, chatId] = match;
+	const [, botToken, chatId, topicIdStr] = match;
 	const url = `https://api.telegram.org/bot${botToken}/sendMessage`;
 
 	// Escape markdown special characters in title and message
 	const escapedTitle = escapeTelegramMarkdown(payload.title);
 	const escapedMessage = escapeTelegramMarkdown(payload.message);
 	const envTag = payload.environmentName ? ` \\[${escapeTelegramMarkdown(payload.environmentName)}\\]` : '';
+
+	const topicId = Number.parseInt(topicIdStr, 10)
 
 	try {
 		const response = await fetch(url, {
@@ -230,6 +232,7 @@ async function sendTelegram(appriseUrl: string, payload: NotificationPayload): P
 			body: JSON.stringify({
 				chat_id: chatId,
 				text: `*${escapedTitle}*${envTag}\n${escapedMessage}`,
+				message_thread_id: Number.isNaN(topicId) ? undefined : topicId,
 				parse_mode: 'Markdown'
 			})
 		});

--- a/src/routes/settings/notifications/NotificationModal.svelte
+++ b/src/routes/settings/notifications/NotificationModal.svelte
@@ -415,6 +415,7 @@
 discord://webhook_id/webhook_token
 slack://token_a/token_b/token_c
 tgram://bot_token/chat_id
+tgram://bot_token/chat_id:topic_id
 ntfy://my-topic
 pushover://user_key/api_token
 jsons://hostname/webhook/path"


### PR DESCRIPTION
## Proposed change

Add support for sending notifications to Topics in Telegram supergroups, as Apprise supports it

## Type of change

<!--
What type of change does your PR introduce to Dockhand?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain:

