### PR TITLE
Add Harbor fallback for catalog and search endpoints

### DIFF
--- a/src/lib/server/docker.ts
+++ b/src/lib/server/docker.ts
@@ -2945,6 +2945,202 @@ export async function getRegistryAuth(
 	return { baseUrl, orgPath: parsed.path, authHeader };
 }
 
+// --- Harbor fallback pour le catalog et la recherche d'images ---
+// Harbor interdit l'accès au endpoint V2 _catalog pour les robots.
+// On détecte Harbor et on utilise l'API projet native en fallback.
+
+/** Cache de détection Harbor par host (TTL 5 min) */
+const harborDetectionCache = new Map<string, { isHarbor: boolean; ts: number }>();
+const HARBOR_CACHE_TTL = 5 * 60 * 1000;
+
+export interface HarborCatalogResult {
+	repositories: string[];
+	/** Curseur de pagination : "harbor:<page>" ou null si dernière page */
+	nextLast: string | null;
+}
+
+/**
+ * Détecte si un registry est une instance Harbor.
+ * Vérifie service="harbor-registry" dans le header WWW-Authenticate de /v2/,
+ * puis confirme via /api/v2.0/ping. Résultat mis en cache 5 min par host.
+ */
+export async function isHarborRegistry(registryUrl: string): Promise<boolean> {
+	const parsed = parseRegistryUrl(registryUrl);
+	const host = parsed.host;
+
+	const cached = harborDetectionCache.get(host);
+	if (cached && Date.now() - cached.ts < HARBOR_CACHE_TTL) {
+		return cached.isHarbor;
+	}
+
+	let isHarbor = false;
+	try {
+		const baseUrl = `https://${host}`;
+
+		// Étape 1 : vérifier le header WWW-Authenticate de /v2/
+		const challengeResp = await fetch(`${baseUrl}/v2/`, {
+			method: 'GET',
+			headers: { 'User-Agent': 'Dockhand/1.0' }
+		});
+		const wwwAuth = challengeResp.headers.get('WWW-Authenticate') || '';
+		if (wwwAuth.toLowerCase().includes('service="harbor-registry"')) {
+			// Étape 2 : confirmer via /api/v2.0/ping
+			const pingResp = await fetch(`${baseUrl}/api/v2.0/ping`, {
+				method: 'GET',
+				headers: { 'User-Agent': 'Dockhand/1.0' }
+			});
+			if (pingResp.ok) {
+				const body = await pingResp.text();
+				if (body.includes('Pong')) {
+					isHarbor = true;
+				}
+			}
+		}
+	} catch {
+		// En cas d'erreur réseau, on considère que ce n'est pas Harbor
+	}
+
+	harborDetectionCache.set(host, { isHarbor, ts: Date.now() });
+	return isHarbor;
+}
+
+/**
+ * Construit le header Basic auth pour l'API Harbor à partir d'un objet registry.
+ */
+function getHarborBasicAuth(registry: { username?: string | null; password?: string | null }): string | null {
+	if (registry.username && registry.password) {
+		return `Basic ${Buffer.from(`${registry.username}:${registry.password}`).toString('base64')}`;
+	}
+	return null;
+}
+
+/**
+ * Liste les repositories via l'API projet Harbor.
+ * Si orgPath est défini → un seul projet. Sinon → énumère tous les projets accessibles.
+ * @param page - numéro de page (1-based)
+ * @param pageSize - nombre de résultats par page
+ */
+export async function harborListRepositories(
+	registry: { url: string; username?: string | null; password?: string | null },
+	orgPath: string,
+	page: number = 1,
+	pageSize: number = 100
+): Promise<HarborCatalogResult> {
+	const parsed = parseRegistryUrl(registry.url);
+	const baseUrl = `https://${parsed.host}/api/v2.0`;
+	const authHeader = getHarborBasicAuth(registry);
+
+	const headers: Record<string, string> = {
+		'Accept': 'application/json',
+		'User-Agent': 'Dockhand/1.0'
+	};
+	if (authHeader) headers['Authorization'] = authHeader;
+
+	const repositories: string[] = [];
+	let totalCount = 0;
+
+	if (orgPath) {
+		// Un seul projet : le path sans le slash initial
+		const project = orgPath.replace(/^\//, '');
+		const url = `${baseUrl}/projects/${encodeURIComponent(project)}/repositories?page=${page}&page_size=${pageSize}`;
+		const resp = await fetch(url, { headers });
+
+		if (!resp.ok) {
+			throw new Error(`Harbor API erreur ${resp.status} pour le projet ${project}`);
+		}
+
+		totalCount = parseInt(resp.headers.get('X-Total-Count') || '0', 10);
+		const repos: Array<{ name: string }> = await resp.json();
+		for (const r of repos) {
+			repositories.push(r.name);
+		}
+	} else {
+		// Pas d'orgPath : énumérer tous les projets accessibles
+		const projectsResp = await fetch(`${baseUrl}/projects?page=1&page_size=100`, { headers });
+		if (!projectsResp.ok) {
+			throw new Error(`Harbor API erreur ${projectsResp.status} pour la liste des projets`);
+		}
+		const projects: Array<{ name: string }> = await projectsResp.json();
+
+		// Paginer les repos du premier projet correspondant à la page demandée
+		// Pour simplifier, on concatène tous les repos de tous les projets
+		for (const proj of projects) {
+			const url = `${baseUrl}/projects/${encodeURIComponent(proj.name)}/repositories?page=1&page_size=100`;
+			const resp = await fetch(url, { headers });
+			if (!resp.ok) continue;
+
+			const repos: Array<{ name: string }> = await resp.json();
+			for (const r of repos) {
+				repositories.push(r.name);
+			}
+		}
+		totalCount = repositories.length;
+	}
+
+	// Calculer si il y a une page suivante
+	const hasMore = orgPath ? (page * pageSize < totalCount) : false;
+	const nextLast = hasMore ? `harbor:${page + 1}` : null;
+
+	return { repositories, nextLast };
+}
+
+/**
+ * Recherche des repositories via l'API Harbor avec filtre q=name=~{term}.
+ * Parcourt tous les projets accessibles (ou un seul si orgPath défini).
+ * Double vérification substring côté client.
+ */
+export async function harborSearchRepositories(
+	registry: { url: string; username?: string | null; password?: string | null },
+	term: string,
+	orgPath: string,
+	limit: number = 25
+): Promise<string[]> {
+	const parsed = parseRegistryUrl(registry.url);
+	const baseUrl = `https://${parsed.host}/api/v2.0`;
+	const authHeader = getHarborBasicAuth(registry);
+
+	const headers: Record<string, string> = {
+		'Accept': 'application/json',
+		'User-Agent': 'Dockhand/1.0'
+	};
+	if (authHeader) headers['Authorization'] = authHeader;
+
+	const termLower = term.toLowerCase();
+	const results: string[] = [];
+
+	// Déterminer les projets à parcourir
+	let projectNames: string[];
+	if (orgPath) {
+		projectNames = [orgPath.replace(/^\//, '')];
+	} else {
+		const projectsResp = await fetch(`${baseUrl}/projects?page=1&page_size=100`, { headers });
+		if (!projectsResp.ok) return results;
+		const projects: Array<{ name: string }> = await projectsResp.json();
+		projectNames = projects.map(p => p.name);
+	}
+
+	// Chercher dans chaque projet avec le filtre Harbor
+	for (const proj of projectNames) {
+		if (results.length >= limit) break;
+
+		const q = encodeURIComponent(`name=~${term}`);
+		const url = `${baseUrl}/projects/${encodeURIComponent(proj)}/repositories?q=${q}&page=1&page_size=${limit}`;
+		const resp = await fetch(url, { headers });
+		if (!resp.ok) continue;
+
+		const repos: Array<{ name: string }> = await resp.json();
+		for (const r of repos) {
+			// Double vérification côté client
+			if (r.name.toLowerCase().includes(termLower)) {
+				results.push(r.name);
+				if (results.length >= limit) break;
+			}
+		}
+	}
+
+	return results;
+}
+
 /**
  * Check the registry for the current manifest digest of an image.
  * Simple HEAD request to get Docker-Content-Digest header.

--- a/src/lib/server/docker.ts
+++ b/src/lib/server/docker.ts
@@ -2945,24 +2945,24 @@ export async function getRegistryAuth(
 	return { baseUrl, orgPath: parsed.path, authHeader };
 }
 
-// --- Harbor fallback pour le catalog et la recherche d'images ---
-// Harbor interdit l'accès au endpoint V2 _catalog pour les robots.
-// On détecte Harbor et on utilise l'API projet native en fallback.
+// --- Harbor fallback for catalog and image search ---
+// Harbor denies access to the V2 _catalog endpoint for robot accounts.
+// We detect Harbor and use the native project API as a fallback.
 
-/** Cache de détection Harbor par host (TTL 5 min) */
+/** Harbor detection cache per host (TTL 5 min) */
 const harborDetectionCache = new Map<string, { isHarbor: boolean; ts: number }>();
 const HARBOR_CACHE_TTL = 5 * 60 * 1000;
 
 export interface HarborCatalogResult {
 	repositories: string[];
-	/** Curseur de pagination : "harbor:<page>" ou null si dernière page */
+	/** Pagination cursor: "harbor:<page>" or null if last page */
 	nextLast: string | null;
 }
 
 /**
- * Détecte si un registry est une instance Harbor.
- * Vérifie service="harbor-registry" dans le header WWW-Authenticate de /v2/,
- * puis confirme via /api/v2.0/ping. Résultat mis en cache 5 min par host.
+ * Detects whether a registry is a Harbor instance.
+ * Checks for service="harbor-registry" in the WWW-Authenticate header from /v2/,
+ * then confirms via /api/v2.0/ping. Result is cached for 5 min per host.
  */
 export async function isHarborRegistry(registryUrl: string): Promise<boolean> {
 	const parsed = parseRegistryUrl(registryUrl);
@@ -2977,14 +2977,14 @@ export async function isHarborRegistry(registryUrl: string): Promise<boolean> {
 	try {
 		const baseUrl = `https://${host}`;
 
-		// Étape 1 : vérifier le header WWW-Authenticate de /v2/
+		// Step 1: check the WWW-Authenticate header from /v2/
 		const challengeResp = await fetch(`${baseUrl}/v2/`, {
 			method: 'GET',
 			headers: { 'User-Agent': 'Dockhand/1.0' }
 		});
 		const wwwAuth = challengeResp.headers.get('WWW-Authenticate') || '';
 		if (wwwAuth.toLowerCase().includes('service="harbor-registry"')) {
-			// Étape 2 : confirmer via /api/v2.0/ping
+			// Step 2: confirm via /api/v2.0/ping
 			const pingResp = await fetch(`${baseUrl}/api/v2.0/ping`, {
 				method: 'GET',
 				headers: { 'User-Agent': 'Dockhand/1.0' }
@@ -2997,7 +2997,7 @@ export async function isHarborRegistry(registryUrl: string): Promise<boolean> {
 			}
 		}
 	} catch {
-		// En cas d'erreur réseau, on considère que ce n'est pas Harbor
+		// On network error, assume it's not Harbor
 	}
 
 	harborDetectionCache.set(host, { isHarbor, ts: Date.now() });
@@ -3005,7 +3005,7 @@ export async function isHarborRegistry(registryUrl: string): Promise<boolean> {
 }
 
 /**
- * Construit le header Basic auth pour l'API Harbor à partir d'un objet registry.
+ * Builds the Basic auth header for the Harbor API from a registry object.
  */
 function getHarborBasicAuth(registry: { username?: string | null; password?: string | null }): string | null {
 	if (registry.username && registry.password) {
@@ -3015,10 +3015,10 @@ function getHarborBasicAuth(registry: { username?: string | null; password?: str
 }
 
 /**
- * Liste les repositories via l'API projet Harbor.
- * Si orgPath est défini → un seul projet. Sinon → énumère tous les projets accessibles.
- * @param page - numéro de page (1-based)
- * @param pageSize - nombre de résultats par page
+ * Lists repositories via the Harbor project API.
+ * If orgPath is set, queries a single project. Otherwise, enumerates all accessible projects.
+ * @param page - page number (1-based)
+ * @param pageSize - number of results per page
  */
 export async function harborListRepositories(
 	registry: { url: string; username?: string | null; password?: string | null },
@@ -3040,13 +3040,13 @@ export async function harborListRepositories(
 	let totalCount = 0;
 
 	if (orgPath) {
-		// Un seul projet : le path sans le slash initial
+		// Single project: path without the leading slash
 		const project = orgPath.replace(/^\//, '');
 		const url = `${baseUrl}/projects/${encodeURIComponent(project)}/repositories?page=${page}&page_size=${pageSize}`;
 		const resp = await fetch(url, { headers });
 
 		if (!resp.ok) {
-			throw new Error(`Harbor API erreur ${resp.status} pour le projet ${project}`);
+			throw new Error(`Harbor API error ${resp.status} for project ${project}`);
 		}
 
 		totalCount = parseInt(resp.headers.get('X-Total-Count') || '0', 10);
@@ -3055,15 +3055,15 @@ export async function harborListRepositories(
 			repositories.push(r.name);
 		}
 	} else {
-		// Pas d'orgPath : énumérer tous les projets accessibles
+		// No orgPath: enumerate all accessible projects
 		const projectsResp = await fetch(`${baseUrl}/projects?page=1&page_size=100`, { headers });
 		if (!projectsResp.ok) {
-			throw new Error(`Harbor API erreur ${projectsResp.status} pour la liste des projets`);
+			throw new Error(`Harbor API error ${projectsResp.status} when listing projects`);
 		}
 		const projects: Array<{ name: string }> = await projectsResp.json();
 
-		// Paginer les repos du premier projet correspondant à la page demandée
-		// Pour simplifier, on concatène tous les repos de tous les projets
+		// Paginate repos from the first matching project
+		// For simplicity, concatenate all repos from all projects
 		for (const proj of projects) {
 			const url = `${baseUrl}/projects/${encodeURIComponent(proj.name)}/repositories?page=1&page_size=100`;
 			const resp = await fetch(url, { headers });
@@ -3077,7 +3077,7 @@ export async function harborListRepositories(
 		totalCount = repositories.length;
 	}
 
-	// Calculer si il y a une page suivante
+	// Check if there is a next page
 	const hasMore = orgPath ? (page * pageSize < totalCount) : false;
 	const nextLast = hasMore ? `harbor:${page + 1}` : null;
 
@@ -3085,9 +3085,9 @@ export async function harborListRepositories(
 }
 
 /**
- * Recherche des repositories via l'API Harbor avec filtre q=name=~{term}.
- * Parcourt tous les projets accessibles (ou un seul si orgPath défini).
- * Double vérification substring côté client.
+ * Searches repositories via the Harbor API using filter q=name=~{term}.
+ * Iterates through all accessible projects (or a single one if orgPath is set).
+ * Client-side substring double-check.
  */
 export async function harborSearchRepositories(
 	registry: { url: string; username?: string | null; password?: string | null },
@@ -3108,7 +3108,7 @@ export async function harborSearchRepositories(
 	const termLower = term.toLowerCase();
 	const results: string[] = [];
 
-	// Déterminer les projets à parcourir
+	// Determine which projects to iterate through
 	let projectNames: string[];
 	if (orgPath) {
 		projectNames = [orgPath.replace(/^\//, '')];
@@ -3119,7 +3119,7 @@ export async function harborSearchRepositories(
 		projectNames = projects.map(p => p.name);
 	}
 
-	// Chercher dans chaque projet avec le filtre Harbor
+	// Search each project using the Harbor filter
 	for (const proj of projectNames) {
 		if (results.length >= limit) break;
 
@@ -3130,7 +3130,7 @@ export async function harborSearchRepositories(
 
 		const repos: Array<{ name: string }> = await resp.json();
 		for (const r of repos) {
-			// Double vérification côté client
+			// Client-side double-check
 			if (r.name.toLowerCase().includes(termLower)) {
 				results.push(r.name);
 				if (results.length >= limit) break;

--- a/src/lib/server/docker.ts
+++ b/src/lib/server/docker.ts
@@ -3168,24 +3168,24 @@ export async function getRegistryAuth(
 	return { baseUrl, orgPath: parsed.path, authHeader };
 }
 
-// --- Harbor fallback pour le catalog et la recherche d'images ---
-// Harbor interdit l'accès au endpoint V2 _catalog pour les robots.
-// On détecte Harbor et on utilise l'API projet native en fallback.
+// --- Harbor fallback for catalog and image search ---
+// Harbor denies access to the V2 _catalog endpoint for robot accounts.
+// We detect Harbor and use the native project API as a fallback.
 
-/** Cache de détection Harbor par host (TTL 5 min) */
+/** Harbor detection cache per host (TTL 5 min) */
 const harborDetectionCache = new Map<string, { isHarbor: boolean; ts: number }>();
 const HARBOR_CACHE_TTL = 5 * 60 * 1000;
 
 export interface HarborCatalogResult {
 	repositories: string[];
-	/** Curseur de pagination : "harbor:<page>" ou null si dernière page */
+	/** Pagination cursor: "harbor:<page>" or null if last page */
 	nextLast: string | null;
 }
 
 /**
- * Détecte si un registry est une instance Harbor.
- * Vérifie service="harbor-registry" dans le header WWW-Authenticate de /v2/,
- * puis confirme via /api/v2.0/ping. Résultat mis en cache 5 min par host.
+ * Detects whether a registry is a Harbor instance.
+ * Checks for service="harbor-registry" in the WWW-Authenticate header from /v2/,
+ * then confirms via /api/v2.0/ping. Result is cached for 5 min per host.
  */
 export async function isHarborRegistry(registryUrl: string): Promise<boolean> {
 	const parsed = parseRegistryUrl(registryUrl);
@@ -3200,14 +3200,14 @@ export async function isHarborRegistry(registryUrl: string): Promise<boolean> {
 	try {
 		const baseUrl = `https://${host}`;
 
-		// Étape 1 : vérifier le header WWW-Authenticate de /v2/
+		// Step 1: check the WWW-Authenticate header from /v2/
 		const challengeResp = await fetch(`${baseUrl}/v2/`, {
 			method: 'GET',
 			headers: { 'User-Agent': 'Dockhand/1.0' }
 		});
 		const wwwAuth = challengeResp.headers.get('WWW-Authenticate') || '';
 		if (wwwAuth.toLowerCase().includes('service="harbor-registry"')) {
-			// Étape 2 : confirmer via /api/v2.0/ping
+			// Step 2: confirm via /api/v2.0/ping
 			const pingResp = await fetch(`${baseUrl}/api/v2.0/ping`, {
 				method: 'GET',
 				headers: { 'User-Agent': 'Dockhand/1.0' }
@@ -3220,7 +3220,7 @@ export async function isHarborRegistry(registryUrl: string): Promise<boolean> {
 			}
 		}
 	} catch {
-		// En cas d'erreur réseau, on considère que ce n'est pas Harbor
+		// On network error, assume it's not Harbor
 	}
 
 	harborDetectionCache.set(host, { isHarbor, ts: Date.now() });
@@ -3228,7 +3228,7 @@ export async function isHarborRegistry(registryUrl: string): Promise<boolean> {
 }
 
 /**
- * Construit le header Basic auth pour l'API Harbor à partir d'un objet registry.
+ * Builds the Basic auth header for the Harbor API from a registry object.
  */
 function getHarborBasicAuth(registry: { username?: string | null; password?: string | null }): string | null {
 	if (registry.username && registry.password) {
@@ -3238,10 +3238,10 @@ function getHarborBasicAuth(registry: { username?: string | null; password?: str
 }
 
 /**
- * Liste les repositories via l'API projet Harbor.
- * Si orgPath est défini → un seul projet. Sinon → énumère tous les projets accessibles.
- * @param page - numéro de page (1-based)
- * @param pageSize - nombre de résultats par page
+ * Lists repositories via the Harbor project API.
+ * If orgPath is set, queries a single project. Otherwise, enumerates all accessible projects.
+ * @param page - page number (1-based)
+ * @param pageSize - number of results per page
  */
 export async function harborListRepositories(
 	registry: { url: string; username?: string | null; password?: string | null },
@@ -3263,13 +3263,13 @@ export async function harborListRepositories(
 	let totalCount = 0;
 
 	if (orgPath) {
-		// Un seul projet : le path sans le slash initial
+		// Single project: path without the leading slash
 		const project = orgPath.replace(/^\//, '');
 		const url = `${baseUrl}/projects/${encodeURIComponent(project)}/repositories?page=${page}&page_size=${pageSize}`;
 		const resp = await fetch(url, { headers });
 
 		if (!resp.ok) {
-			throw new Error(`Harbor API erreur ${resp.status} pour le projet ${project}`);
+			throw new Error(`Harbor API error ${resp.status} for project ${project}`);
 		}
 
 		totalCount = parseInt(resp.headers.get('X-Total-Count') || '0', 10);
@@ -3278,15 +3278,15 @@ export async function harborListRepositories(
 			repositories.push(r.name);
 		}
 	} else {
-		// Pas d'orgPath : énumérer tous les projets accessibles
+		// No orgPath: enumerate all accessible projects
 		const projectsResp = await fetch(`${baseUrl}/projects?page=1&page_size=100`, { headers });
 		if (!projectsResp.ok) {
-			throw new Error(`Harbor API erreur ${projectsResp.status} pour la liste des projets`);
+			throw new Error(`Harbor API error ${projectsResp.status} when listing projects`);
 		}
 		const projects: Array<{ name: string }> = await projectsResp.json();
 
-		// Paginer les repos du premier projet correspondant à la page demandée
-		// Pour simplifier, on concatène tous les repos de tous les projets
+		// Paginate repos from the first matching project
+		// For simplicity, concatenate all repos from all projects
 		for (const proj of projects) {
 			const url = `${baseUrl}/projects/${encodeURIComponent(proj.name)}/repositories?page=1&page_size=100`;
 			const resp = await fetch(url, { headers });
@@ -3300,7 +3300,7 @@ export async function harborListRepositories(
 		totalCount = repositories.length;
 	}
 
-	// Calculer si il y a une page suivante
+	// Check if there is a next page
 	const hasMore = orgPath ? (page * pageSize < totalCount) : false;
 	const nextLast = hasMore ? `harbor:${page + 1}` : null;
 
@@ -3308,9 +3308,9 @@ export async function harborListRepositories(
 }
 
 /**
- * Recherche des repositories via l'API Harbor avec filtre q=name=~{term}.
- * Parcourt tous les projets accessibles (ou un seul si orgPath défini).
- * Double vérification substring côté client.
+ * Searches repositories via the Harbor API using filter q=name=~{term}.
+ * Iterates through all accessible projects (or a single one if orgPath is set).
+ * Client-side substring double-check.
  */
 export async function harborSearchRepositories(
 	registry: { url: string; username?: string | null; password?: string | null },
@@ -3331,7 +3331,7 @@ export async function harborSearchRepositories(
 	const termLower = term.toLowerCase();
 	const results: string[] = [];
 
-	// Déterminer les projets à parcourir
+	// Determine which projects to iterate through
 	let projectNames: string[];
 	if (orgPath) {
 		projectNames = [orgPath.replace(/^\//, '')];
@@ -3342,7 +3342,7 @@ export async function harborSearchRepositories(
 		projectNames = projects.map(p => p.name);
 	}
 
-	// Chercher dans chaque projet avec le filtre Harbor
+	// Search each project using the Harbor filter
 	for (const proj of projectNames) {
 		if (results.length >= limit) break;
 
@@ -3353,7 +3353,7 @@ export async function harborSearchRepositories(
 
 		const repos: Array<{ name: string }> = await resp.json();
 		for (const r of repos) {
-			// Double vérification côté client
+			// Client-side double-check
 			if (r.name.toLowerCase().includes(termLower)) {
 				results.push(r.name);
 				if (results.length >= limit) break;

--- a/src/lib/server/docker.ts
+++ b/src/lib/server/docker.ts
@@ -3172,7 +3172,7 @@ export async function getRegistryAuth(
 // Harbor denies access to the V2 _catalog endpoint for robot accounts.
 // We detect Harbor and use the native project API as a fallback.
 
-/** Harbor detection cache per host (TTL 5 min) */
+/** Harbor detection cache per host (TTL 5 min). Only definitive (non-error) detections are cached. */
 const harborDetectionCache = new Map<string, { isHarbor: boolean; ts: number }>();
 const HARBOR_CACHE_TTL = 5 * 60 * 1000;
 
@@ -3196,10 +3196,11 @@ export async function isHarborRegistry(registryUrl: string): Promise<boolean> {
 		return cached.isHarbor;
 	}
 
+	// Respect the registry's configured scheme and port (parsed.host includes the port).
+	const baseUrl = `${parsed.protocol}://${parsed.host}`;
+
 	let isHarbor = false;
 	try {
-		const baseUrl = `https://${host}`;
-
 		// Step 1: check the WWW-Authenticate header from /v2/
 		const challengeResp = await fetch(`${baseUrl}/v2/`, {
 			method: 'GET',
@@ -3219,27 +3220,108 @@ export async function isHarborRegistry(registryUrl: string): Promise<boolean> {
 				}
 			}
 		}
+		// A definitive answer was obtained (no network error): cache it.
+		harborDetectionCache.set(host, { isHarbor, ts: Date.now() });
 	} catch {
-		// On network error, assume it's not Harbor
+		// Network error: detection is indeterminate. Do NOT cache, so a transient
+		// outage can't pin "not Harbor" for the whole TTL and keep returning 403s
+		// once Harbor recovers.
 	}
 
-	harborDetectionCache.set(host, { isHarbor, ts: Date.now() });
 	return isHarbor;
 }
 
 /**
  * Builds the Basic auth header for the Harbor API from a registry object.
+ * Credentials are trimmed: pasted values often carry trailing whitespace that
+ * silently breaks Basic auth.
  */
 function getHarborBasicAuth(registry: { username?: string | null; password?: string | null }): string | null {
-	if (registry.username && registry.password) {
-		return `Basic ${Buffer.from(`${registry.username}:${registry.password}`).toString('base64')}`;
+	const username = registry.username?.trim();
+	const password = registry.password?.trim();
+	if (username && password) {
+		return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
 	}
 	return null;
 }
 
+/** Builds the common headers (JSON + Basic auth) for Harbor API requests. */
+function harborHeaders(registry: { username?: string | null; password?: string | null }): Record<string, string> {
+	const headers: Record<string, string> = {
+		'Accept': 'application/json',
+		'User-Agent': 'Dockhand/1.0'
+	};
+	const authHeader = getHarborBasicAuth(registry);
+	if (authHeader) headers['Authorization'] = authHeader;
+	return headers;
+}
+
+/** Removes Harbor query-grammar control characters so a search term can't break or alter the q filter. */
+function sanitizeHarborQueryTerm(term: string): string {
+	// Harbor's query grammar uses , = ~ ( ) as control characters.
+	return term.replace(/[,=~()]/g, '');
+}
+
+/**
+ * Follows Harbor list-endpoint pagination, collecting every item's name.
+ * Terminates on a short page or once X-Total-Count is reached; a safety cap
+ * bounds pathological servers (a warning is logged if it is hit).
+ */
+async function harborPaginateNames(
+	urlForPage: (page: number, pageSize: number) => string,
+	headers: Record<string, string>,
+	options: { throwOnFirstError: boolean; label: string }
+): Promise<string[]> {
+	const names: string[] = [];
+	const pageSize = 100;
+	const maxPages = 100; // ~10k items: defensive bound against a server that never returns a short page
+	let total = 0;
+	let page = 1;
+	while (page <= maxPages) {
+		const resp = await fetch(urlForPage(page, pageSize), { headers });
+		if (!resp.ok) {
+			if (page === 1 && options.throwOnFirstError) {
+				throw new Error(`Harbor API error ${resp.status} while ${options.label}`);
+			}
+			break;
+		}
+		if (page === 1) total = parseInt(resp.headers.get('X-Total-Count') || '0', 10);
+		const items: Array<{ name: string }> = await resp.json();
+		for (const item of items) names.push(item.name);
+		if (items.length < pageSize) break;
+		if (total > 0 && names.length >= total) break;
+		page++;
+	}
+	if (page > maxPages) {
+		console.warn(`[Harbor] Pagination safety cap (${maxPages} pages) reached while ${options.label}; the list may be truncated`);
+	}
+	return names;
+}
+
+/** Enumerates the names of all Harbor projects the account can access. */
+async function harborListAllProjects(baseUrl: string, headers: Record<string, string>): Promise<string[]> {
+	return harborPaginateNames(
+		(page, size) => `${baseUrl}/projects?page=${page}&page_size=${size}`,
+		headers,
+		{ throwOnFirstError: true, label: 'listing projects' }
+	);
+}
+
+/** Enumerates the names of all repositories within a single Harbor project. */
+async function harborListProjectRepositories(baseUrl: string, project: string, headers: Record<string, string>): Promise<string[]> {
+	return harborPaginateNames(
+		(page, size) => `${baseUrl}/projects/${encodeURIComponent(project)}/repositories?page=${page}&page_size=${size}`,
+		headers,
+		{ throwOnFirstError: false, label: `listing repositories of project ${project}` }
+	);
+}
+
 /**
  * Lists repositories via the Harbor project API.
- * If orgPath is set, queries a single project. Otherwise, enumerates all accessible projects.
+ * With orgPath set, paginates a single project natively (using X-Total-Count).
+ * Without orgPath, enumerates every accessible project and all of their
+ * repositories, then paginates the flattened list so the UI gets a correct
+ * hasMore signal instead of a silently truncated first page.
  * @param page - page number (1-based)
  * @param pageSize - number of results per page
  */
@@ -3250,67 +3332,44 @@ export async function harborListRepositories(
 	pageSize: number = 100
 ): Promise<HarborCatalogResult> {
 	const parsed = parseRegistryUrl(registry.url);
-	const baseUrl = `https://${parsed.host}/api/v2.0`;
-	const authHeader = getHarborBasicAuth(registry);
-
-	const headers: Record<string, string> = {
-		'Accept': 'application/json',
-		'User-Agent': 'Dockhand/1.0'
-	};
-	if (authHeader) headers['Authorization'] = authHeader;
-
-	const repositories: string[] = [];
-	let totalCount = 0;
+	const baseUrl = `${parsed.protocol}://${parsed.host}/api/v2.0`;
+	const headers = harborHeaders(registry);
 
 	if (orgPath) {
-		// Single project: path without the leading slash
+		// Single project: native page-based pagination.
 		const project = orgPath.replace(/^\//, '');
 		const url = `${baseUrl}/projects/${encodeURIComponent(project)}/repositories?page=${page}&page_size=${pageSize}`;
 		const resp = await fetch(url, { headers });
-
 		if (!resp.ok) {
 			throw new Error(`Harbor API error ${resp.status} for project ${project}`);
 		}
-
-		totalCount = parseInt(resp.headers.get('X-Total-Count') || '0', 10);
+		const totalCount = parseInt(resp.headers.get('X-Total-Count') || '0', 10);
 		const repos: Array<{ name: string }> = await resp.json();
-		for (const r of repos) {
-			repositories.push(r.name);
-		}
-	} else {
-		// No orgPath: enumerate all accessible projects
-		const projectsResp = await fetch(`${baseUrl}/projects?page=1&page_size=100`, { headers });
-		if (!projectsResp.ok) {
-			throw new Error(`Harbor API error ${projectsResp.status} when listing projects`);
-		}
-		const projects: Array<{ name: string }> = await projectsResp.json();
-
-		// Paginate repos from the first matching project
-		// For simplicity, concatenate all repos from all projects
-		for (const proj of projects) {
-			const url = `${baseUrl}/projects/${encodeURIComponent(proj.name)}/repositories?page=1&page_size=100`;
-			const resp = await fetch(url, { headers });
-			if (!resp.ok) continue;
-
-			const repos: Array<{ name: string }> = await resp.json();
-			for (const r of repos) {
-				repositories.push(r.name);
-			}
-		}
-		totalCount = repositories.length;
+		const repositories = repos.map(r => r.name);
+		const hasMore = page * pageSize < totalCount;
+		return { repositories, nextLast: hasMore ? `harbor:${page + 1}` : null };
 	}
 
-	// Check if there is a next page
-	const hasMore = orgPath ? (page * pageSize < totalCount) : false;
-	const nextLast = hasMore ? `harbor:${page + 1}` : null;
+	// No orgPath: enumerate all projects and all of their repositories, then
+	// slice the flattened list for the requested page.
+	const projects = await harborListAllProjects(baseUrl, headers);
+	const all: string[] = [];
+	for (const project of projects) {
+		const repos = await harborListProjectRepositories(baseUrl, project, headers);
+		for (const name of repos) all.push(name);
+	}
 
-	return { repositories, nextLast };
+	const start = (page - 1) * pageSize;
+	const repositories = all.slice(start, start + pageSize);
+	const hasMore = start + pageSize < all.length;
+	return { repositories, nextLast: hasMore ? `harbor:${page + 1}` : null };
 }
 
 /**
  * Searches repositories via the Harbor API using filter q=name=~{term}.
  * Iterates through all accessible projects (or a single one if orgPath is set).
- * Client-side substring double-check.
+ * The term is sanitized for the Harbor query grammar; a client-side substring
+ * check on the original term keeps the results precise.
  */
 export async function harborSearchRepositories(
 	registry: { url: string; username?: string | null; password?: string | null },
@@ -3319,41 +3378,30 @@ export async function harborSearchRepositories(
 	limit: number = 25
 ): Promise<string[]> {
 	const parsed = parseRegistryUrl(registry.url);
-	const baseUrl = `https://${parsed.host}/api/v2.0`;
-	const authHeader = getHarborBasicAuth(registry);
-
-	const headers: Record<string, string> = {
-		'Accept': 'application/json',
-		'User-Agent': 'Dockhand/1.0'
-	};
-	if (authHeader) headers['Authorization'] = authHeader;
+	const baseUrl = `${parsed.protocol}://${parsed.host}/api/v2.0`;
+	const headers = harborHeaders(registry);
 
 	const termLower = term.toLowerCase();
+	const safeTerm = sanitizeHarborQueryTerm(term);
 	const results: string[] = [];
 
-	// Determine which projects to iterate through
-	let projectNames: string[];
-	if (orgPath) {
-		projectNames = [orgPath.replace(/^\//, '')];
-	} else {
-		const projectsResp = await fetch(`${baseUrl}/projects?page=1&page_size=100`, { headers });
-		if (!projectsResp.ok) return results;
-		const projects: Array<{ name: string }> = await projectsResp.json();
-		projectNames = projects.map(p => p.name);
-	}
+	const projectNames = orgPath
+		? [orgPath.replace(/^\//, '')]
+		: await harborListAllProjects(baseUrl, headers);
 
 	// Search each project using the Harbor filter
-	for (const proj of projectNames) {
+	for (const project of projectNames) {
 		if (results.length >= limit) break;
 
-		const q = encodeURIComponent(`name=~${term}`);
-		const url = `${baseUrl}/projects/${encodeURIComponent(proj)}/repositories?q=${q}&page=1&page_size=${limit}`;
+		const q = encodeURIComponent(`name=~${safeTerm}`);
+		const url = `${baseUrl}/projects/${encodeURIComponent(project)}/repositories?q=${q}&page=1&page_size=${limit}`;
 		const resp = await fetch(url, { headers });
 		if (!resp.ok) continue;
 
 		const repos: Array<{ name: string }> = await resp.json();
 		for (const r of repos) {
-			// Client-side double-check
+			// The server filter ran on the sanitized term, so re-check the original
+			// term client-side to guarantee precise substring matches.
 			if (r.name.toLowerCase().includes(termLower)) {
 				results.push(r.name);
 				if (results.length >= limit) break;

--- a/src/lib/server/docker.ts
+++ b/src/lib/server/docker.ts
@@ -3168,6 +3168,202 @@ export async function getRegistryAuth(
 	return { baseUrl, orgPath: parsed.path, authHeader };
 }
 
+// --- Harbor fallback pour le catalog et la recherche d'images ---
+// Harbor interdit l'accès au endpoint V2 _catalog pour les robots.
+// On détecte Harbor et on utilise l'API projet native en fallback.
+
+/** Cache de détection Harbor par host (TTL 5 min) */
+const harborDetectionCache = new Map<string, { isHarbor: boolean; ts: number }>();
+const HARBOR_CACHE_TTL = 5 * 60 * 1000;
+
+export interface HarborCatalogResult {
+	repositories: string[];
+	/** Curseur de pagination : "harbor:<page>" ou null si dernière page */
+	nextLast: string | null;
+}
+
+/**
+ * Détecte si un registry est une instance Harbor.
+ * Vérifie service="harbor-registry" dans le header WWW-Authenticate de /v2/,
+ * puis confirme via /api/v2.0/ping. Résultat mis en cache 5 min par host.
+ */
+export async function isHarborRegistry(registryUrl: string): Promise<boolean> {
+	const parsed = parseRegistryUrl(registryUrl);
+	const host = parsed.host;
+
+	const cached = harborDetectionCache.get(host);
+	if (cached && Date.now() - cached.ts < HARBOR_CACHE_TTL) {
+		return cached.isHarbor;
+	}
+
+	let isHarbor = false;
+	try {
+		const baseUrl = `https://${host}`;
+
+		// Étape 1 : vérifier le header WWW-Authenticate de /v2/
+		const challengeResp = await fetch(`${baseUrl}/v2/`, {
+			method: 'GET',
+			headers: { 'User-Agent': 'Dockhand/1.0' }
+		});
+		const wwwAuth = challengeResp.headers.get('WWW-Authenticate') || '';
+		if (wwwAuth.toLowerCase().includes('service="harbor-registry"')) {
+			// Étape 2 : confirmer via /api/v2.0/ping
+			const pingResp = await fetch(`${baseUrl}/api/v2.0/ping`, {
+				method: 'GET',
+				headers: { 'User-Agent': 'Dockhand/1.0' }
+			});
+			if (pingResp.ok) {
+				const body = await pingResp.text();
+				if (body.includes('Pong')) {
+					isHarbor = true;
+				}
+			}
+		}
+	} catch {
+		// En cas d'erreur réseau, on considère que ce n'est pas Harbor
+	}
+
+	harborDetectionCache.set(host, { isHarbor, ts: Date.now() });
+	return isHarbor;
+}
+
+/**
+ * Construit le header Basic auth pour l'API Harbor à partir d'un objet registry.
+ */
+function getHarborBasicAuth(registry: { username?: string | null; password?: string | null }): string | null {
+	if (registry.username && registry.password) {
+		return `Basic ${Buffer.from(`${registry.username}:${registry.password}`).toString('base64')}`;
+	}
+	return null;
+}
+
+/**
+ * Liste les repositories via l'API projet Harbor.
+ * Si orgPath est défini → un seul projet. Sinon → énumère tous les projets accessibles.
+ * @param page - numéro de page (1-based)
+ * @param pageSize - nombre de résultats par page
+ */
+export async function harborListRepositories(
+	registry: { url: string; username?: string | null; password?: string | null },
+	orgPath: string,
+	page: number = 1,
+	pageSize: number = 100
+): Promise<HarborCatalogResult> {
+	const parsed = parseRegistryUrl(registry.url);
+	const baseUrl = `https://${parsed.host}/api/v2.0`;
+	const authHeader = getHarborBasicAuth(registry);
+
+	const headers: Record<string, string> = {
+		'Accept': 'application/json',
+		'User-Agent': 'Dockhand/1.0'
+	};
+	if (authHeader) headers['Authorization'] = authHeader;
+
+	const repositories: string[] = [];
+	let totalCount = 0;
+
+	if (orgPath) {
+		// Un seul projet : le path sans le slash initial
+		const project = orgPath.replace(/^\//, '');
+		const url = `${baseUrl}/projects/${encodeURIComponent(project)}/repositories?page=${page}&page_size=${pageSize}`;
+		const resp = await fetch(url, { headers });
+
+		if (!resp.ok) {
+			throw new Error(`Harbor API erreur ${resp.status} pour le projet ${project}`);
+		}
+
+		totalCount = parseInt(resp.headers.get('X-Total-Count') || '0', 10);
+		const repos: Array<{ name: string }> = await resp.json();
+		for (const r of repos) {
+			repositories.push(r.name);
+		}
+	} else {
+		// Pas d'orgPath : énumérer tous les projets accessibles
+		const projectsResp = await fetch(`${baseUrl}/projects?page=1&page_size=100`, { headers });
+		if (!projectsResp.ok) {
+			throw new Error(`Harbor API erreur ${projectsResp.status} pour la liste des projets`);
+		}
+		const projects: Array<{ name: string }> = await projectsResp.json();
+
+		// Paginer les repos du premier projet correspondant à la page demandée
+		// Pour simplifier, on concatène tous les repos de tous les projets
+		for (const proj of projects) {
+			const url = `${baseUrl}/projects/${encodeURIComponent(proj.name)}/repositories?page=1&page_size=100`;
+			const resp = await fetch(url, { headers });
+			if (!resp.ok) continue;
+
+			const repos: Array<{ name: string }> = await resp.json();
+			for (const r of repos) {
+				repositories.push(r.name);
+			}
+		}
+		totalCount = repositories.length;
+	}
+
+	// Calculer si il y a une page suivante
+	const hasMore = orgPath ? (page * pageSize < totalCount) : false;
+	const nextLast = hasMore ? `harbor:${page + 1}` : null;
+
+	return { repositories, nextLast };
+}
+
+/**
+ * Recherche des repositories via l'API Harbor avec filtre q=name=~{term}.
+ * Parcourt tous les projets accessibles (ou un seul si orgPath défini).
+ * Double vérification substring côté client.
+ */
+export async function harborSearchRepositories(
+	registry: { url: string; username?: string | null; password?: string | null },
+	term: string,
+	orgPath: string,
+	limit: number = 25
+): Promise<string[]> {
+	const parsed = parseRegistryUrl(registry.url);
+	const baseUrl = `https://${parsed.host}/api/v2.0`;
+	const authHeader = getHarborBasicAuth(registry);
+
+	const headers: Record<string, string> = {
+		'Accept': 'application/json',
+		'User-Agent': 'Dockhand/1.0'
+	};
+	if (authHeader) headers['Authorization'] = authHeader;
+
+	const termLower = term.toLowerCase();
+	const results: string[] = [];
+
+	// Déterminer les projets à parcourir
+	let projectNames: string[];
+	if (orgPath) {
+		projectNames = [orgPath.replace(/^\//, '')];
+	} else {
+		const projectsResp = await fetch(`${baseUrl}/projects?page=1&page_size=100`, { headers });
+		if (!projectsResp.ok) return results;
+		const projects: Array<{ name: string }> = await projectsResp.json();
+		projectNames = projects.map(p => p.name);
+	}
+
+	// Chercher dans chaque projet avec le filtre Harbor
+	for (const proj of projectNames) {
+		if (results.length >= limit) break;
+
+		const q = encodeURIComponent(`name=~${term}`);
+		const url = `${baseUrl}/projects/${encodeURIComponent(proj)}/repositories?q=${q}&page=1&page_size=${limit}`;
+		const resp = await fetch(url, { headers });
+		if (!resp.ok) continue;
+
+		const repos: Array<{ name: string }> = await resp.json();
+		for (const r of repos) {
+			// Double vérification côté client
+			if (r.name.toLowerCase().includes(termLower)) {
+				results.push(r.name);
+				if (results.length >= limit) break;
+			}
+		}
+	}
+
+	return results;
+}
+
 /**
  * Check the registry for the current manifest digest of an image.
  * Simple HEAD request to get Docker-Content-Digest header.

--- a/src/routes/api/registry/catalog/+server.ts
+++ b/src/routes/api/registry/catalog/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getRegistry } from '$lib/server/db';
-import { getRegistryAuth } from '$lib/server/docker';
+import { getRegistryAuth, isHarborRegistry, harborListRepositories, parseRegistryUrl } from '$lib/server/docker';
 
 const PAGE_SIZE = 100;
 
@@ -22,6 +22,12 @@ export const GET: RequestHandler = async ({ url }) => {
 		// Docker Hub doesn't support catalog listing
 		if (registry.url.includes('docker.io') || registry.url.includes('hub.docker.com') || registry.url.includes('registry.hub.docker.com')) {
 			return json({ error: 'Docker Hub does not support catalog listing. Please use search instead.' }, { status: 400 });
+		}
+
+		// Fallback Harbor : l'endpoint _catalog est interdit pour les robots Harbor.
+		// On utilise l'API projet native à la place.
+		if (await isHarborRegistry(registry.url)) {
+			return handleHarborCatalog(registry, lastParam);
 		}
 
 		const { baseUrl, orgPath, authHeader } = await getRegistryAuth(registry, 'registry:catalog:*');
@@ -114,3 +120,39 @@ export const GET: RequestHandler = async ({ url }) => {
 		return json({ error: 'Failed to fetch catalog: ' + (error.message || 'Unknown error') }, { status: 500 });
 	}
 };
+
+/**
+ * Gère le catalog pour un registry Harbor via l'API projet native.
+ * Décode le curseur "harbor:N" pour la pagination.
+ */
+async function handleHarborCatalog(
+	registry: { url: string; username?: string | null; password?: string | null },
+	lastParam: string | null
+): Promise<Response> {
+	const { path: orgPath } = parseRegistryUrl(registry.url);
+
+	// Décoder le curseur Harbor : "harbor:<page>" → numéro de page
+	let page = 1;
+	if (lastParam?.startsWith('harbor:')) {
+		page = parseInt(lastParam.substring(7), 10) || 1;
+	}
+
+	const result = await harborListRepositories(registry, orgPath, page, PAGE_SIZE);
+
+	const results = result.repositories.map((name: string) => ({
+		name,
+		description: '',
+		star_count: 0,
+		is_official: false,
+		is_automated: false
+	}));
+
+	return json({
+		repositories: results,
+		pagination: {
+			pageSize: PAGE_SIZE,
+			hasMore: !!result.nextLast,
+			nextLast: result.nextLast
+		}
+	});
+}

--- a/src/routes/api/registry/catalog/+server.ts
+++ b/src/routes/api/registry/catalog/+server.ts
@@ -24,8 +24,8 @@ export const GET: RequestHandler = async ({ url }) => {
 			return json({ error: 'Docker Hub does not support catalog listing. Please use search instead.' }, { status: 400 });
 		}
 
-		// Fallback Harbor : l'endpoint _catalog est interdit pour les robots Harbor.
-		// On utilise l'API projet native à la place.
+		// Harbor fallback: the _catalog endpoint is forbidden for Harbor robot accounts.
+		// Use the native project API instead.
 		if (await isHarborRegistry(registry.url)) {
 			return handleHarborCatalog(registry, lastParam);
 		}
@@ -122,8 +122,8 @@ export const GET: RequestHandler = async ({ url }) => {
 };
 
 /**
- * Gère le catalog pour un registry Harbor via l'API projet native.
- * Décode le curseur "harbor:N" pour la pagination.
+ * Handles catalog listing for a Harbor registry via the native project API.
+ * Decodes the "harbor:N" cursor for pagination.
  */
 async function handleHarborCatalog(
 	registry: { url: string; username?: string | null; password?: string | null },
@@ -131,7 +131,7 @@ async function handleHarborCatalog(
 ): Promise<Response> {
 	const { path: orgPath } = parseRegistryUrl(registry.url);
 
-	// Décoder le curseur Harbor : "harbor:<page>" → numéro de page
+	// Decode the Harbor cursor: "harbor:<page>" → page number
 	let page = 1;
 	if (lastParam?.startsWith('harbor:')) {
 		page = parseInt(lastParam.substring(7), 10) || 1;

--- a/src/routes/api/registry/search/+server.ts
+++ b/src/routes/api/registry/search/+server.ts
@@ -105,7 +105,7 @@ async function tryDirectImageLookup(registry: any, imageName: string): Promise<b
 
 // Search through catalog (slow for large registries, limited to first few pages)
 async function searchCatalog(registry: any, term: string, limit: number): Promise<string[]> {
-	// Fallback Harbor : utiliser l'API projet native pour la recherche
+	// Harbor fallback: use the native project API for search
 	if (await isHarborRegistry(registry.url)) {
 		const { path: orgPath } = parseRegistryUrl(registry.url);
 		return harborSearchRepositories(registry, term, orgPath, limit);

--- a/src/routes/api/registry/search/+server.ts
+++ b/src/routes/api/registry/search/+server.ts
@@ -127,7 +127,7 @@ async function tryDirectImageLookup(registry: any, imageName: string): Promise<b
 
 // Search through catalog (slow for large registries, limited to first few pages)
 async function searchCatalog(registry: any, term: string, limit: number): Promise<string[]> {
-	// Fallback Harbor : utiliser l'API projet native pour la recherche
+	// Harbor fallback: use the native project API for search
 	if (await isHarborRegistry(registry.url)) {
 		const { path: orgPath } = parseRegistryUrl(registry.url);
 		return harborSearchRepositories(registry, term, orgPath, limit);

--- a/src/routes/api/registry/search/+server.ts
+++ b/src/routes/api/registry/search/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getRegistry } from '$lib/server/db';
-import { getRegistryAuth, parseRegistryUrl } from '$lib/server/docker';
+import { getRegistryAuth, isHarborRegistry, harborSearchRepositories, parseRegistryUrl } from '$lib/server/docker';
 
 interface SearchResult {
 	name: string;
@@ -127,6 +127,12 @@ async function tryDirectImageLookup(registry: any, imageName: string): Promise<b
 
 // Search through catalog (slow for large registries, limited to first few pages)
 async function searchCatalog(registry: any, term: string, limit: number): Promise<string[]> {
+	// Fallback Harbor : utiliser l'API projet native pour la recherche
+	if (await isHarborRegistry(registry.url)) {
+		const { path: orgPath } = parseRegistryUrl(registry.url);
+		return harborSearchRepositories(registry, term, orgPath, limit);
+	}
+
 	// Note: orgPath could be used here to filter results, but search is already term-based
 	const { baseUrl, authHeader } = await getRegistryAuth(registry, 'registry:catalog:*');
 


### PR DESCRIPTION
## Summary

- **Harbor robot accounts are denied access to the V2 `_catalog` endpoint** (scope `registry:catalog:*` returns an empty JWT), making catalog browsing and image search non-functional for Harbor registries
- This PR adds **automatic Harbor detection** and transparently falls back to the **native Harbor project API** (`/api/v2.0/projects/{name}/repositories`) for both catalog listing and image search
- **No configuration change required** — Harbor registries are detected automatically via the `WWW-Authenticate` header and `/api/v2.0/ping`, with a 5-minute cache

## Changes

### `src/lib/server/docker.ts`
- `isHarborRegistry()`: detect Harbor via `WWW-Authenticate` + `/api/v2.0/ping` (result cached 5 min)
- `harborListRepositories()`: list repos through Harbor project API with pagination support
- `harborSearchRepositories()`: search repos using Harbor's `q=name=~{term}` filter
- `HarborCatalogResult` type + `getHarborBasicAuth()` helper

### `src/routes/api/registry/catalog/+server.ts`
- Harbor detection before `_catalog` call, delegates to `handleHarborCatalog()`

### `src/routes/api/registry/search/+server.ts`
- Harbor detection in `searchCatalog()`, delegates to `harborSearchRepositories()`

## Test plan

- [x] Tested against a real Harbor instance with a robot account
- [x] Catalog listing returns repositories correctly
- [x] Image search returns filtered results
- [x] Non-Harbor registries are unaffected (fallback is only triggered for Harbor)
- [x] Built and deployed as `fnsys/dockhand:harbor-fix`

Fixes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)