### PR TITLE
fix: propagate DOCKER_API_VERSION to updater sidecar

### DIFF
--- a/src/routes/api/self-update/+server.ts
+++ b/src/routes/api/self-update/+server.ts
@@ -371,6 +371,22 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 					...networkEnvVars
 				];
 
+				// Pass Docker API version so the updater CLI speaks a compatible version.
+				// Without this, newer CLI versions (e.g. API 1.53) fail against older
+				// daemons (e.g. Synology DSM shipping API 1.43).
+				const dockerApiVersion = process.env.DOCKER_API_VERSION;
+				if (dockerApiVersion) {
+					updaterEnv.push(`DOCKER_API_VERSION=${dockerApiVersion}`);
+				} else {
+					const versionRes = await localDockerFetch('/version');
+					if (versionRes.ok) {
+						const vInfo = await versionRes.json() as { ApiVersion?: string };
+						if (vInfo.ApiVersion) {
+							updaterEnv.push(`DOCKER_API_VERSION=${vInfo.ApiVersion}`);
+						}
+					}
+				}
+
 				// Configure updater's Docker access based on connection type
 				const tcpHost = getDockerTcpHost();
 				const updaterHostConfig: Record<string, unknown> = { AutoRemove: true };


### PR DESCRIPTION
## Summary

Fixes #759

The `dockhand-updater` sidecar ships Docker CLI 29.2.1 (API 1.53), which fails on hosts with older Docker daemons. On Synology DSM (Docker 24.0.2, API 1.43), every `docker` command in `update.sh` returns:

```
Error response from daemon: client version 1.53 is too new. Maximum supported API version is 1.43
```

This causes the updater to exit with code 1 after stopping the old container, leaving Dockhand in a broken state (old container stopped, new container not started).

## Changes

Before creating the updater container, query the Docker daemon's API version via `/version` and pass it as `DOCKER_API_VERSION` in the updater's environment. If `DOCKER_API_VERSION` is already set on the main container, that value is forwarded instead.

This ensures the Docker CLI inside the updater sidecar speaks a version the daemon supports, regardless of what CLI version the updater image ships.

## Testing

Verified manually on Synology DS920+ (DSM 7.2, Docker 24.0.2, API 1.43):
- Without fix: updater exits code 1, every docker command fails with version mismatch
- With `DOCKER_API_VERSION=1.43` set manually: updater completes successfully