### PR TITLE
Fix --no-cache flag in git deployments

### DIFF
--- a/src/lib/server/compose-args.test.ts
+++ b/src/lib/server/compose-args.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildComposeOperationArgs, shouldRunSeparateBuildStep } from './compose-args';
+
+describe('buildComposeOperationArgs', () => {
+	it('does not pass --build or --no-cache on plain up', () => {
+		const args = buildComposeOperationArgs('up', {});
+
+		assert.deepEqual(args, ['up', '-d', '--remove-orphans']);
+	});
+
+	it('passes --build on up when build is requested without disabling cache', () => {
+		const args = buildComposeOperationArgs('up', { build: true });
+
+		assert.deepEqual(args, ['up', '-d', '--remove-orphans', '--build']);
+	});
+
+	it('never leaks --no-cache into up, even when noBuildCache is requested', () => {
+		const args = buildComposeOperationArgs('up', { build: true, noBuildCache: true });
+
+		assert.ok(!args.includes('--no-cache'), `expected no --no-cache in: ${args.join(' ')}`);
+	});
+
+	it('omits --build on up when noBuildCache is requested (separate build step handles it)', () => {
+		const args = buildComposeOperationArgs('up', { build: true, noBuildCache: true });
+
+		assert.ok(!args.includes('--build'), `expected no --build in: ${args.join(' ')}`);
+	});
+
+	it('includes --force-recreate, --pull and the service name on up', () => {
+		const args = buildComposeOperationArgs('up', {
+			forceRecreate: true,
+			pullPolicy: 'always',
+			serviceName: 'web'
+		});
+
+		assert.deepEqual(args, ['up', '-d', '--remove-orphans', '--force-recreate', '--pull', 'always', 'web']);
+	});
+
+	it('build operation passes --no-cache when requested', () => {
+		const args = buildComposeOperationArgs('build', { noBuildCache: true });
+
+		assert.deepEqual(args, ['build', '--no-cache']);
+	});
+
+	it('build operation omits --no-cache when not requested', () => {
+		const args = buildComposeOperationArgs('build', { noBuildCache: false });
+
+		assert.deepEqual(args, ['build']);
+	});
+
+	it('build operation scopes to a single service', () => {
+		const args = buildComposeOperationArgs('build', { noBuildCache: true, serviceName: 'web' });
+
+		assert.deepEqual(args, ['build', '--no-cache', 'web']);
+	});
+
+	it('down passes --volumes only when removeVolumes is requested', () => {
+		assert.deepEqual(buildComposeOperationArgs('down', {}), ['down', '--remove-orphans']);
+		assert.deepEqual(buildComposeOperationArgs('down', { removeVolumes: true }), ['down', '--remove-orphans', '--volumes']);
+	});
+
+	it('pull scopes to a single service when requested', () => {
+		assert.deepEqual(buildComposeOperationArgs('pull', {}), ['pull']);
+		assert.deepEqual(buildComposeOperationArgs('pull', { serviceName: 'web' }), ['pull', 'web']);
+	});
+});
+
+describe('shouldRunSeparateBuildStep', () => {
+	it('runs the build step for local socket deployments (no env)', () => {
+		assert.equal(shouldRunSeparateBuildStep(true, true, undefined), true);
+	});
+
+	it('runs the build step for direct TCP deployments', () => {
+		assert.equal(shouldRunSeparateBuildStep(true, true, 'direct'), true);
+	});
+
+	it('does not run the build step for hawser-standard deployments', () => {
+		assert.equal(shouldRunSeparateBuildStep(true, true, 'hawser-standard'), false);
+	});
+
+	it('does not run the build step for hawser-edge deployments', () => {
+		assert.equal(shouldRunSeparateBuildStep(true, true, 'hawser-edge'), false);
+	});
+
+	it('does not run the build step when noBuildCache is not requested', () => {
+		assert.equal(shouldRunSeparateBuildStep(true, false, 'socket'), false);
+	});
+
+	it('does not run the build step when build is not requested', () => {
+		assert.equal(shouldRunSeparateBuildStep(false, true, 'socket'), false);
+	});
+});

--- a/src/lib/server/compose-args.ts
+++ b/src/lib/server/compose-args.ts
@@ -1,0 +1,71 @@
+export interface ComposeOperationArgOptions {
+	forceRecreate?: boolean;
+	removeVolumes?: boolean;
+	build?: boolean;
+	noBuildCache?: boolean;
+	pullPolicy?: string;
+	serviceName?: string;
+}
+
+// Operation-specific compose CLI args, split out of executeLocalCompose for unit testing.
+export function buildComposeOperationArgs(
+	operation: 'up' | 'down' | 'stop' | 'start' | 'restart' | 'pull' | 'build',
+	options: ComposeOperationArgOptions = {}
+): string[] {
+	const { forceRecreate, removeVolumes, build, noBuildCache, pullPolicy, serviceName } = options;
+	const args: string[] = [];
+
+	switch (operation) {
+		case 'up':
+			args.push('up', '-d', '--remove-orphans');
+			if (forceRecreate) args.push('--force-recreate');
+			if (build && !noBuildCache) args.push('--build');
+			if (pullPolicy) args.push('--pull', pullPolicy);
+			// If targeting a specific service, only update that service
+			if (serviceName) {
+				args.push(serviceName);
+			}
+			break;
+		case 'down':
+			args.push('down', '--remove-orphans');
+			if (removeVolumes) args.push('--volumes');
+			break;
+		case 'stop':
+			args.push('stop');
+			break;
+		case 'start':
+			args.push('start');
+			break;
+		case 'restart':
+			args.push('restart');
+			break;
+		case 'pull':
+			args.push('pull');
+			// If targeting a specific service, pull only that service
+			if (serviceName) {
+				args.push(serviceName);
+			}
+			break;
+		case 'build':
+			args.push('build');
+			if (noBuildCache) args.push('--no-cache');
+			if (pullPolicy) args.push('--pull');
+			if (serviceName) {
+				args.push(serviceName);
+			}
+			break;
+	}
+
+	return args;
+}
+
+// Hawser's remote agent has no 'build' operation yet (see #880, #1020), so the separate
+// no-cache build step only runs for local/direct deployments until it does.
+export function shouldRunSeparateBuildStep(
+	build: boolean | undefined,
+	noBuildCache: boolean | undefined,
+	connectionType: string | null | undefined
+): boolean {
+	const isHawser = connectionType === 'hawser-standard' || connectionType === 'hawser-edge';
+	return !!build && !!noBuildCache && !isHawser;
+}

--- a/src/lib/server/stacks.ts
+++ b/src/lib/server/stacks.ts
@@ -834,7 +834,7 @@ function findComposeOverrideFile(stackDir: string, composeFileName: string): str
  * @param customComposePath - Optional path to existing compose file (for imported stacks, skips writing)
  */
 async function executeLocalCompose(
-	operation: 'up' | 'down' | 'stop' | 'start' | 'restart' | 'pull',
+	operation: 'up' | 'down' | 'stop' | 'start' | 'restart' | 'pull' | 'build',
 	stackName: string,
 	composeContent: string,
 	dockerHost?: string,
@@ -1043,8 +1043,7 @@ async function executeLocalCompose(
 		case 'up':
 			args.push('up', '-d', '--remove-orphans');
 			if (forceRecreate) args.push('--force-recreate');
-			if (build) args.push('--build');
-			if (build && noBuildCache) args.push('--no-cache');
+			if (build && !noBuildCache) args.push('--build');
 			if (pullPolicy) args.push('--pull', pullPolicy);
 			// If targeting a specific service, only update that service
 			if (serviceName) {
@@ -1067,6 +1066,14 @@ async function executeLocalCompose(
 		case 'pull':
 			args.push('pull');
 			// If targeting a specific service, pull only that service
+			if (serviceName) {
+				args.push(serviceName);
+			}
+			break;
+		case 'build':
+			args.push('build');
+			if (noBuildCache) args.push('--no-cache');
+			if (pullPolicy) args.push('--pull');
 			if (serviceName) {
 				args.push(serviceName);
 			}
@@ -1209,7 +1216,7 @@ async function executeLocalCompose(
  * @param secretVars - Secret environment variables (injected via shell env on Hawser, NEVER in .env)
  */
 async function executeComposeViaHawser(
-	operation: 'up' | 'down' | 'stop' | 'start' | 'restart' | 'pull',
+	operation: 'up' | 'down' | 'stop' | 'start' | 'restart' | 'pull' | 'build',
 	stackName: string,
 	composeContent: string,
 	envId: number,
@@ -1359,7 +1366,7 @@ async function executeComposeViaHawser(
  * @param secretVars - Secret environment variables (from DB, injected via shell env)
  */
 async function executeComposeCommand(
-	operation: 'up' | 'down' | 'stop' | 'start' | 'restart' | 'pull',
+	operation: 'up' | 'down' | 'stop' | 'start' | 'restart' | 'pull' | 'build',
 	options: ComposeCommandOptions,
 	composeContent: string,
 	envVars?: Record<string, string>,
@@ -2315,24 +2322,41 @@ export async function deployStack(options: DeployStackOptions): Promise<StackOpe
 		// so no override file is needed - only pass secrets for shell injection.
 		const isGitStack = !!sourceDir;
 
-		console.log(`${logPrefix} Calling executeComposeCommand...`);
+		const cmdOptions: ComposeCommandOptions = {
+			stackName: name,
+			envId,
+			forceRecreate,
+			build,
+			noBuildCache,
+			pullPolicy,
+			stackFiles,
+			workingDir,
+			composePath: actualComposePath,
+			envPath: actualEnvPath,
+			useOverrideFile: isGitStack,
+			// Pass compose filename for Hawser (extracted from path or provided explicitly)
+			composeFileName: composeFileName || (actualComposePath ? basename(actualComposePath) : undefined)
+		};
+
+		// If build and noBuildCache are true, run a separate build step first
+		if (build && noBuildCache) {
+			console.log(`${logPrefix} Running separate build step with --no-cache...`);
+			const buildResult = await executeComposeCommand(
+				'build',
+				cmdOptions,
+				compose,
+				isGitStack ? dbNonSecretVars : undefined,
+				secretVars
+			);
+			if (!buildResult.success) {
+				return buildResult;
+			}
+		}
+
+		console.log(`${logPrefix} Calling executeComposeCommand (up)...`);
 		const result = await executeComposeCommand(
 			'up',
-			{
-				stackName: name,
-				envId,
-				forceRecreate,
-				build,
-				noBuildCache,
-				pullPolicy,
-				stackFiles,
-				workingDir,
-				composePath: actualComposePath,
-				envPath: actualEnvPath,
-				useOverrideFile: isGitStack,
-				// Pass compose filename for Hawser (extracted from path or provided explicitly)
-				composeFileName: composeFileName || (actualComposePath ? basename(actualComposePath) : undefined)
-			},
+			cmdOptions,
 			compose,
 			isGitStack ? dbNonSecretVars : undefined,
 			secretVars

--- a/src/lib/server/stacks.ts
+++ b/src/lib/server/stacks.ts
@@ -31,6 +31,7 @@ import { unregisterSchedule } from './scheduler';
 import { deleteGitStackFiles, parseEnvFileContent } from './git';
 import { cleanPem } from '$lib/utils/pem';
 import { rewriteComposeVolumePaths, getHostDataDir } from './host-path';
+import { buildComposeOperationArgs, shouldRunSeparateBuildStep } from './compose-args';
 
 // =============================================================================
 // TYPES
@@ -1039,46 +1040,7 @@ async function executeLocalCompose(
 		console.log(`${logPrefix} [HostPath] Using stdin for compose content (paths translated)`);
 	}
 
-	switch (operation) {
-		case 'up':
-			args.push('up', '-d', '--remove-orphans');
-			if (forceRecreate) args.push('--force-recreate');
-			if (build && !noBuildCache) args.push('--build');
-			if (pullPolicy) args.push('--pull', pullPolicy);
-			// If targeting a specific service, only update that service
-			if (serviceName) {
-				args.push(serviceName);
-			}
-			break;
-		case 'down':
-			args.push('down', '--remove-orphans');
-			if (removeVolumes) args.push('--volumes');
-			break;
-		case 'stop':
-			args.push('stop');
-			break;
-		case 'start':
-			args.push('start');
-			break;
-		case 'restart':
-			args.push('restart');
-			break;
-		case 'pull':
-			args.push('pull');
-			// If targeting a specific service, pull only that service
-			if (serviceName) {
-				args.push(serviceName);
-			}
-			break;
-		case 'build':
-			args.push('build');
-			if (noBuildCache) args.push('--no-cache');
-			if (pullPolicy) args.push('--pull');
-			if (serviceName) {
-				args.push(serviceName);
-			}
-			break;
-	}
+	args.push(...buildComposeOperationArgs(operation, { forceRecreate, removeVolumes, build, noBuildCache, pullPolicy, serviceName }));
 
 	const commandStr = args.join(' ');
 
@@ -2338,8 +2300,9 @@ export async function deployStack(options: DeployStackOptions): Promise<StackOpe
 			composeFileName: composeFileName || (actualComposePath ? basename(actualComposePath) : undefined)
 		};
 
-		// If build and noBuildCache are true, run a separate build step first
-		if (build && noBuildCache) {
+		const targetEnv = envId ? await getEnvironment(envId) : null;
+
+		if (shouldRunSeparateBuildStep(build, noBuildCache, targetEnv?.connectionType)) {
 			console.log(`${logPrefix} Running separate build step with --no-cache...`);
 			const buildResult = await executeComposeCommand(
 				'build',
@@ -2618,4 +2581,3 @@ export async function saveStackEnvVars(
 // They can be removed once all imports are updated
 
 export type { StackOperationResult as CreateStackResult };
-


### PR DESCRIPTION
## Proposed change
This PR fixes the "Disable build cache" option in git deployments not working due to the passing of the "--no-cache" flag to the wrong docker compose command.
Now the system detects and forces a fresh image build with the "--no-cache" flag, before attempting to deploy (up) the stack again.

Closes #880 

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain:


## Additional notes & discussion
Changes were made and tested according to the insights of @jotka in issue #880, Thanks!. However, I do not believe that this PR alone would provide the behaviour that one would expect when they want to disable build cache (at least not for me...).

The main reason that I say this is that I expect that the new deployment will be made purely of the new image to be built from the incoming git changes from upstream. However, what actually happens is that the changes from git are being copied over to the current (or old, depending on how you see it) build context in a dirty fashion, and then docker is instructed to build the image from this new source code.

I believe this behaviour is to maximize caching of source artifacts that don't change often (if at all!), and also to preserve non-git tracked files or artifacts such as local media, local databases, whatever the deployed service may generate or store in a host mount volume.

This "dirtiness" of the build context causes build issues for me when using Microsoft's .NET framework whenever I delete, rename, or move a file, the old stale counterparts still exist from the previous deployment in the current build context and cause a namespace collision when building the project because the deleted and newly added files may both define the same namespace, and that isn't allowed in .NET or whatever.

My hacky solution for this is to track the current source code and the incoming source code files, and basically nuke away any current files that don't exist in the git repo anymore, as to avoid the aforementioned namespace collisions. Why not nuke all the source code? Again, local media files may be stored in host mounts on the host machine, and those may contain sensitive info that one may not intend to delete when disabling build cache so.... I ignore any files that neither exist in the current and incoming source code.

This change-tracking commit is not part of this PR however, it's on https://github.com/He-Is-HaZaRdOuS/dockhand/commits/main/ in case any reviewer is interested in this niche case that I encountered, I'd be happy to provide more information or discuss it more (although my fork and local image build of dockhand is serving me just fine for the time being).

Anywho... This PR is fine as-is from an objective standpoint, and thanks for the opportunity!