### PR TITLE
feat: Simple 1Password integration

### DIFF
--- a/drizzle-pg/0009_add_op_service_accounts.sql
+++ b/drizzle-pg/0009_add_op_service_accounts.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "op_service_accounts" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"token" text NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "op_service_accounts_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+ALTER TABLE "stack_sources" ADD COLUMN "op_service_account_id" integer;--> statement-breakpoint
+ALTER TABLE "stack_sources" ADD CONSTRAINT "stack_sources_op_service_account_id_op_service_accounts_id_fk" FOREIGN KEY ("op_service_account_id") REFERENCES "public"."op_service_accounts"("id") ON DELETE set null ON UPDATE no action;

--- a/drizzle-pg/meta/0009_snapshot.json
+++ b/drizzle-pg/meta/0009_snapshot.json
@@ -1,0 +1,3209 @@
+{
+  "id": "776bd871-655c-4254-b7ab-075936efd8cf",
+  "prevId": "175a1422-8e71-4a61-b6bb-20fafd855358",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_tokens_user_id_idx": {
+          "name": "api_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_token_prefix_idx": {
+          "name": "api_tokens_token_prefix_idx",
+          "columns": [
+            {
+              "expression": "token_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_logs_user_id_idx": {
+          "name": "audit_logs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_environment_id_environments_id_fk": {
+          "name": "audit_logs_environment_id_environments_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_settings": {
+      "name": "auth_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auth_enabled": {
+          "name": "auth_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "default_provider": {
+          "name": "default_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'local'"
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_update_settings": {
+      "name": "auto_update_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'daily'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_criteria": {
+          "name": "vulnerability_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'never'"
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auto_update_settings_environment_id_environments_id_fk": {
+          "name": "auto_update_settings_environment_id_environments_id_fk",
+          "tableFrom": "auto_update_settings",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auto_update_settings_environment_id_container_name_unique": {
+          "name": "auto_update_settings_environment_id_container_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "environment_id",
+            "container_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.config_sets": {
+      "name": "config_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ports": {
+          "name": "ports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volumes": {
+          "name": "volumes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network_mode": {
+          "name": "network_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'bridge'"
+        },
+        "restart_policy": {
+          "name": "restart_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'no'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "config_sets_name_unique": {
+          "name": "config_sets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.container_events": {
+      "name": "container_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_attributes": {
+          "name": "actor_attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "container_events_env_timestamp_idx": {
+          "name": "container_events_env_timestamp_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "container_events_environment_id_environments_id_fk": {
+          "name": "container_events_environment_id_environments_id_fk",
+          "tableFrom": "container_events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment_notifications": {
+      "name": "environment_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "environment_notifications_environment_id_environments_id_fk": {
+          "name": "environment_notifications_environment_id_environments_id_fk",
+          "tableFrom": "environment_notifications",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environment_notifications_notification_id_notification_settings_id_fk": {
+          "name": "environment_notifications_notification_id_notification_settings_id_fk",
+          "tableFrom": "environment_notifications",
+          "tableTo": "notification_settings",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "environment_notifications_environment_id_notification_id_unique": {
+          "name": "environment_notifications_environment_id_notification_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "environment_id",
+            "notification_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environments": {
+      "name": "environments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2375
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'http'"
+        },
+        "tls_ca": {
+          "name": "tls_ca",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls_cert": {
+          "name": "tls_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls_key": {
+          "name": "tls_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls_skip_verify": {
+          "name": "tls_skip_verify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'globe'"
+        },
+        "collect_activity": {
+          "name": "collect_activity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "collect_metrics": {
+          "name": "collect_metrics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "highlight_changes": {
+          "name": "highlight_changes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'socket'"
+        },
+        "socket_path": {
+          "name": "socket_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/var/run/docker.sock'"
+        },
+        "hawser_token": {
+          "name": "hawser_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hawser_last_seen": {
+          "name": "hawser_last_seen",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hawser_agent_id": {
+          "name": "hawser_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hawser_agent_name": {
+          "name": "hawser_agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hawser_version": {
+          "name": "hawser_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hawser_capabilities": {
+          "name": "hawser_capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "environments_name_unique": {
+          "name": "environments_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_credentials": {
+      "name": "git_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssh_private_key": {
+          "name": "ssh_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssh_passphrase": {
+          "name": "ssh_passphrase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_credentials_name_unique": {
+          "name": "git_credentials_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_repositories": {
+      "name": "git_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'main'"
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compose_path": {
+          "name": "compose_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'docker-compose.yml'"
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_update": {
+          "name": "auto_update",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "auto_update_schedule": {
+          "name": "auto_update_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'daily'"
+        },
+        "auto_update_cron": {
+          "name": "auto_update_cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0 3 * * *'"
+        },
+        "webhook_enabled": {
+          "name": "webhook_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_commit": {
+          "name": "last_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "git_repositories_credential_id_git_credentials_id_fk": {
+          "name": "git_repositories_credential_id_git_credentials_id_fk",
+          "tableFrom": "git_repositories",
+          "tableTo": "git_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_repositories_name_unique": {
+          "name": "git_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_stacks": {
+      "name": "git_stacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_path": {
+          "name": "compose_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'docker-compose.yml'"
+        },
+        "env_file_path": {
+          "name": "env_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_update": {
+          "name": "auto_update",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "auto_update_schedule": {
+          "name": "auto_update_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'daily'"
+        },
+        "auto_update_cron": {
+          "name": "auto_update_cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0 3 * * *'"
+        },
+        "webhook_enabled": {
+          "name": "webhook_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_dir": {
+          "name": "context_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_on_deploy": {
+          "name": "build_on_deploy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "no_build_cache": {
+          "name": "no_build_cache",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "repull_images": {
+          "name": "repull_images",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "force_redeploy": {
+          "name": "force_redeploy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_commit": {
+          "name": "last_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_files": {
+          "name": "synced_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "git_stacks_environment_id_environments_id_fk": {
+          "name": "git_stacks_environment_id_environments_id_fk",
+          "tableFrom": "git_stacks",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_stacks_repository_id_git_repositories_id_fk": {
+          "name": "git_stacks_repository_id_git_repositories_id_fk",
+          "tableFrom": "git_stacks",
+          "tableTo": "git_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_stacks_stack_name_environment_id_unique": {
+          "name": "git_stacks_stack_name_environment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stack_name",
+            "environment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hawser_tokens": {
+      "name": "hawser_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hawser_tokens_environment_id_environments_id_fk": {
+          "name": "hawser_tokens_environment_id_environments_id_fk",
+          "tableFrom": "hawser_tokens",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hawser_tokens_token_unique": {
+          "name": "hawser_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_metrics": {
+      "name": "host_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_percent": {
+          "name": "cpu_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_percent": {
+          "name": "memory_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_used": {
+          "name": "memory_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_total": {
+          "name": "memory_total",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "host_metrics_env_timestamp_idx": {
+          "name": "host_metrics_env_timestamp_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "host_metrics_environment_id_environments_id_fk": {
+          "name": "host_metrics_environment_id_environments_id_fk",
+          "tableFrom": "host_metrics",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ldap_config": {
+      "name": "ldap_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(uid={{username}})'"
+        },
+        "username_attribute": {
+          "name": "username_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'uid'"
+        },
+        "email_attribute": {
+          "name": "email_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'mail'"
+        },
+        "display_name_attribute": {
+          "name": "display_name_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cn'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_group": {
+          "name": "admin_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls_enabled": {
+          "name": "tls_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "tls_ca": {
+          "name": "tls_ca",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_config": {
+      "name": "oidc_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'openid profile email'"
+        },
+        "username_claim": {
+          "name": "username_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'preferred_username'"
+        },
+        "email_claim": {
+          "name": "email_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'email'"
+        },
+        "display_name_claim": {
+          "name": "display_name_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'name'"
+        },
+        "admin_claim": {
+          "name": "admin_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_value": {
+          "name": "admin_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_mappings_claim": {
+          "name": "role_mappings_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'groups'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.op_service_accounts": {
+      "name": "op_service_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "op_service_accounts_name_unique": {
+          "name": "op_service_accounts_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_container_updates": {
+      "name": "pending_container_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_image": {
+          "name": "current_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pending_container_updates_environment_id_environments_id_fk": {
+          "name": "pending_container_updates_environment_id_environments_id_fk",
+          "tableFrom": "pending_container_updates",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_container_updates_environment_id_container_id_unique": {
+          "name": "pending_container_updates_environment_id_container_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "environment_id",
+            "container_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registries": {
+      "name": "registries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registries_name_unique": {
+          "name": "registries_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_ids": {
+          "name": "environment_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_executions": {
+      "name": "schedule_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logs": {
+          "name": "logs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedule_executions_type_id_idx": {
+          "name": "schedule_executions_type_id_idx",
+          "columns": [
+            {
+              "expression": "schedule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_executions_environment_id_environments_id_fk": {
+          "name": "schedule_executions_environment_id_environments_id_fk",
+          "tableFrom": "schedule_executions",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stack_environment_variables": {
+      "name": "stack_environment_variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stack_environment_variables_environment_id_environments_id_fk": {
+          "name": "stack_environment_variables_environment_id_environments_id_fk",
+          "tableFrom": "stack_environment_variables",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stack_environment_variables_stack_name_environment_id_key_unique": {
+          "name": "stack_environment_variables_stack_name_environment_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stack_name",
+            "environment_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stack_events": {
+      "name": "stack_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stack_events_environment_id_environments_id_fk": {
+          "name": "stack_events_environment_id_environments_id_fk",
+          "tableFrom": "stack_events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stack_sources": {
+      "name": "stack_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal'"
+        },
+        "git_repository_id": {
+          "name": "git_repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_stack_id": {
+          "name": "git_stack_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compose_path": {
+          "name": "compose_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env_path": {
+          "name": "env_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "op_service_account_id": {
+          "name": "op_service_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stack_sources_environment_id_environments_id_fk": {
+          "name": "stack_sources_environment_id_environments_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stack_sources_git_repository_id_git_repositories_id_fk": {
+          "name": "stack_sources_git_repository_id_git_repositories_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "git_repositories",
+          "columnsFrom": [
+            "git_repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stack_sources_git_stack_id_git_stacks_id_fk": {
+          "name": "stack_sources_git_stack_id_git_stacks_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "git_stacks",
+          "columnsFrom": [
+            "git_stack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stack_sources_op_service_account_id_op_service_accounts_id_fk": {
+          "name": "stack_sources_op_service_account_id_op_service_accounts_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "op_service_accounts",
+          "columnsFrom": [
+            "op_service_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stack_sources_stack_name_environment_id_unique": {
+          "name": "stack_sources_stack_name_environment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stack_name",
+            "environment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template_sources": {
+      "name": "template_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "builtin": {
+          "name": "builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "template_sources_source_id_unique": {
+          "name": "template_sources_source_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preferences_environment_id_environments_id_fk": {
+          "name": "user_preferences_environment_id_environments_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_environment_id_key_unique": {
+          "name": "user_preferences_user_id_environment_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "environment_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_environment_id_environments_id_fk": {
+          "name": "user_roles_environment_id_environments_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_roles_user_id_role_id_environment_id_unique": {
+          "name": "user_roles_user_id_role_id_environment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "role_id",
+            "environment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'local'"
+        },
+        "mfa_enabled": {
+          "name": "mfa_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "mfa_secret": {
+          "name": "mfa_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vulnerability_scans": {
+      "name": "vulnerability_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_name": {
+          "name": "image_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanner": {
+          "name": "scanner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scan_duration": {
+          "name": "scan_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "critical_count": {
+          "name": "critical_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "high_count": {
+          "name": "high_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "medium_count": {
+          "name": "medium_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "low_count": {
+          "name": "low_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "negligible_count": {
+          "name": "negligible_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "unknown_count": {
+          "name": "unknown_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "vulnerabilities": {
+          "name": "vulnerabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vulnerability_scans_env_image_idx": {
+          "name": "vulnerability_scans_env_image_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vulnerability_scans_environment_id_environments_id_fk": {
+          "name": "vulnerability_scans_environment_id_environments_id_fk",
+          "tableFrom": "vulnerability_scans",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle-pg/meta/_journal.json
+++ b/drizzle-pg/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1781620381909,
       "tag": "0008_add_template_sources",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1783800723406,
+      "tag": "0009_add_op_service_accounts",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/0009_add_op_service_accounts.sql
+++ b/drizzle/0009_add_op_service_accounts.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `op_service_accounts` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`token` text NOT NULL,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP,
+	`updated_at` text DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `op_service_accounts_name_unique` ON `op_service_accounts` (`name`);--> statement-breakpoint
+ALTER TABLE `stack_sources` ADD `op_service_account_id` integer REFERENCES op_service_accounts(id);

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,3340 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9a7bfbaa-5b88-4c91-a029-4e0626ec9df2",
+  "prevId": "3da291da-60a8-4d1e-8649-bd09cd7f4d79",
+  "tables": {
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "api_tokens_user_id_idx": {
+          "name": "api_tokens_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "api_tokens_token_prefix_idx": {
+          "name": "api_tokens_token_prefix_idx",
+          "columns": [
+            "token_prefix"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "audit_logs_user_id_idx": {
+          "name": "audit_logs_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_environment_id_environments_id_fk": {
+          "name": "audit_logs_environment_id_environments_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_settings": {
+      "name": "auth_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "auth_enabled": {
+          "name": "auth_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "default_provider": {
+          "name": "default_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 86400
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auto_update_settings": {
+      "name": "auto_update_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'daily'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vulnerability_criteria": {
+          "name": "vulnerability_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'never'"
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "auto_update_settings_environment_id_container_name_unique": {
+          "name": "auto_update_settings_environment_id_container_name_unique",
+          "columns": [
+            "environment_id",
+            "container_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "auto_update_settings_environment_id_environments_id_fk": {
+          "name": "auto_update_settings_environment_id_environments_id_fk",
+          "tableFrom": "auto_update_settings",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_sets": {
+      "name": "config_sets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ports": {
+          "name": "ports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "volumes": {
+          "name": "volumes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "network_mode": {
+          "name": "network_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'bridge'"
+        },
+        "restart_policy": {
+          "name": "restart_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'no'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "config_sets_name_unique": {
+          "name": "config_sets_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "container_events": {
+      "name": "container_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_attributes": {
+          "name": "actor_attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "container_events_env_timestamp_idx": {
+          "name": "container_events_env_timestamp_idx",
+          "columns": [
+            "environment_id",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "container_events_environment_id_environments_id_fk": {
+          "name": "container_events_environment_id_environments_id_fk",
+          "tableFrom": "container_events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environment_notifications": {
+      "name": "environment_notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "environment_notifications_environment_id_notification_id_unique": {
+          "name": "environment_notifications_environment_id_notification_id_unique",
+          "columns": [
+            "environment_id",
+            "notification_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "environment_notifications_environment_id_environments_id_fk": {
+          "name": "environment_notifications_environment_id_environments_id_fk",
+          "tableFrom": "environment_notifications",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environment_notifications_notification_id_notification_settings_id_fk": {
+          "name": "environment_notifications_notification_id_notification_settings_id_fk",
+          "tableFrom": "environment_notifications",
+          "tableTo": "notification_settings",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 2375
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "tls_ca": {
+          "name": "tls_ca",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tls_cert": {
+          "name": "tls_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tls_key": {
+          "name": "tls_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tls_skip_verify": {
+          "name": "tls_skip_verify",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'globe'"
+        },
+        "collect_activity": {
+          "name": "collect_activity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "collect_metrics": {
+          "name": "collect_metrics",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "highlight_changes": {
+          "name": "highlight_changes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'socket'"
+        },
+        "socket_path": {
+          "name": "socket_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'/var/run/docker.sock'"
+        },
+        "hawser_token": {
+          "name": "hawser_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hawser_last_seen": {
+          "name": "hawser_last_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hawser_agent_id": {
+          "name": "hawser_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hawser_agent_name": {
+          "name": "hawser_agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hawser_version": {
+          "name": "hawser_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hawser_capabilities": {
+          "name": "hawser_capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "environments_name_unique": {
+          "name": "environments_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "git_credentials": {
+      "name": "git_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ssh_private_key": {
+          "name": "ssh_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ssh_passphrase": {
+          "name": "ssh_passphrase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "git_credentials_name_unique": {
+          "name": "git_credentials_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "git_repositories": {
+      "name": "git_repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'main'"
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compose_path": {
+          "name": "compose_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'docker-compose.yml'"
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_update": {
+          "name": "auto_update",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_update_schedule": {
+          "name": "auto_update_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'daily'"
+        },
+        "auto_update_cron": {
+          "name": "auto_update_cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'0 3 * * *'"
+        },
+        "webhook_enabled": {
+          "name": "webhook_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_commit": {
+          "name": "last_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "git_repositories_name_unique": {
+          "name": "git_repositories_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "git_repositories_credential_id_git_credentials_id_fk": {
+          "name": "git_repositories_credential_id_git_credentials_id_fk",
+          "tableFrom": "git_repositories",
+          "tableTo": "git_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "git_stacks": {
+      "name": "git_stacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compose_path": {
+          "name": "compose_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'docker-compose.yml'"
+        },
+        "env_file_path": {
+          "name": "env_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_update": {
+          "name": "auto_update",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_update_schedule": {
+          "name": "auto_update_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'daily'"
+        },
+        "auto_update_cron": {
+          "name": "auto_update_cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'0 3 * * *'"
+        },
+        "webhook_enabled": {
+          "name": "webhook_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_dir": {
+          "name": "context_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "build_on_deploy": {
+          "name": "build_on_deploy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "no_build_cache": {
+          "name": "no_build_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "repull_images": {
+          "name": "repull_images",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "force_redeploy": {
+          "name": "force_redeploy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_commit": {
+          "name": "last_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_files": {
+          "name": "synced_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "git_stacks_stack_name_environment_id_unique": {
+          "name": "git_stacks_stack_name_environment_id_unique",
+          "columns": [
+            "stack_name",
+            "environment_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "git_stacks_environment_id_environments_id_fk": {
+          "name": "git_stacks_environment_id_environments_id_fk",
+          "tableFrom": "git_stacks",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_stacks_repository_id_git_repositories_id_fk": {
+          "name": "git_stacks_repository_id_git_repositories_id_fk",
+          "tableFrom": "git_stacks",
+          "tableTo": "git_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hawser_tokens": {
+      "name": "hawser_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hawser_tokens_token_unique": {
+          "name": "hawser_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "hawser_tokens_environment_id_environments_id_fk": {
+          "name": "hawser_tokens_environment_id_environments_id_fk",
+          "tableFrom": "hawser_tokens",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_metrics": {
+      "name": "host_metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cpu_percent": {
+          "name": "cpu_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_percent": {
+          "name": "memory_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_used": {
+          "name": "memory_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memory_total": {
+          "name": "memory_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "host_metrics_env_timestamp_idx": {
+          "name": "host_metrics_env_timestamp_idx",
+          "columns": [
+            "environment_id",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "host_metrics_environment_id_environments_id_fk": {
+          "name": "host_metrics_environment_id_environments_id_fk",
+          "tableFrom": "host_metrics",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ldap_config": {
+      "name": "ldap_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'(uid={{username}})'"
+        },
+        "username_attribute": {
+          "name": "username_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'uid'"
+        },
+        "email_attribute": {
+          "name": "email_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'mail'"
+        },
+        "display_name_attribute": {
+          "name": "display_name_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'cn'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_group": {
+          "name": "admin_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tls_enabled": {
+          "name": "tls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "tls_ca": {
+          "name": "tls_ca",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_settings": {
+      "name": "notification_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oidc_config": {
+      "name": "oidc_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'openid profile email'"
+        },
+        "username_claim": {
+          "name": "username_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'preferred_username'"
+        },
+        "email_claim": {
+          "name": "email_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "display_name_claim": {
+          "name": "display_name_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'name'"
+        },
+        "admin_claim": {
+          "name": "admin_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_value": {
+          "name": "admin_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role_mappings_claim": {
+          "name": "role_mappings_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'groups'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "op_service_accounts": {
+      "name": "op_service_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "op_service_accounts_name_unique": {
+          "name": "op_service_accounts_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pending_container_updates": {
+      "name": "pending_container_updates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_image": {
+          "name": "current_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "pending_container_updates_environment_id_container_id_unique": {
+          "name": "pending_container_updates_environment_id_container_id_unique",
+          "columns": [
+            "environment_id",
+            "container_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pending_container_updates_environment_id_environments_id_fk": {
+          "name": "pending_container_updates_environment_id_environments_id_fk",
+          "tableFrom": "pending_container_updates",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "registries": {
+      "name": "registries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "registries_name_unique": {
+          "name": "registries_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_ids": {
+          "name": "environment_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedule_executions": {
+      "name": "schedule_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logs": {
+          "name": "logs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "schedule_executions_type_id_idx": {
+          "name": "schedule_executions_type_id_idx",
+          "columns": [
+            "schedule_type",
+            "schedule_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedule_executions_environment_id_environments_id_fk": {
+          "name": "schedule_executions_environment_id_environments_id_fk",
+          "tableFrom": "schedule_executions",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stack_environment_variables": {
+      "name": "stack_environment_variables",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "stack_environment_variables_stack_name_environment_id_key_unique": {
+          "name": "stack_environment_variables_stack_name_environment_id_key_unique",
+          "columns": [
+            "stack_name",
+            "environment_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "stack_environment_variables_environment_id_environments_id_fk": {
+          "name": "stack_environment_variables_environment_id_environments_id_fk",
+          "tableFrom": "stack_environment_variables",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stack_events": {
+      "name": "stack_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stack_events_environment_id_environments_id_fk": {
+          "name": "stack_events_environment_id_environments_id_fk",
+          "tableFrom": "stack_events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stack_sources": {
+      "name": "stack_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "git_repository_id": {
+          "name": "git_repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_stack_id": {
+          "name": "git_stack_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compose_path": {
+          "name": "compose_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_path": {
+          "name": "env_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "op_service_account_id": {
+          "name": "op_service_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "stack_sources_stack_name_environment_id_unique": {
+          "name": "stack_sources_stack_name_environment_id_unique",
+          "columns": [
+            "stack_name",
+            "environment_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "stack_sources_environment_id_environments_id_fk": {
+          "name": "stack_sources_environment_id_environments_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stack_sources_git_repository_id_git_repositories_id_fk": {
+          "name": "stack_sources_git_repository_id_git_repositories_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "git_repositories",
+          "columnsFrom": [
+            "git_repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stack_sources_git_stack_id_git_stacks_id_fk": {
+          "name": "stack_sources_git_stack_id_git_stacks_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "git_stacks",
+          "columnsFrom": [
+            "git_stack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stack_sources_op_service_account_id_op_service_accounts_id_fk": {
+          "name": "stack_sources_op_service_account_id_op_service_accounts_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "op_service_accounts",
+          "columnsFrom": [
+            "op_service_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "template_sources": {
+      "name": "template_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "builtin": {
+          "name": "builtin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "template_sources_source_id_unique": {
+          "name": "template_sources_source_id_unique",
+          "columns": [
+            "source_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_preferences": {
+      "name": "user_preferences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_preferences_user_id_environment_id_key_unique": {
+          "name": "user_preferences_user_id_environment_id_key_unique",
+          "columns": [
+            "user_id",
+            "environment_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preferences_environment_id_environments_id_fk": {
+          "name": "user_preferences_environment_id_environments_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_roles": {
+      "name": "user_roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_roles_user_id_role_id_environment_id_unique": {
+          "name": "user_roles_user_id_role_id_environment_id_unique",
+          "columns": [
+            "user_id",
+            "role_id",
+            "environment_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_environment_id_environments_id_fk": {
+          "name": "user_roles_environment_id_environments_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "mfa_enabled": {
+          "name": "mfa_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "mfa_secret": {
+          "name": "mfa_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vulnerability_scans": {
+      "name": "vulnerability_scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_name": {
+          "name": "image_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scanner": {
+          "name": "scanner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_duration": {
+          "name": "scan_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "critical_count": {
+          "name": "critical_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "high_count": {
+          "name": "high_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "medium_count": {
+          "name": "medium_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "low_count": {
+          "name": "low_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "negligible_count": {
+          "name": "negligible_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unknown_count": {
+          "name": "unknown_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "vulnerabilities": {
+          "name": "vulnerabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "vulnerability_scans_env_image_idx": {
+          "name": "vulnerability_scans_env_image_idx",
+          "columns": [
+            "environment_id",
+            "image_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "vulnerability_scans_environment_id_environments_id_fk": {
+          "name": "vulnerability_scans_environment_id_environments_id_fk",
+          "tableFrom": "vulnerability_scans",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1781620376161,
       "tag": "0008_add_template_sources",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1783800723008,
+      "tag": "0009_add_op_service_accounts",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"generate:legal": "node scripts/generate-legal-pages.ts"
 	},
 	"dependencies": {
+		"@1password/sdk": "0.4.1-beta.1",
 		"@codemirror/autocomplete": "6.20.0",
 		"@codemirror/commands": "6.10.1",
 		"@codemirror/lang-css": "6.3.1",

--- a/src/lib/server/audit.ts
+++ b/src/lib/server/audit.ts
@@ -318,6 +318,24 @@ export async function auditGitCredential(
 }
 
 /**
+ * Helper for 1Password service account actions
+ */
+export async function auditOpServiceAccount(
+	event: RequestEvent,
+	action: AuditAction,
+	accountId: number,
+	accountName: string,
+	details?: any
+): Promise<void> {
+	await audit(event, action, 'op_service_account', {
+		entityId: String(accountId),
+		entityName: accountName,
+		description: `1Password service account ${accountName} ${action}`,
+		details
+	});
+}
+
+/**
  * Helper for config set actions
  */
 export async function auditConfigSet(

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -66,7 +66,8 @@ const EMPTY_PERMISSIONS: Permissions = {
 	license: [],
 	audit_logs: [],
 	activity: [],
-	schedules: []
+	schedules: [],
+	secrets: [],
 };
 
 /**
@@ -360,7 +361,8 @@ export async function getUserPermissionsById(userId: number): Promise<Permission
 		license: [],
 		audit_logs: [],
 		activity: [],
-		schedules: []
+		schedules: [],
+		secrets: [],
 	};
 
 	for (const ur of userRoles) {
@@ -441,7 +443,8 @@ export async function getUserPermissionsForEnvironment(userId: number, environme
 		license: [],
 		audit_logs: [],
 		activity: [],
-		schedules: []
+		schedules: [],
+		secrets: [],
 	};
 
 	for (const ur of userRoles) {

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -39,6 +39,7 @@ import {
 	gitCredentials,
 	gitRepositories,
 	gitStacks,
+	opServiceAccounts,
 	stackSources,
 	vulnerabilityScans,
 	auditLogs,
@@ -67,6 +68,7 @@ import {
 	type GitCredential,
 	type GitRepository,
 	type GitStack,
+	type OpServiceAccount,
 	type StackSource,
 	type VulnerabilityScan,
 	type AuditLog,
@@ -98,6 +100,7 @@ export type {
 	GitCredential,
 	GitRepository,
 	GitStack,
+	OpServiceAccount,
 	StackSource,
 	VulnerabilityScan,
 	AuditLog,
@@ -291,6 +294,69 @@ export async function setDefaultRegistry(id: number): Promise<boolean> {
 	await db.update(registries).set({ isDefault: false });
 	await db.update(registries).set({ isDefault: true }).where(eq(registries.id, id));
 	return true;
+}
+
+// =============================================================================
+// 1PASSWORD SERVICE ACCOUNT OPERATIONS
+// =============================================================================
+
+export async function getOpServiceAccounts(): Promise<Array<Omit<OpServiceAccount, 'token'>>> {
+	const results = await db.select({
+		id: opServiceAccounts.id,
+		name: opServiceAccounts.name,
+		createdAt: opServiceAccounts.createdAt,
+		updatedAt: opServiceAccounts.updatedAt
+	}).from(opServiceAccounts).orderBy(asc(opServiceAccounts.name));
+	return results;
+}
+
+export async function getOpServiceAccountById(id: number): Promise<OpServiceAccount | undefined> {
+	const results = await db.select().from(opServiceAccounts).where(eq(opServiceAccounts.id, id));
+	if (!results[0]) return undefined;
+	return { ...results[0], token: decrypt(results[0].token) ?? '' };
+}
+
+export async function createOpServiceAccount(data: { name: string; token: string }): Promise<Omit<OpServiceAccount, 'token'>> {
+	const encrypted = encrypt(data.token);
+	if (!encrypted) throw new Error('Token is required');
+	const result = await db.insert(opServiceAccounts).values({
+		name: data.name,
+		token: encrypted
+	}).returning();
+	const { token: _omit, ...safe } = result[0];
+	return safe;
+}
+
+export async function updateOpServiceAccount(
+	id: number,
+	data: { name?: string; token?: string }
+): Promise<Omit<OpServiceAccount, 'token'> | undefined> {
+	const updateData: Record<string, any> = { updatedAt: new Date().toISOString() };
+	if (data.name !== undefined) updateData.name = data.name;
+	if (data.token !== undefined && data.token !== '') {
+		const encrypted = encrypt(data.token);
+		if (encrypted) updateData.token = encrypted;
+	}
+	await db.update(opServiceAccounts).set(updateData).where(eq(opServiceAccounts.id, id));
+	const results = await db.select({
+		id: opServiceAccounts.id,
+		name: opServiceAccounts.name,
+		createdAt: opServiceAccounts.createdAt,
+		updatedAt: opServiceAccounts.updatedAt
+	}).from(opServiceAccounts).where(eq(opServiceAccounts.id, id));
+	return results[0];
+}
+
+export async function deleteOpServiceAccount(id: number): Promise<Omit<OpServiceAccount, 'token'> | null> {
+	const rows = await db.delete(opServiceAccounts)
+		.where(eq(opServiceAccounts.id, id))
+		.returning({
+			id: opServiceAccounts.id,
+			name: opServiceAccounts.name,
+			createdAt: opServiceAccounts.createdAt,
+			updatedAt: opServiceAccounts.updatedAt
+		});
+	return rows[0] ?? null;
 }
 
 // =============================================================================
@@ -1168,6 +1234,7 @@ export interface Permissions {
 	audit_logs: string[];
 	activity: string[];
 	schedules: string[];
+	secrets: string[];
 }
 
 export interface AuthSettingsData {
@@ -2761,6 +2828,7 @@ export interface StackSourceData {
 	gitStackId: number | null;
 	composePath: string | null;
 	envPath: string | null;
+	opServiceAccountId: number | null;
 	createdAt: string;
 	updatedAt: string;
 }
@@ -2868,6 +2936,7 @@ export async function upsertStackSource(data: {
 	gitStackId?: number | null;
 	composePath?: string | null;
 	envPath?: string | null;
+	opServiceAccountId?: number | null;
 }): Promise<StackSourceData> {
 	const existing = await getStackSource(data.stackName, data.environmentId);
 
@@ -2882,15 +2951,19 @@ export async function upsertStackSource(data: {
 			console.log(`[GitStack] Updating stack_sources "${data.stackName}" env=${data.environmentId}: ${changes.join(', ')}`);
 		}
 
+		const updateSet: Record<string, any> = {
+			sourceType: data.sourceType,
+			gitRepositoryId: newRepoId,
+			gitStackId: newStackId,
+			composePath: data.composePath ?? null,
+			envPath: data.envPath ?? null,
+			updatedAt: new Date().toISOString()
+		};
+		if (data.opServiceAccountId !== undefined) {
+			updateSet.opServiceAccountId = data.opServiceAccountId;
+		}
 		await db.update(stackSources)
-			.set({
-				sourceType: data.sourceType,
-				gitRepositoryId: newRepoId,
-				gitStackId: newStackId,
-				composePath: data.composePath ?? null,
-				envPath: data.envPath ?? null,
-				updatedAt: new Date().toISOString()
-			})
+			.set(updateSet)
 			.where(eq(stackSources.id, existing.id));
 		return getStackSource(data.stackName, data.environmentId) as Promise<StackSourceData>;
 	} else {
@@ -2902,7 +2975,8 @@ export async function upsertStackSource(data: {
 			gitRepositoryId: data.gitRepositoryId || null,
 			gitStackId: data.gitStackId || null,
 			composePath: data.composePath ?? null,
-			envPath: data.envPath ?? null
+			envPath: data.envPath ?? null,
+			opServiceAccountId: data.opServiceAccountId ?? null
 		});
 		return getStackSource(data.stackName, data.environmentId) as Promise<StackSourceData>;
 	}
@@ -2911,17 +2985,21 @@ export async function upsertStackSource(data: {
 export async function updateStackSource(
 	stackName: string,
 	environmentId: number | null,
-	updates: { composePath?: string | null; envPath?: string | null }
+	updates: { composePath?: string | null; envPath?: string | null; opServiceAccountId?: number | null }
 ): Promise<boolean> {
 	const existing = await getStackSource(stackName, environmentId);
 	if (!existing) return false;
 
+	const set: Record<string, any> = {
+		composePath: updates.composePath !== undefined ? updates.composePath : existing.composePath,
+		envPath: updates.envPath !== undefined ? updates.envPath : existing.envPath,
+		updatedAt: new Date().toISOString()
+	};
+	if (updates.opServiceAccountId !== undefined) {
+		set.opServiceAccountId = updates.opServiceAccountId;
+	}
 	await db.update(stackSources)
-		.set({
-			composePath: updates.composePath !== undefined ? updates.composePath : existing.composePath,
-			envPath: updates.envPath !== undefined ? updates.envPath : existing.envPath,
-			updatedAt: new Date().toISOString()
-		})
+		.set(set)
 		.where(eq(stackSources.id, existing.id));
 
 	return true;
@@ -3266,7 +3344,8 @@ export type AuditAction =
 export type AuditEntityType =
 	| 'container' | 'image' | 'stack' | 'volume' | 'network'
 	| 'user' | 'role' | 'settings' | 'environment' | 'registry' | 'git_repository' | 'git_credential'
-	| 'config_set' | 'notification' | 'oidc_provider' | 'ldap_config' | 'git_stack' | 'api_token';
+	| 'config_set' | 'notification' | 'oidc_provider' | 'ldap_config' | 'git_stack' | 'api_token'
+	| 'op_service_account';
 
 export interface AuditLogData {
 	id: number;

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -2951,19 +2951,17 @@ export async function upsertStackSource(data: {
 			console.log(`[GitStack] Updating stack_sources "${data.stackName}" env=${data.environmentId}: ${changes.join(', ')}`);
 		}
 
-		const updateSet: Record<string, any> = {
-			sourceType: data.sourceType,
-			gitRepositoryId: newRepoId,
-			gitStackId: newStackId,
-			composePath: data.composePath ?? null,
-			envPath: data.envPath ?? null,
-			updatedAt: new Date().toISOString()
-		};
-		if (data.opServiceAccountId !== undefined) {
-			updateSet.opServiceAccountId = data.opServiceAccountId;
-		}
 		await db.update(stackSources)
-			.set(updateSet)
+			.set({
+				sourceType: data.sourceType,
+				gitRepositoryId: newRepoId,
+				gitStackId: newStackId,
+				composePath: data.composePath ?? null,
+				envPath: data.envPath ?? null,
+				updatedAt: new Date().toISOString(),
+				// Preserve existing binding when caller (like git) omits it
+				...(data.opServiceAccountId !== undefined && { opServiceAccountId: data.opServiceAccountId })
+			})
 			.where(eq(stackSources.id, existing.id));
 		return getStackSource(data.stackName, data.environmentId) as Promise<StackSourceData>;
 	} else {
@@ -2990,16 +2988,13 @@ export async function updateStackSource(
 	const existing = await getStackSource(stackName, environmentId);
 	if (!existing) return false;
 
-	const set: Record<string, any> = {
-		composePath: updates.composePath !== undefined ? updates.composePath : existing.composePath,
-		envPath: updates.envPath !== undefined ? updates.envPath : existing.envPath,
-		updatedAt: new Date().toISOString()
-	};
-	if (updates.opServiceAccountId !== undefined) {
-		set.opServiceAccountId = updates.opServiceAccountId;
-	}
 	await db.update(stackSources)
-		.set(set)
+		.set({
+			composePath: updates.composePath !== undefined ? updates.composePath : existing.composePath,
+			envPath: updates.envPath !== undefined ? updates.envPath : existing.envPath,
+			opServiceAccountId: updates.opServiceAccountId !== undefined ? updates.opServiceAccountId : existing.opServiceAccountId,
+			updatedAt: new Date().toISOString()
+		})
 		.where(eq(stackSources.id, existing.id));
 
 	return true;

--- a/src/lib/server/db/drizzle.ts
+++ b/src/lib/server/db/drizzle.ts
@@ -770,7 +770,8 @@ async function seedDatabase(): Promise<void> {
 		audit_logs: ['view'],
 		activity: ['view'],
 		schedules: ['view', 'edit', 'run'],
-		templates: ['view', 'deploy', 'manage']
+		templates: ['view', 'deploy', 'manage'],
+		secrets: ['view', 'create', 'edit', 'delete']
 	});
 
 	const operatorPermissions = JSON.stringify({
@@ -790,7 +791,8 @@ async function seedDatabase(): Promise<void> {
 		audit_logs: [],
 		activity: ['view'],
 		schedules: ['view', 'edit', 'run'],
-		templates: ['view', 'deploy']
+		templates: ['view', 'deploy'],
+		secrets: ['view']
 	});
 
 	const viewerPermissions = JSON.stringify({
@@ -810,7 +812,8 @@ async function seedDatabase(): Promise<void> {
 		audit_logs: [],
 		activity: ['view'],
 		schedules: ['view'],
-		templates: ['view']
+		templates: ['view'],
+		secrets: [],
 	});
 
 	// Seed template sources if table is empty
@@ -915,6 +918,7 @@ export const userRoles = schemaProxy.userRoles;
 export const gitCredentials = schemaProxy.gitCredentials;
 export const gitRepositories = schemaProxy.gitRepositories;
 export const gitStacks = schemaProxy.gitStacks;
+export const opServiceAccounts = schemaProxy.opServiceAccounts;
 export const stackSources = schemaProxy.stackSources;
 export const vulnerabilityScans = schemaProxy.vulnerabilityScans;
 export const auditLogs = schemaProxy.auditLogs;
@@ -961,6 +965,8 @@ export type {
 	NewGitRepository,
 	GitStack,
 	NewGitStack,
+	OpServiceAccount,
+	NewOpServiceAccount,
 	StackSource,
 	NewStackSource,
 	VulnerabilityScan,

--- a/src/lib/server/db/schema/index.ts
+++ b/src/lib/server/db/schema/index.ts
@@ -282,6 +282,14 @@ export const gitCredentials = sqliteTable('git_credentials', {
 	updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`)
 });
 
+export const opServiceAccounts = sqliteTable('op_service_accounts', {
+	id: integer('id').primaryKey({ autoIncrement: true }),
+	name: text('name').notNull().unique(),
+	token: text('token').notNull(),
+	createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),
+	updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`)
+});
+
 export const gitRepositories = sqliteTable('git_repositories', {
 	id: integer('id').primaryKey({ autoIncrement: true }),
 	name: text('name').notNull().unique(),
@@ -340,6 +348,7 @@ export const stackSources = sqliteTable('stack_sources', {
 	gitStackId: integer('git_stack_id').references(() => gitStacks.id, { onDelete: 'set null' }),
 	composePath: text('compose_path'), // Custom path to compose file (for stacks with non-default location)
 	envPath: text('env_path'), // Custom path to .env file (for stacks with non-default location)
+	opServiceAccountId: integer('op_service_account_id').references(() => opServiceAccounts.id, { onDelete: 'set null' }),
 	createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),
 	updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`)
 }, (table) => ({
@@ -566,6 +575,9 @@ export type NewEnvironmentNotification = typeof environmentNotifications.$inferI
 
 export type GitCredential = typeof gitCredentials.$inferSelect;
 export type NewGitCredential = typeof gitCredentials.$inferInsert;
+
+export type OpServiceAccount = typeof opServiceAccounts.$inferSelect;
+export type NewOpServiceAccount = typeof opServiceAccounts.$inferInsert;
 
 export type GitRepository = typeof gitRepositories.$inferSelect;
 export type NewGitRepository = typeof gitRepositories.$inferInsert;

--- a/src/lib/server/db/schema/pg-schema.ts
+++ b/src/lib/server/db/schema/pg-schema.ts
@@ -285,6 +285,14 @@ export const gitCredentials = pgTable('git_credentials', {
 	updatedAt: timestamp('updated_at', { mode: 'string' }).defaultNow()
 });
 
+export const opServiceAccounts = pgTable('op_service_accounts', {
+	id: serial('id').primaryKey(),
+	name: text('name').notNull().unique(),
+	token: text('token').notNull(),
+	createdAt: timestamp('created_at', { mode: 'string' }).defaultNow(),
+	updatedAt: timestamp('updated_at', { mode: 'string' }).defaultNow()
+});
+
 export const gitRepositories = pgTable('git_repositories', {
 	id: serial('id').primaryKey(),
 	name: text('name').notNull().unique(),
@@ -343,6 +351,7 @@ export const stackSources = pgTable('stack_sources', {
 	gitStackId: integer('git_stack_id').references(() => gitStacks.id, { onDelete: 'set null' }),
 	composePath: text('compose_path'), // Custom path to compose file (for stacks with non-default location)
 	envPath: text('env_path'), // Custom path to .env file (for stacks with non-default location)
+	opServiceAccountId: integer('op_service_account_id').references(() => opServiceAccounts.id, { onDelete: 'set null' }),
 	createdAt: timestamp('created_at', { mode: 'string' }).defaultNow(),
 	updatedAt: timestamp('updated_at', { mode: 'string' }).defaultNow()
 }, (table) => ({

--- a/src/lib/server/onepassword.ts
+++ b/src/lib/server/onepassword.ts
@@ -61,3 +61,41 @@ export async function resolveEnvironment(
 	}
 	return result;
 }
+
+/**
+ * Returns true when the trimmed value is an op:// secret reference.
+ */
+export function isOpReference(value: unknown): value is string {
+	return typeof value === 'string' && value.trim().startsWith('op://');
+}
+
+/**
+ * Resolves a list of op:// secret references in a single SDK call.
+ * Returns a map of only the successfully resolved refs. Individual failures
+ * (ref not found, parsing errors, etc.) are logged as warnings and skipped,
+ * leaving the original literal for the caller to handle. The SDK itself may
+ * still throw on transport / auth failures — those propagate to the caller.
+ */
+export async function resolveSecretReferences(
+	token: string,
+	refs: string[],
+	logPrefix = '[1Password]'
+): Promise<Map<string, string>> {
+	const result = new Map<string, string>();
+	if (refs.length === 0) {
+		return result;
+	}
+	const client = await makeClient(token);
+	const response = await client.secrets.resolveAll(refs);
+	for (const [ref, item] of Object.entries(response.individualResponses)) {
+		if (item.error) {
+			const detail = item.error.message ?? item.error.type ?? 'unknown error';
+			console.warn(`${logPrefix} Skipping op:// reference ${ref}: ${detail}`);
+			continue;
+		}
+		if (item.content?.secret !== undefined) {
+			result.set(ref, item.content.secret);
+		}
+	}
+	return result;
+}

--- a/src/lib/server/onepassword.ts
+++ b/src/lib/server/onepassword.ts
@@ -1,0 +1,63 @@
+/**
+ * 1Password Service Account integration.
+ *
+ * Thin wrapper around the official @1password/sdk that exposes only what
+ * Dockhand needs: validating a service account token and reading variables
+ * from a 1Password Environment.
+ *
+ * Decrypted tokens stay inside this module and the in-memory SDK client.
+ * Nothing here writes to disk or to the database.
+ */
+
+import { createClient } from '@1password/sdk';
+
+const INTEGRATION_NAME = 'Dockhand';
+const INTEGRATION_VERSION = '1.0.0';
+
+async function makeClient(token: string) {
+	return createClient({
+		auth: token,
+		integrationName: INTEGRATION_NAME,
+		integrationVersion: INTEGRATION_VERSION
+	});
+}
+
+export interface TestConnectionResult {
+	ok: boolean;
+	error?: string;
+}
+
+/**
+ * Authenticates a service account token. Returns ok: true if the SDK accepts
+ * the token, ok: false with an error message otherwise.
+ */
+export async function testConnection(token: string): Promise<TestConnectionResult> {
+	const trimmed = token?.trim();
+	if (!trimmed) {
+		return { ok: false, error: 'Token is empty' };
+	}
+	try {
+		await makeClient(trimmed);
+		return { ok: true };
+	} catch (e: unknown) {
+		const message = e instanceof Error ? e.message : String(e);
+		return { ok: false, error: message || 'Authentication failed' };
+	}
+}
+
+/**
+ * Fetches all variables from a 1Password Environment as a plain key/value map.
+ * The token is decrypted by the caller and passed in directly.
+ */
+export async function resolveEnvironment(
+	token: string,
+	environmentId: string
+): Promise<Record<string, string>> {
+	const client = await makeClient(token);
+	const response = await client.environments.getVariables(environmentId);
+	const result: Record<string, string> = {};
+	for (const variable of response.variables) {
+		result[variable.name] = variable.value;
+	}
+	return result;
+}

--- a/src/lib/server/onepassword.ts
+++ b/src/lib/server/onepassword.ts
@@ -2,8 +2,8 @@
  * 1Password Service Account integration.
  *
  * Thin wrapper around the official @1password/sdk that exposes only what
- * Dockhand needs: validating a service account token and reading variables
- * from a 1Password Environment.
+ * Dockhand needs: validating a service account token, reading variables
+ * from a 1Password Environment, and interpolating op:// references.
  *
  * Decrypted tokens stay inside this module and the in-memory SDK client.
  * Nothing here writes to disk or to the database.

--- a/src/lib/server/stacks.ts
+++ b/src/lib/server/stacks.ts
@@ -2937,14 +2937,20 @@ async function resolveOpEnvVars(
 	opServiceAccountId?: number | null,
 	stackEnvFileContent?: string
 ): Promise<EnrichedEnvVars> {
-	const opEnvId = dbNonSecretVars['OP_ENVIRONMENT_ID'] ?? secretVars['OP_ENVIRONMENT_ID'];
-	if (opEnvId) {
-		// Strip OP_ENVIRONMENT_ID from values passed to the stack
-		delete secretVars['OP_ENVIRONMENT_ID'];
-		delete dbNonSecretVars['OP_ENVIRONMENT_ID'];
+	const envFileVars = stackEnvFileContent ? parseEnvFileContent(stackEnvFileContent) : {};
 
+	// Priority: secrets > DB non-secrets > .env file (each tier overrides the previous)
+	const opEnvId =
+		secretVars['OP_ENVIRONMENT_ID'] ??
+		dbNonSecretVars['OP_ENVIRONMENT_ID'] ??
+		envFileVars['OP_ENVIRONMENT_ID'];
+	if (opEnvId) {
 		try {
 			if (opServiceAccountId) {
+				// Strip OP_ENVIRONMENT_ID from values passed to the stack
+				delete secretVars['OP_ENVIRONMENT_ID'];
+				delete dbNonSecretVars['OP_ENVIRONMENT_ID'];
+
 				const account = await getOpServiceAccountById(opServiceAccountId);
 				if (account?.token) {
 					console.log(`${logPrefix} Resolving 1Password Environment via "${account.name}"`);
@@ -2968,12 +2974,9 @@ async function resolveOpEnvVars(
 	}
 
 	const envFileOpRefs = new Map<string, string>();
-	if (stackEnvFileContent) {
-		const parsed = parseEnvFileContent(stackEnvFileContent);
-		for (const [key, value] of Object.entries(parsed)) {
-			if (isOpReference(value)) {
-				envFileOpRefs.set(key, value.trim());
-			}
+	for (const [key, value] of Object.entries(envFileVars)) {
+		if (isOpReference(value)) {
+			envFileOpRefs.set(key, value.trim());
 		}
 	}
 
@@ -3028,7 +3031,7 @@ async function resolveOpEnvVars(
 			}
 		}
 	}
-	
+
 	let promotedFromEnvFile = 0;
 	for (const [key, ref] of envFileOpRefs) {
 		if (key in secretVars || key in dbNonSecretVars) continue;

--- a/src/lib/server/stacks.ts
+++ b/src/lib/server/stacks.ts
@@ -36,13 +36,17 @@ import {
 	getPendingContainerUpdates,
 	deleteAutoUpdateSchedule,
 	getAutoUpdateSetting,
-	getStackSourceByComposePath
+	getStackSourceByComposePath,
+	getOpServiceAccountById,
+	type StackSourceWithRepo
 } from './db';
+import { resolveEnvironment as resolveOpEnvironment } from './onepassword';
 import { unregisterSchedule } from './scheduler';
 import { deleteGitStackFiles, parseEnvFileContent } from './git';
 import { cleanPem } from '$lib/utils/pem';
 import { rewriteComposeVolumePaths, getHostDataDir } from './host-path';
 import { getOrderValue } from './container-labels';
+import { opServiceAccounts } from './db/drizzle.js';
 
 // =============================================================================
 // TYPES
@@ -596,6 +600,7 @@ export async function saveStackComposeFile(
 		moveFromDir?: string;  // Old directory to move all files from when path changes
 		oldComposePath?: string;  // Old compose file path for renaming
 		oldEnvPath?: string;  // Old env file path for renaming
+		opServiceAccountId?: number | null;  // 1Password binding (undefined = unchanged)
 	}
 ): Promise<{ success: boolean; error?: string }> {
 	// Validate stack name - Docker Compose requires lowercase alphanumeric, hyphens, underscores
@@ -754,14 +759,22 @@ export async function saveStackComposeFile(
 		}
 	}
 
-	// If a custom composePath is being set (new or update), save it to the database
-	if (options?.composePath || options?.envPath !== undefined) {
+	// If a custom composePath, envPath, or 1Password binding is being set (new or update), save it to the database
+	if (
+		options?.composePath ||
+		options?.envPath !== undefined ||
+		options?.opServiceAccountId !== undefined
+	) {
 		await upsertStackSource({
 			stackName: name,
 			environmentId: envId ?? null,
 			sourceType: 'internal',
 			composePath: options?.composePath || source?.composePath || null,
-			envPath: options?.envPath !== undefined ? options.envPath : (source?.envPath ?? null)
+			envPath: options?.envPath !== undefined ? options.envPath : (source?.envPath ?? null),
+			opServiceAccountId:
+				options?.opServiceAccountId !== undefined
+					? options.opServiceAccountId
+					: (source?.opServiceAccountId ?? null),
 		});
 	}
 
@@ -2589,8 +2602,17 @@ export async function deployStack(options: DeployStackOptions): Promise<StackOpe
 		console.log(compose);
 
 		// Fetch overrides and secrets from DB
-		const dbNonSecretVars = await getNonSecretEnvVarsAsRecord(name, envId);
-		const secretVars = await getSecretEnvVarsAsRecord(name, envId);
+		const initialDbNonSecretVars = await getNonSecretEnvVarsAsRecord(name, envId);
+		const initialSecretVars = await getSecretEnvVarsAsRecord(name, envId);
+
+		// Add environment variables from 1Password
+		const source = await getStackSource(name, envId);
+		const { dbNonSecretVars, secretVars } = await resolveOpEnvVars(
+			initialDbNonSecretVars, 
+			initialSecretVars, 
+			logPrefix, 
+			source?.opServiceAccountId,
+		);
 		console.log(`${logPrefix} DB non-secret override vars:`, Object.keys(dbNonSecretVars).length);
 		console.log(`${logPrefix} DB secret vars:`, Object.keys(secretVars).length);
 
@@ -2887,6 +2909,59 @@ export async function saveStackEnvVars(
 }
 
 // =============================================================================
+// 1PASSWORD INTEGRATION
+// =============================================================================
+
+interface EnrichedEnvVars {
+	dbNonSecretVars: Record<string, string>;
+	secretVars: Record<string, string>;
+}
+
+async function resolveOpEnvVars(
+	dbNonSecretVars: Record<string, string>, 
+	secretVars: Record<string, string>, 
+	logPrefix: string, 
+	opServiceAccountId?: number | null
+): Promise<EnrichedEnvVars> {
+	const opEnvId = dbNonSecretVars['OP_ENVIRONMENT_ID'] ?? secretVars['OP_ENVIRONMENT_ID'];
+	if (opEnvId) {
+		// Strip OP_ENVIRONMENT_ID from values passed to the stack
+		delete secretVars['OP_ENVIRONMENT_ID'];
+		delete dbNonSecretVars['OP_ENVIRONMENT_ID'];
+
+		try {
+			if (opServiceAccountId) {
+				const account = await getOpServiceAccountById(opServiceAccountId);
+				if (account?.token) {
+					console.log(`${logPrefix} Resolving 1Password Environment via "${account.name}"`);
+
+					const opVars = await resolveOpEnvironment(account.token, opEnvId);
+					console.log(`${logPrefix} 1Password injected ${opVars.length} secret(s)`);
+
+					// merge secrets with override
+					return {
+						dbNonSecretVars,
+						secretVars: Object.assign(opVars, secretVars),
+					}
+				} else {
+					console.warn(`${logPrefix} OP_ENVIRONMENT_ID is set but service account ${opServiceAccountId} not found`);
+				}
+			} else {
+				console.warn(`${logPrefix} OP_ENVIRONMENT_ID is set but no 1Password service account is bound to this stack`);
+			}
+		} catch (e: any) {
+			const msg = e instanceof Error ? e.message : String(e);
+			throw new Error(`Failed to load 1Password environment: ${msg}`);
+		}
+	}
+
+	return {
+		dbNonSecretVars,
+		secretVars,
+	}
+}
+
+// =============================================================================
 // RE-EXPORTS FOR BACKWARDS COMPATIBILITY
 // =============================================================================
 
@@ -2894,4 +2969,3 @@ export async function saveStackEnvVars(
 // They can be removed once all imports are updated
 
 export type { StackOperationResult as CreateStackResult };
-

--- a/src/lib/server/stacks.ts
+++ b/src/lib/server/stacks.ts
@@ -40,13 +40,16 @@ import {
 	getOpServiceAccountById,
 	type StackSourceWithRepo
 } from './db';
-import { resolveEnvironment as resolveOpEnvironment } from './onepassword';
+import {
+	resolveEnvironment as resolveOpEnvironment,
+	isOpReference,
+	resolveSecretReferences
+} from './onepassword';
 import { unregisterSchedule } from './scheduler';
 import { deleteGitStackFiles, parseEnvFileContent } from './git';
 import { cleanPem } from '$lib/utils/pem';
 import { rewriteComposeVolumePaths, getHostDataDir } from './host-path';
 import { getOrderValue } from './container-labels';
-import { opServiceAccounts } from './db/drizzle.js';
 
 // =============================================================================
 // TYPES
@@ -2124,6 +2127,10 @@ export async function startStack(
 	const containers = await getStackContainers(stackName, envId);
 	const operation = containers.length > 0 ? 'start' : 'up';
 
+	if (operation === 'up') {
+		await applyOpReferencesToComposeResult(result, stackName, envId, `[Stack:${stackName}]`);
+	}
+
 	return executeComposeCommand(
 		operation,
 		opts,
@@ -2197,6 +2204,7 @@ export async function restartStack(
 	if (mode === 'recreate') {
 		// Stop first, then bring up with --force-recreate to ensure new container IDs
 		await executeComposeCommand('stop', opts, result.content!, result.nonSecretVars, result.secretVars);
+		await applyOpReferencesToComposeResult(result, stackName, envId, `[Stack:${stackName}]`);
 		composeResult = await executeComposeCommand('up', { ...opts, forceRecreate: true }, result.content!, result.nonSecretVars, result.secretVars);
 	} else {
 		composeResult = await executeComposeCommand('restart', opts, result.content!, result.nonSecretVars, result.secretVars);
@@ -2587,11 +2595,13 @@ export async function deployStack(options: DeployStackOptions): Promise<StackOpe
 			stackFiles[composeFilename] = compose;
 			console.log(`${logPrefix} Added ${composeFilename} to stackFiles for Hawser (${compose.length} chars)`);
 		}
-		if (actualEnvPath && existsSync(actualEnvPath) && !stackFiles['.env']) {
+
+		let envFileContent: string | undefined = stackFiles['.env'];
+		if (!envFileContent && actualEnvPath && existsSync(actualEnvPath)) {
 			try {
-				const envContent = readFileSync(actualEnvPath, 'utf-8');
-				stackFiles['.env'] = envContent;
-				console.log(`${logPrefix} Added .env to stackFiles for Hawser (${envContent.length} chars)`);
+				envFileContent = readFileSync(actualEnvPath, 'utf-8');
+				stackFiles['.env'] = envFileContent;
+				console.log(`${logPrefix} Added .env to stackFiles for Hawser (${envFileContent.length} chars)`);
 			} catch (err) {
 				console.warn(`${logPrefix} Failed to read .env file at ${actualEnvPath}:`, err);
 			}
@@ -2608,10 +2618,11 @@ export async function deployStack(options: DeployStackOptions): Promise<StackOpe
 		// Add environment variables from 1Password
 		const source = await getStackSource(name, envId);
 		const { dbNonSecretVars, secretVars } = await resolveOpEnvVars(
-			initialDbNonSecretVars, 
-			initialSecretVars, 
-			logPrefix, 
+			initialDbNonSecretVars,
+			initialSecretVars,
+			logPrefix,
 			source?.opServiceAccountId,
+			envFileContent
 		);
 		console.log(`${logPrefix} DB non-secret override vars:`, Object.keys(dbNonSecretVars).length);
 		console.log(`${logPrefix} DB secret vars:`, Object.keys(secretVars).length);
@@ -2756,6 +2767,8 @@ export async function updateStackService(
 			error: result.error || `Compose file not found for stack "${stackName}"`
 		};
 	}
+
+	await applyOpReferencesToComposeResult(result, stackName, envId, `[Stack:${stackName}]`);
 
 	// Don't use forceRecreate - Docker Compose will detect the image change
 	// naturally since the image was already pulled before this function is called.
@@ -2918,10 +2931,11 @@ interface EnrichedEnvVars {
 }
 
 async function resolveOpEnvVars(
-	dbNonSecretVars: Record<string, string>, 
-	secretVars: Record<string, string>, 
-	logPrefix: string, 
-	opServiceAccountId?: number | null
+	dbNonSecretVars: Record<string, string>,
+	secretVars: Record<string, string>,
+	logPrefix: string,
+	opServiceAccountId?: number | null,
+	stackEnvFileContent?: string
 ): Promise<EnrichedEnvVars> {
 	const opEnvId = dbNonSecretVars['OP_ENVIRONMENT_ID'] ?? secretVars['OP_ENVIRONMENT_ID'];
 	if (opEnvId) {
@@ -2936,29 +2950,132 @@ async function resolveOpEnvVars(
 					console.log(`${logPrefix} Resolving 1Password Environment via "${account.name}"`);
 
 					const opVars = await resolveOpEnvironment(account.token, opEnvId);
-					console.log(`${logPrefix} 1Password injected ${opVars.length} secret(s)`);
+					console.log(`${logPrefix} 1Password injected ${Object.keys(opVars).length} secret(s)`);
 
-					// merge secrets with override
-					return {
-						dbNonSecretVars,
-						secretVars: Object.assign(opVars, secretVars),
-					}
+					// 1Password Environment values are merged underneath, with explicit
+					// DB secrets retaining priority
+					secretVars = Object.assign(opVars, secretVars);
 				} else {
 					console.warn(`${logPrefix} OP_ENVIRONMENT_ID is set but service account ${opServiceAccountId} not found`);
 				}
 			} else {
 				console.warn(`${logPrefix} OP_ENVIRONMENT_ID is set but no 1Password service account is bound to this stack`);
 			}
-		} catch (e: any) {
+		} catch (e: unknown) {
 			const msg = e instanceof Error ? e.message : String(e);
 			throw new Error(`Failed to load 1Password environment: ${msg}`);
 		}
 	}
 
-	return {
-		dbNonSecretVars,
-		secretVars,
+	const envFileOpRefs = new Map<string, string>();
+	if (stackEnvFileContent) {
+		const parsed = parseEnvFileContent(stackEnvFileContent);
+		for (const [key, value] of Object.entries(parsed)) {
+			if (isOpReference(value)) {
+				envFileOpRefs.set(key, value.trim());
+			}
+		}
 	}
+
+	const refs = new Set<string>();
+	for (const value of Object.values(dbNonSecretVars)) {
+		if (isOpReference(value)) refs.add(value.trim());
+	}
+	for (const value of Object.values(secretVars)) {
+		if (isOpReference(value)) refs.add(value.trim());
+	}
+	for (const ref of envFileOpRefs.values()) refs.add(ref);
+
+	if (refs.size === 0) {
+		return { dbNonSecretVars, secretVars };
+	}
+
+	if (!opServiceAccountId) {
+		console.warn(`${logPrefix} Found ${refs.size} op:// reference(s) but no 1Password service account is bound to this stack; leaving them as literals`);
+		return { dbNonSecretVars, secretVars };
+	}
+
+	const account = await getOpServiceAccountById(opServiceAccountId);
+	if (!account?.token) {
+		console.warn(`${logPrefix} Found ${refs.size} op:// reference(s) but service account ${opServiceAccountId} not found; leaving them as literals`);
+		return { dbNonSecretVars, secretVars };
+	}
+
+	let refMap: Map<string, string>;
+	try {
+		refMap = await resolveSecretReferences(account.token, Array.from(refs), logPrefix);
+	} catch (e: unknown) {
+		const msg = e instanceof Error ? e.message : String(e);
+		throw new Error(`Failed to resolve 1Password references: ${msg}`);
+	}
+
+	let promotedFromDb = 0;
+	for (const [key, value] of Object.entries(dbNonSecretVars)) {
+		if (isOpReference(value)) {
+			const resolved = refMap.get(value.trim());
+			if (resolved !== undefined) {
+				delete dbNonSecretVars[key];
+				secretVars[key] = resolved;
+				promotedFromDb++;
+			}
+		}
+	}
+	for (const [key, value] of Object.entries(secretVars)) {
+		if (isOpReference(value)) {
+			const resolved = refMap.get(value.trim());
+			if (resolved !== undefined) {
+				secretVars[key] = resolved;
+			}
+		}
+	}
+	
+	let promotedFromEnvFile = 0;
+	for (const [key, ref] of envFileOpRefs) {
+		if (key in secretVars || key in dbNonSecretVars) continue;
+		const resolved = refMap.get(ref);
+		if (resolved !== undefined) {
+			secretVars[key] = resolved;
+			promotedFromEnvFile++;
+		}
+	}
+
+	console.log(`${logPrefix} 1Password resolved ${refMap.size}/${refs.size} op:// reference(s) (promoted from DB: ${promotedFromDb}, from .env: ${promotedFromEnvFile})`);
+
+	return { dbNonSecretVars, secretVars };
+}
+
+/**
+ * Resolve op:// references for a compose result produced by requireComposeFile().
+ * Mutates result.secretVars / result.nonSecretVars in place so callers can pass
+ * the result through to executeComposeCommand without further plumbing.
+ */
+async function applyOpReferencesToComposeResult(
+	result: RequireComposeResult,
+	stackName: string,
+	envId: number | null | undefined,
+	logPrefix: string
+): Promise<void> {
+	if (!result.success || !result.secretVars || !result.nonSecretVars) return;
+
+	let envFileContent: string | undefined;
+	if (result.envPath && existsSync(result.envPath)) {
+		try {
+			envFileContent = readFileSync(result.envPath, 'utf-8');
+		} catch (err) {
+			console.warn(`${logPrefix} Failed to read .env at ${result.envPath}:`, err);
+		}
+	}
+
+	const source = await getStackSource(stackName, envId ?? undefined);
+	const { dbNonSecretVars, secretVars } = await resolveOpEnvVars(
+		{ ...result.nonSecretVars },
+		{ ...result.secretVars },
+		logPrefix,
+		source?.opServiceAccountId,
+		envFileContent
+	);
+	result.nonSecretVars = dbNonSecretVars;
+	result.secretVars = secretVars;
 }
 
 // =============================================================================

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -19,6 +19,7 @@ export interface Permissions {
 	activity: string[];
 	schedules: string[];
 	templates: string[];
+	secrets: string[];
 }
 
 export interface AuthUser {

--- a/src/routes/api/git/stacks/+server.ts
+++ b/src/routes/api/git/stacks/+server.ts
@@ -61,6 +61,14 @@ export const POST: RequestHandler = async (event) => {
 			return json({ error: 'Stack name must start with a letter or number, and contain only letters, numbers, hyphens, and underscores' }, { status: 400 });
 		}
 
+		if (
+			'opServiceAccountId' in data &&
+			data.opServiceAccountId !== null &&
+			typeof data.opServiceAccountId !== 'number'
+		) {
+			return json({ error: 'opServiceAccountId must be a number or null' }, { status: 400 });
+		}
+
 		// Check for name conflicts with existing stacks (regular/external/git)
 		const existing = await getStackSource(trimmedStackName, data.environmentId || null);
 		if (existing) {
@@ -133,7 +141,8 @@ export const POST: RequestHandler = async (event) => {
 			environmentId: data.environmentId || null,
 			sourceType: 'git',
 			gitRepositoryId: repositoryId,
-			gitStackId: gitStack.id
+			gitStackId: gitStack.id,
+			opServiceAccountId: data.opServiceAccountId ?? null
 		});
 
 		// Register schedule with croner if auto-update is enabled

--- a/src/routes/api/git/stacks/[id]/+server.ts
+++ b/src/routes/api/git/stacks/[id]/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { getGitStack, updateGitStack, deleteGitStack, deleteStackSource, updateStackSourceName, updateStackEnvVarsName, setStackEnvVars, getStackEnvVars, deleteStackEnvVars } from '$lib/server/db';
+import { getGitStack, updateGitStack, deleteGitStack, deleteStackSource, updateStackSourceName, updateStackEnvVarsName, setStackEnvVars, getStackEnvVars, deleteStackEnvVars, updateStackSource } from '$lib/server/db';
 import { deleteGitStackFiles, deployGitStack } from '$lib/server/git';
 import { authorize } from '$lib/server/authorize';
 import { registerSchedule, unregisterSchedule } from '$lib/server/scheduler';
@@ -51,6 +51,14 @@ export const PUT: RequestHandler = async (event) => {
 
 		const data = await request.json();
 
+		if (
+			'opServiceAccountId' in data &&
+			data.opServiceAccountId !== null &&
+			typeof data.opServiceAccountId !== 'number'
+		) {
+			return json({ error: 'opServiceAccountId must be a number or null' }, { status: 400 });
+		}
+
 		// Validate stack name if it's being changed
 		if (data.stackName !== undefined) {
 			const trimmedStackName = data.stackName.trim();
@@ -84,6 +92,13 @@ export const PUT: RequestHandler = async (event) => {
 		if (data.stackName && data.stackName !== oldStackName) {
 			await updateStackSourceName(oldStackName, data.stackName, existing.environmentId);
 			await updateStackEnvVarsName(oldStackName, data.stackName, existing.environmentId);
+		}
+
+		// Update 1Password binding
+		if ('opServiceAccountId' in data) {
+			await updateStackSource(updated.stackName, existing.environmentId, {
+				opServiceAccountId: data.opServiceAccountId ?? null
+			});
 		}
 
 		// Register or unregister schedule with croner

--- a/src/routes/api/onepassword/+server.ts
+++ b/src/routes/api/onepassword/+server.ts
@@ -1,0 +1,48 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getOpServiceAccounts, createOpServiceAccount } from '$lib/server/db';
+import { authorize } from '$lib/server/authorize';
+import { auditOpServiceAccount } from '$lib/server/audit';
+
+export const GET: RequestHandler = async ({ cookies }) => {
+	const auth = await authorize(cookies);
+	if (auth.authEnabled && !(await auth.can('secrets', 'view'))) {
+		return json({ error: 'Permission denied' }, { status: 403 });
+	}
+
+	try {
+		const accounts = await getOpServiceAccounts();
+		return json(accounts.map((a) => ({ ...a, hasToken: true })));
+	} catch (error) {
+		console.error('Error fetching 1Password service accounts:', error);
+		return json({ error: 'Failed to fetch service accounts' }, { status: 500 });
+	}
+};
+
+export const POST: RequestHandler = async (event) => {
+	const { request, cookies } = event;
+	const auth = await authorize(cookies);
+	if (auth.authEnabled && !(await auth.can('secrets', 'create'))) {
+		return json({ error: 'Permission denied' }, { status: 403 });
+	}
+
+	try {
+		const data = await request.json();
+		const name = typeof data.name === 'string' ? data.name.trim() : '';
+		const token = typeof data.token === 'string' ? data.token.trim() : '';
+
+		if (!name || !token) {
+			return json({ error: 'Name and token are required' }, { status: 400 });
+		}
+
+		const account = await createOpServiceAccount({ name, token });
+		await auditOpServiceAccount(event, 'create', account.id, account.name);
+		return json({ ...account, hasToken: true }, { status: 201 });
+	} catch (error: any) {
+		console.error('Error creating 1Password service account:', error);
+		if (error.message?.includes('UNIQUE') || error.message?.includes('unique')) {
+			return json({ error: 'A service account with this name already exists' }, { status: 400 });
+		}
+		return json({ error: 'Failed to create service account' }, { status: 500 });
+	}
+};

--- a/src/routes/api/onepassword/[id]/+server.ts
+++ b/src/routes/api/onepassword/[id]/+server.ts
@@ -1,0 +1,86 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import {
+	getOpServiceAccounts,
+	updateOpServiceAccount,
+	deleteOpServiceAccount
+} from '$lib/server/db';
+import { authorize } from '$lib/server/authorize';
+import { auditOpServiceAccount } from '$lib/server/audit';
+
+async function findAccount(id: number) {
+	const all = await getOpServiceAccounts();
+	return all.find((a) => a.id === id);
+}
+
+export const PUT: RequestHandler = async (event) => {
+	const { params, request, cookies } = event;
+	const auth = await authorize(cookies);
+	if (auth.authEnabled && !(await auth.can('secrets', 'edit'))) {
+		return json({ error: 'Permission denied' }, { status: 403 });
+	}
+
+	try {
+		const id = Number.parseInt(params.id);
+		if (Number.isNaN(id)) {
+			return json({ error: 'Invalid service account ID' }, { status: 400 });
+		}
+
+		const existing = await findAccount(id);
+		if (!existing) {
+			return json({ error: 'Service account not found' }, { status: 404 });
+		}
+
+		const data = await request.json();
+		const name = typeof data.name === 'string' ? data.name.trim() : undefined;
+		const token = typeof data.token === 'string' ? data.token.trim() : undefined;
+
+		if (name !== undefined && !name) {
+			return json({ error: 'Name cannot be empty' }, { status: 400 });
+		}
+
+		const updated = await updateOpServiceAccount(id, { name, token });
+		if (!updated) {
+			return json({ error: 'Service account not found' }, { status: 404 });
+		}
+
+		const details: Record<string, any> = {};
+		if (name && name !== existing.name) details.name = { from: existing.name, to: name };
+		if (token) details.tokenRotated = true;
+
+		await auditOpServiceAccount(event, 'update', id, updated.name, details);
+		return json({ ...updated, hasToken: true });
+	} catch (error: any) {
+		console.error('Error updating 1Password service account:', error);
+		if (error.message?.includes('UNIQUE') || error.message?.includes('unique')) {
+			return json({ error: 'A service account with this name already exists' }, { status: 400 });
+		}
+		return json({ error: 'Failed to update service account' }, { status: 500 });
+	}
+};
+
+export const DELETE: RequestHandler = async (event) => {
+	const { params, cookies } = event;
+	const auth = await authorize(cookies);
+	if (auth.authEnabled && !(await auth.can('secrets', 'delete'))) {
+		return json({ error: 'Permission denied' }, { status: 403 });
+	}
+
+	try {
+		const id = Number.parseInt(params.id);
+		if (Number.isNaN(id)) {
+			return json({ error: 'Invalid service account ID' }, { status: 400 });
+		}
+
+		const deleted = await deleteOpServiceAccount(id);
+		if (!deleted) {
+			return json({ error: 'Service account not found' }, { status: 404 });
+		}
+
+		await auditOpServiceAccount(event, 'delete', id, deleted.name);
+		return json({ success: true });
+	} catch (error) {
+		console.error('Error deleting 1Password service account:', error);
+		return json({ error: 'Failed to delete service account' }, { status: 500 });
+	}
+};

--- a/src/routes/api/onepassword/[id]/test/+server.ts
+++ b/src/routes/api/onepassword/[id]/test/+server.ts
@@ -1,0 +1,28 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getOpServiceAccountById } from '$lib/server/db';
+import { authorize } from '$lib/server/authorize';
+import { testConnection } from '$lib/server/onepassword';
+
+export const POST: RequestHandler = async ({ params, cookies }) => {
+	const auth = await authorize(cookies);
+	if (auth.authEnabled && !(await auth.can('secrets', 'view'))) {
+		return json({ error: 'Permission denied' }, { status: 403 });
+	}
+
+	const id = Number.parseInt(params.id);
+	if (Number.isNaN(id)) {
+		return json({ error: 'Invalid service account ID' }, { status: 400 });
+	}
+
+	const account = await getOpServiceAccountById(id);
+	if (!account) {
+		return json({ error: 'Service account not found' }, { status: 404 });
+	}
+
+	const result = await testConnection(account.token);
+	if (!result.ok) {
+		return json({ ok: false, error: result.error }, { status: 200 });
+	}
+	return json({ ok: true });
+};

--- a/src/routes/api/onepassword/test/+server.ts
+++ b/src/routes/api/onepassword/test/+server.ts
@@ -1,0 +1,27 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authorize } from '$lib/server/authorize';
+import { testConnection } from '$lib/server/onepassword';
+
+/** Test a token before it's persisted to the database. */
+export const POST: RequestHandler = async ({ request, cookies }) => {
+	const auth = await authorize(cookies);
+	if (auth.authEnabled && !(await auth.can('secrets', 'create'))) {
+		return json({ error: 'Permission denied' }, { status: 403 });
+	}
+
+	let token = '';
+	try {
+		const data = await request.json();
+		token = typeof data.token === 'string' ? data.token : '';
+	} catch {
+		return json({ error: 'Invalid request body' }, { status: 400 });
+	}
+
+	if (!token.trim()) {
+		return json({ ok: false, error: 'Token is required' }, { status: 200 });
+	}
+
+	const result = await testConnection(token);
+	return json(result);
+};

--- a/src/routes/api/stacks/+server.ts
+++ b/src/routes/api/stacks/+server.ts
@@ -91,7 +91,7 @@ export const POST: RequestHandler = async (event) => {
 
 	try {
 		const body = await request.json();
-		const { name, compose, start, envVars, rawEnvContent, composePath, envPath } = body;
+		const { name, compose, start, envVars, rawEnvContent, composePath, envPath, opServiceAccountId } = body;
 
 		if (!name || typeof name !== 'string') {
 			return json({ error: 'Stack name is required' }, { status: 400 });
@@ -99,6 +99,14 @@ export const POST: RequestHandler = async (event) => {
 
 		if (!compose || typeof compose !== 'string') {
 			return json({ error: 'Compose file content is required' }, { status: 400 });
+		}
+
+		if (
+			'opServiceAccountId' in body &&
+			opServiceAccountId !== null &&
+			typeof opServiceAccountId !== 'number'
+		) {
+			return json({ error: 'opServiceAccountId must be a number or null' }, { status: 400 });
 		}
 
 		// If start is false, only create the compose file without deploying
@@ -134,7 +142,8 @@ export const POST: RequestHandler = async (event) => {
 				environmentId: envIdNum,
 				sourceType: 'internal',
 				composePath: composePath || undefined,
-				envPath: envPath || undefined
+				envPath: envPath || undefined,
+				opServiceAccountId,
 			});
 
 			// Audit log
@@ -175,7 +184,8 @@ export const POST: RequestHandler = async (event) => {
 			environmentId: envIdNum,
 			sourceType: 'internal',
 			composePath: composePath || undefined,
-			envPath: envPath || undefined
+			envPath: envPath || undefined,
+			opServiceAccountId
 		});
 
 		// Deploy via SSE to keep connection alive during long operations

--- a/src/routes/api/stacks/[name]/compose/+server.ts
+++ b/src/routes/api/stacks/[name]/compose/+server.ts
@@ -56,15 +56,23 @@ export const PUT: RequestHandler = async ({ params, request, url, cookies }) => 
 
 	try {
 		const body = await request.json();
-		const { content, restart = false, composePath, envPath, moveFromDir, oldComposePath, oldEnvPath } = body;
+		const { content, restart = false, composePath, envPath, moveFromDir, oldComposePath, oldEnvPath, opServiceAccountId } = body;
 
 		if (!content || typeof content !== 'string') {
 			return json({ error: 'Compose file content is required' }, { status: 400 });
 		}
 
-		// Build options object for custom paths, move operation, and file renames
-		const pathOptions = (composePath || envPath !== undefined || moveFromDir || oldComposePath || oldEnvPath)
-			? { composePath, envPath, moveFromDir, oldComposePath, oldEnvPath }
+		if (
+			'opServiceAccountId' in body &&
+			opServiceAccountId !== null &&
+			typeof opServiceAccountId !== 'number'
+		) {
+			return json({ error: 'opServiceAccountId must be a number or null' }, { status: 400 });
+		}
+
+		// Build options object for custom paths, move operation, file renames, and 1Password binding
+		const pathOptions = (composePath || envPath !== undefined || moveFromDir || oldComposePath || oldEnvPath || opServiceAccountId !== undefined)
+			? { composePath, envPath, moveFromDir, oldComposePath, oldEnvPath, opServiceAccountId }
 			: undefined;
 
 		if (restart) {

--- a/src/routes/api/stacks/sources/+server.ts
+++ b/src/routes/api/stacks/sources/+server.ts
@@ -18,12 +18,21 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 		const sources = await getStackSources(envIdNum);
 
 		// Convert to a map for easier lookup in the frontend
-		const sourceMap: Record<string, { sourceType: string; composePath?: string | null; repository?: any }> = {};
+		const sourceMap: Record<
+			string,
+			{
+				sourceType: string;
+				composePath?: string | null;
+				repository?: any;
+				opServiceAccountId?: number | null;
+			}
+		> = {};
 		for (const source of sources) {
 			sourceMap[source.stackName] = {
 				sourceType: source.sourceType,
 				composePath: source.composePath,
-				repository: source.repository
+				repository: source.repository,
+				opServiceAccountId: source.opServiceAccountId,
 			};
 		}
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -16,7 +16,8 @@
 		Users,
 		Info,
 		GitBranch,
-		Tags
+		Tags,
+		KeyRound
 	} from 'lucide-svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 
@@ -26,6 +27,7 @@
 	import LabelsTab from './labels/LabelsTab.svelte';
 	import RegistriesTab from './registries/RegistriesTab.svelte';
 	import GitTab from './git/GitTab.svelte';
+	import SecretsTab from './secrets/SecretsTab.svelte';
 	import ConfigSetsTab from './config-sets/ConfigSetsTab.svelte';
 	import NotificationsTab from './notifications/NotificationsTab.svelte';
 	import AuthTab from './auth/AuthTab.svelte';
@@ -69,6 +71,10 @@
 				<GitBranch class="w-4 h-4" />
 				Git
 			</Tabs.Trigger>
+			<Tabs.Trigger value="secrets" class="flex-1 flex items-center justify-center gap-1.5">
+				<KeyRound class="w-4 h-4" />
+				Secrets
+			</Tabs.Trigger>
 			<Tabs.Trigger value="config-sets" class="flex-1 flex items-center justify-center gap-1.5">
 				<Layers class="w-4 h-4" />
 				Config sets
@@ -109,6 +115,10 @@
 
 		<Tabs.Content value="git" class="flex-1 min-h-0 overflow-y-auto pr-3">
 			{#if activeTab === 'git'}<GitTab />{/if}
+		</Tabs.Content>
+
+		<Tabs.Content value="secrets" class="flex-1 min-h-0 overflow-y-auto" pr-3>
+			{#if activeTab === 'secrets'}<SecretsTab />{/if}
 		</Tabs.Content>
 
 		<Tabs.Content value="config-sets" class="flex-1 min-h-0 overflow-y-auto pr-3">

--- a/src/routes/settings/auth/roles/RoleModal.svelte
+++ b/src/routes/settings/auth/roles/RoleModal.svelte
@@ -65,6 +65,7 @@
 		audit_logs: string[];
 		activity: string[];
 		schedules: string[];
+		secrets: string[];
 	}>({
 		containers: [],
 		images: [],
@@ -81,7 +82,8 @@
 		license: [],
 		audit_logs: [],
 		activity: [],
-		schedules: []
+		schedules: [],
+		secrets: []
 	});
 
 
@@ -138,6 +140,12 @@
 			{ key: 'view', label: 'View schedules' },
 			{ key: 'edit', label: 'Edit schedules' },
 			{ key: 'run', label: 'Run schedules' }
+		],
+		secrets: [
+			{ key: 'view', label: 'View secrets' },
+			{ key: 'create', label: 'Create secrets' },
+			{ key: 'edit', label: 'Edit secrets' },
+			{ key: 'delete', label: 'Delete secrets' }
 		]
 	};
 
@@ -204,7 +212,8 @@
 		license: KeyRound,
 		audit_logs: ClipboardList,
 		activity: Activity,
-		schedules: Timer
+		schedules: Timer,
+		secrets: KeyRound
 	};
 
 	const categoryColorsSolid: Record<string, string> = {
@@ -223,7 +232,8 @@
 		license: 'bg-yellow-100 dark:bg-yellow-950 text-yellow-700 dark:text-yellow-400 border-yellow-300 dark:border-yellow-800',
 		audit_logs: 'bg-stone-100 dark:bg-stone-950 text-stone-700 dark:text-stone-400 border-stone-300 dark:border-stone-800',
 		activity: 'bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-400 border-emerald-300 dark:border-emerald-800',
-		schedules: 'bg-sky-100 dark:bg-sky-950 text-sky-700 dark:text-sky-400 border-sky-300 dark:border-sky-800'
+		schedules: 'bg-sky-100 dark:bg-sky-950 text-sky-700 dark:text-sky-400 border-sky-300 dark:border-sky-800',
+		secrets: 'bg-lime-100 dark:bg-lime-950 text-lime-700 dark:text-lime-400 border-lime-300 dark:border-lime-800'
 	};
 
 	const permissionIcons: Record<string, typeof Eye> = {
@@ -272,7 +282,8 @@
 			license: [],
 			audit_logs: [],
 			activity: [],
-			schedules: []
+			schedules: [],
+			secrets: []
 		};
 	}
 
@@ -302,7 +313,8 @@
 					license: [...(role.permissions.license || [])],
 					audit_logs: [...(role.permissions.audit_logs || [])],
 					activity: [...(role.permissions.activity || [])],
-					schedules: [...(role.permissions.schedules || [])]
+					schedules: [...(role.permissions.schedules || [])],
+					secrets: [...(role.permissions.secrets || [])]
 				};
 				formError = '';
 				formErrors = {};
@@ -330,7 +342,8 @@
 					license: [...(copyFrom.permissions.license || [])],
 					audit_logs: [...(copyFrom.permissions.audit_logs || [])],
 					activity: [...(copyFrom.permissions.activity || [])],
-					schedules: [...(copyFrom.permissions.schedules || [])]
+					schedules: [...(copyFrom.permissions.schedules || [])],
+					secrets: [...(copyFrom.permissions.secrets || [])]
 				};
 				formError = '';
 				formErrors = {};

--- a/src/routes/settings/secrets/SecretsTab.svelte
+++ b/src/routes/settings/secrets/SecretsTab.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { fade } from "svelte/transition";
+	import { toast } from "svelte-sonner";
+	import { Button } from "$lib/components/ui/button";
+	import * as Card from "$lib/components/ui/card";
+	import { Badge } from "$lib/components/ui/badge";
+	import {
+		Plus,
+		Trash2,
+		Pencil,
+		KeyRound,
+		PlugZap,
+		RefreshCw,
+	} from "lucide-svelte";
+	import ConfirmPopover from "$lib/components/ConfirmPopover.svelte";
+	import { canAccess } from "$lib/stores/auth";
+	import { EmptyState } from "$lib/components/ui/empty-state";
+	import ServiceAccountModal, {
+		type OpServiceAccount,
+	} from "./ServiceAccountModal.svelte";
+
+	let accounts = $state<OpServiceAccount[]>([]);
+	let loading = $state(true);
+	let showModal = $state(false);
+	let editing = $state<OpServiceAccount | null>(null);
+	let confirmDeleteId = $state<number | null>(null);
+	let testingId = $state<number | null>(null);
+
+	async function fetchAccounts() {
+		loading = true;
+		try {
+			const response = await fetch("/api/onepassword");
+			accounts = await response.json();
+		} catch (e) {
+			console.error("Failed to fetch 1Password service accounts:", e);
+			toast.error("Failed to fetch service accounts");
+		} finally {
+			loading = false;
+		}
+	}
+
+	function openModal(account?: OpServiceAccount) {
+		editing = account || null;
+		showModal = true;
+	}
+
+	async function deleteAccount(id: number) {
+		try {
+			const response = await fetch(`/api/onepassword/${id}`, {
+				method: "DELETE",
+			});
+			if (response.ok) {
+				await fetchAccounts();
+				toast.success("Service account deleted");
+			} else {
+				const data = await response.json();
+				toast.error(data.error || "Failed to delete service account");
+			}
+		} catch {
+			toast.error("Failed to delete service account");
+		}
+	}
+
+	async function testAccount(account: OpServiceAccount) {
+		testingId = account.id;
+		try {
+			const response = await fetch(
+				`/api/onepassword/${account.id}/test`,
+				{ method: "POST" },
+			);
+			const data = await response.json();
+			if (data.ok) {
+				toast.success(`${account.name}: connection works`);
+			} else {
+				toast.error(
+					`${account.name}: ${data.error || "connection failed"}`,
+				);
+			}
+		} catch {
+			toast.error("Connection test failed");
+		} finally {
+			testingId = null;
+		}
+	}
+
+	onMount(() => {
+		fetchAccounts();
+	});
+</script>
+
+<div class="space-y-4">
+	<div class="flex justify-between items-center">
+		<div class="flex items-center gap-3">
+			<Badge variant="secondary" class="text-xs"
+				>{accounts.length} total</Badge
+			>
+		</div>
+		<div class="flex gap-2">
+			{#if $canAccess("secrets", "create")}
+				<Button size="sm" onclick={() => openModal()}>
+					<Plus class="w-4 h-4" />
+					Add 1Password service account
+				</Button>
+			{/if}
+			<Button size="sm" variant="outline" onclick={fetchAccounts}
+				>Refresh</Button
+			>
+		</div>
+	</div>
+
+	{#if loading && accounts.length === 0}
+		<p class="text-muted-foreground text-sm">Loading service accounts...</p>
+	{:else if accounts.length === 0}
+		<EmptyState
+			icon={KeyRound}
+			title="No 1Password service accounts"
+			description="Add a service account to load secrets from 1Password at deploy time"
+		/>
+	{:else}
+		<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+			{#each accounts as account (account.id)}
+				<div out:fade={{ duration: 200 }}>
+					<Card.Root>
+						<Card.Header class="pb-2">
+							<div class="flex items-start justify-between">
+								<div class="flex items-center gap-2">
+									<KeyRound
+										class="w-5 h-5 text-muted-foreground"
+									/>
+									<Card.Title class="text-base"
+										>{account.name}</Card.Title
+									>
+								</div>
+								<Badge variant="secondary" class="text-xs"
+									>Encrypted</Badge
+								>
+							</div>
+						</Card.Header>
+						<Card.Content class="space-y-3">
+							<div class="text-xs text-muted-foreground">
+								Added {new Date(
+									account.createdAt,
+								).toLocaleDateString()}
+							</div>
+							<div class="flex gap-2 pt-2 min-h-[32px]">
+								{#if $canAccess("secrets", "view")}
+									<Button
+										variant="outline"
+										size="sm"
+										onclick={() => testAccount(account)}
+										disabled={testingId === account.id}
+									>
+										{#if testingId === account.id}
+											<RefreshCw
+												class="w-3 h-3 animate-spin"
+											/>
+										{:else}
+											<PlugZap class="w-3 h-3" />
+										{/if}
+										Test
+									</Button>
+								{/if}
+								{#if $canAccess("secrets", "edit")}
+									<Button
+										variant="outline"
+										size="sm"
+										onclick={() => openModal(account)}
+									>
+										<Pencil class="w-3 h-3" />
+									</Button>
+								{/if}
+								{#if $canAccess("secrets", "delete")}
+									<ConfirmPopover
+										open={confirmDeleteId === account.id}
+										action="Delete"
+										itemType="service account"
+										itemName={account.name}
+										title="Remove"
+										position="left"
+										onConfirm={() =>
+											deleteAccount(account.id)}
+										onOpenChange={(open) =>
+											(confirmDeleteId = open
+												? account.id
+												: null)}
+									>
+										{#snippet children({ open })}
+											<Trash2
+												class="w-3 h-3 {open
+													? 'text-destructive'
+													: 'text-muted-foreground hover:text-destructive'}"
+											/>
+										{/snippet}
+									</ConfirmPopover>
+								{/if}
+							</div>
+						</Card.Content>
+					</Card.Root>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<ServiceAccountModal
+	bind:open={showModal}
+	account={editing}
+	onClose={() => {
+		showModal = false;
+		editing = null;
+	}}
+	onSaved={fetchAccounts}
+/>

--- a/src/routes/settings/secrets/ServiceAccountModal.svelte
+++ b/src/routes/settings/secrets/ServiceAccountModal.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+	import { Button } from "$lib/components/ui/button";
+	import * as Dialog from "$lib/components/ui/dialog";
+	import { Label } from "$lib/components/ui/label";
+	import { Input } from "$lib/components/ui/input";
+	import { Plus, Check, RefreshCw, PlugZap } from "lucide-svelte";
+	import { toast } from "svelte-sonner";
+	import { focusFirstInput } from "$lib/utils";
+
+	export interface OpServiceAccount {
+		id: number;
+		name: string;
+		hasToken: boolean;
+		createdAt: string;
+	}
+
+	interface Props {
+		open: boolean;
+		account?: OpServiceAccount | null;
+		onClose: () => void;
+		onSaved: () => void;
+	}
+
+	let {
+		open = $bindable(),
+		account = null,
+		onClose,
+		onSaved,
+	}: Props = $props();
+
+	const isEditing = $derived(account !== null);
+
+	let formName = $state("");
+	let formToken = $state("");
+	let formError = $state("");
+	let formSaving = $state(false);
+	let formTesting = $state(false);
+
+	function resetForm() {
+		formName = "";
+		formToken = "";
+		formError = "";
+		formSaving = false;
+		formTesting = false;
+	}
+
+	$effect(() => {
+		if (open) {
+			if (account) {
+				formName = account.name;
+				formToken = "";
+				formError = "";
+			} else {
+				resetForm();
+			}
+		}
+	});
+
+	async function testCurrent() {
+		formTesting = true;
+		formError = "";
+		try {
+			let response: Response;
+			if (isEditing && !formToken.trim()) {
+				response = await fetch(`/api/onepassword/${account!.id}/test`, {
+					method: "POST",
+				});
+			} else {
+				if (!formToken.trim()) {
+					formError = "Provide a token to test";
+					return;
+				}
+				response = await fetch("/api/onepassword/test", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ token: formToken.trim() }),
+				});
+			}
+			const data = await response.json();
+			if (data.ok) {
+				toast.success("1Password connection works");
+			} else {
+				toast.error(data.error || "Connection failed");
+				formError = data.error || "Connection failed";
+			}
+		} catch {
+			toast.error("Connection test failed");
+		} finally {
+			formTesting = false;
+		}
+	}
+
+	async function save() {
+		if (!formName.trim()) {
+			formError = "Name is required";
+			return;
+		}
+		if (!isEditing && !formToken.trim()) {
+			formError = "Token is required";
+			return;
+		}
+
+		formSaving = true;
+		formError = "";
+
+		try {
+			const body: Record<string, string> = { name: formName.trim() };
+			if (formToken.trim()) body.token = formToken.trim();
+
+			const url = isEditing
+				? `/api/onepassword/${account!.id}`
+				: "/api/onepassword";
+			const method = isEditing ? "PUT" : "POST";
+
+			const response = await fetch(url, {
+				method,
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(body),
+			});
+
+			if (response.ok) {
+				open = false;
+				onSaved();
+			} else {
+				const data = await response.json();
+				formError =
+					data.error ||
+					`Failed to ${isEditing ? "update" : "create"} service account`;
+			}
+		} catch {
+			formError = `Failed to ${isEditing ? "update" : "create"} service account`;
+		} finally {
+			formSaving = false;
+		}
+	}
+
+	function handleClose() {
+		open = false;
+		onClose();
+	}
+</script>
+
+<Dialog.Root
+	bind:open
+	onOpenChange={(o) => {
+		if (o) {
+			formError = "";
+			focusFirstInput();
+		}
+	}}
+>
+	<Dialog.Content class="max-w-md">
+		<Dialog.Header>
+			<Dialog.Title
+				>{isEditing ? "Edit" : "Add"} 1Password service account</Dialog.Title
+			>
+		</Dialog.Header>
+		<div class="space-y-4">
+			{#if formError}
+				<div class="text-sm text-red-600 dark:text-red-400">
+					{formError}
+				</div>
+			{/if}
+			<div class="space-y-2">
+				<Label for="op-name">Name</Label>
+				<Input
+					id="op-name"
+					bind:value={formName}
+					placeholder="Production secrets"
+				/>
+			</div>
+			<div class="space-y-2">
+				<Label for="op-token">Service account token</Label>
+				<Input
+					id="op-token"
+					type="password"
+					bind:value={formToken}
+					placeholder={isEditing
+						? "leave blank to keep existing"
+						: "ops_eyJ..."}
+				/>
+				<p class="text-xs text-muted-foreground">
+					Token is stored encrypted
+				</p>
+			</div>
+		</div>
+		<Dialog.Footer>
+			<Button
+				variant="outline"
+				onclick={testCurrent}
+				disabled={formTesting || formSaving}
+			>
+				{#if formTesting}
+					<RefreshCw class="w-4 h-4 mr-1 animate-spin" />
+				{:else}
+					<PlugZap class="w-4 h-4 mr-1" />
+				{/if}
+				Test connection
+			</Button>
+			<div class="flex-1"></div>
+			<Button variant="outline" onclick={handleClose}>Cancel</Button>
+			<Button onclick={save} disabled={formSaving}>
+				{#if formSaving}
+					<RefreshCw class="w-4 h-4 mr-1 animate-spin" />
+				{:else if isEditing}
+					<Check class="w-4 h-4" />
+				{:else}
+					<Plus class="w-4 h-4" />
+				{/if}
+				{isEditing ? "Save" : "Add"}
+			</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/routes/stacks/GitStackModal.svelte
+++ b/src/routes/stacks/GitStackModal.svelte
@@ -7,7 +7,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Input } from '$lib/components/ui/input';
 	import { TogglePill } from '$lib/components/ui/toggle-pill';
-	import { Loader2, GitBranch, RefreshCw, Webhook, Rocket, RefreshCcw, Copy, Check, XCircle, FolderGit2, Github, Key, KeyRound, Lock, FileText, HelpCircle, GripVertical, X, Download, Hammer, ArrowDownToLine, Zap, FolderOpen, Ban, TriangleAlert } from 'lucide-svelte';
+	import { Loader2, GitBranch, RefreshCw, Webhook, Rocket, RefreshCcw, Copy, Check, XCircle, FolderGit2, Github, Key, KeyRound, Lock, FileText, CircleQuestionMark, GripVertical, X, Download, Hammer, ArrowDownToLine, Zap, FolderOpen, Ban, TriangleAlert } from 'lucide-svelte';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import CronEditor from '$lib/components/cron-editor.svelte';
@@ -109,6 +109,11 @@
 	let copiedWebhookUrl = $state<'ok' | 'error' | null>(null);
 	let copiedWebhookSecret = $state<'ok' | 'error' | null>(null);
 
+	// 1Password service accounts
+	type OpAccountOption = { id: number; name: string };
+	let opAccounts = $state<OpAccountOption[]>([]);
+	let formOpServiceAccountId = $state<number | null>(null);
+
 	// Environment variables state
 	let formEnvFilePath = $state<string | null>(null);
 	let envFiles = $state<string[]>([]);
@@ -160,7 +165,20 @@
 		// Add global mouse event listeners for split dragging
 		window.addEventListener('mousemove', handleMouseMove);
 		window.addEventListener('mouseup', handleMouseUp);
+
+		fetchOpAccounts();
 	});
+
+	async function fetchOpAccounts() {
+		try {
+			const response = await fetch('/api/onepassword');
+			if (!response.ok) return;
+			const data = await response.json();
+			opAccounts = (data ?? []).map((a: any) => ({ id: a.id, name: a.name }));
+		} catch (e) {
+			console.warn('Failed to load 1Password service accounts:', e);
+		}
+	}
 
 	onDestroy(() => {
 		window.removeEventListener('mousemove', handleMouseMove);
@@ -375,6 +393,10 @@
 			formRepullImages = gitStack.repullImages ?? false;
 			formForceRedeploy = gitStack.forceRedeploy ?? false;
 			formDeployNow = false;
+			formOpServiceAccountId = null;
+			
+			// Load 1Password binding
+			loadOpBindingForStack(gitStack.stackName);
 
 			// Load env files and overrides SYNCHRONOUSLY to avoid race conditions
 			// Wait for all loads to complete before allowing any other effect to run
@@ -404,6 +426,20 @@
 			formRepullImages = false;
 			formForceRedeploy = false;
 			formDeployNow = false;
+			formOpServiceAccountId = null;
+		}
+	}
+
+	async function loadOpBindingForStack(stackName: string) {
+		try {
+			const url = environmentId ? `/api/stacks/sources?env=${environmentId}` : '/api/stacks/sources';
+			const response = await fetch(url);
+			if (!response.ok) return;
+			const sourceMap = await response.json();
+			const source = sourceMap?.[stackName];
+			formOpServiceAccountId = source?.opServiceAccountId ?? null;
+		} catch (e) {
+			console.warn('Failed to load 1Password binding for git stack:', e);
 		}
 	}
 
@@ -484,6 +520,7 @@
 				repullImages: formRepullImages,
 				forceRedeploy: formForceRedeploy,
 				deployNow: deployAfterSave,
+				opServiceAccountId: formOpServiceAccountId,
 				envVars: overrideVars.map(v => ({
 					key: v.key.trim(),
 					value: v.value,
@@ -804,7 +841,7 @@
 					<Label for="env-file-path">Additional env file (optional)</Label>
 					<Tooltip.Root>
 						<Tooltip.Trigger>
-							<HelpCircle class="w-3.5 h-3.5 text-muted-foreground cursor-help" />
+							<CircleQuestionMark class="w-3.5 h-3.5 text-muted-foreground cursor-help" />
 						</Tooltip.Trigger>
 						<Tooltip.Content>
 							<div class="w-80">
@@ -829,7 +866,7 @@
 					<Label for="context-dir">Context directory (optional)</Label>
 					<Tooltip.Root>
 						<Tooltip.Trigger>
-							<HelpCircle class="w-3.5 h-3.5 text-muted-foreground cursor-help" />
+							<CircleQuestionMark class="w-3.5 h-3.5 text-muted-foreground cursor-help" />
 						</Tooltip.Trigger>
 						<Tooltip.Content>
 							<div class="w-80">
@@ -1053,6 +1090,41 @@
 
 			<!-- Right column: Environment Variables -->
 			<div class="flex-1 min-w-0 flex flex-col overflow-hidden bg-zinc-50 dark:bg-zinc-800/50">
+				<!-- 1Password service account selector -->
+				<div class="px-3 py-2 border-b border-zinc-200 dark:border-zinc-700 bg-zinc-100/60 dark:bg-zinc-800/60 flex items-center gap-2 text-xs">
+					<Label for="op-account-select-git" class="text-xs text-muted-foreground shrink-0">1Password Service Account</Label>
+					<Select.Root
+						type="single"
+						value={formOpServiceAccountId !== null ? String(formOpServiceAccountId) : ''}
+						onValueChange={(v) => { formOpServiceAccountId = v ? parseInt(v) : null; }}
+					>
+						<Select.Trigger id="op-account-select-git" class="h-7 text-xs">
+							{#if formOpServiceAccountId !== null}
+								{opAccounts.find((a) => a.id === formOpServiceAccountId)?.name ?? 'Unknown account'}
+							{:else}
+								<span class="text-muted-foreground">None — disabled</span>
+							{/if}
+						</Select.Trigger>
+						<Select.Content>
+							<Select.Item value="" label="None">
+								<span class="text-muted-foreground">None — disabled</span>
+							</Select.Item>
+							{#each opAccounts as account (account.id)}
+								<Select.Item value={String(account.id)} label={account.name}>
+									{account.name}
+								</Select.Item>
+							{/each}
+						</Select.Content>
+					</Select.Root>
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							<CircleQuestionMark class="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+						</Tooltip.Trigger>
+						<Tooltip.Content class="max-w-xs text-xs">
+							Set <code>OP_ENVIRONMENT_ID</code> in env vars to a 1Password Environment ID. Its variables are loaded and injected as secrets.
+						</Tooltip.Content>
+					</Tooltip.Root>
+				</div>
 				<StackEnvVarsPanel
 					bind:variables={envVars}
 					placeholder={{ key: 'MY_VAR', value: 'value' }}
@@ -1081,7 +1153,7 @@
 								</Button>
 								<Tooltip.Root>
 									<Tooltip.Trigger>
-										<HelpCircle class="w-3.5 h-3.5 text-muted-foreground cursor-help" />
+										<CircleQuestionMark class="w-3.5 h-3.5 text-muted-foreground cursor-help" />
 									</Tooltip.Trigger>
 									<Tooltip.Content>
 										<div class="w-64">

--- a/src/routes/stacks/StackModal.svelte
+++ b/src/routes/stacks/StackModal.svelte
@@ -7,7 +7,7 @@
 	import CodeEditor, { type VariableMarker } from '$lib/components/CodeEditor.svelte';
 	import StackEnvVarsPanel from '$lib/components/StackEnvVarsPanel.svelte';
 	import { type EnvVar, type ValidationResult } from '$lib/components/StackEnvVarsEditor.svelte';
-	import { Layers, Save, Play, Code, GitGraph, Loader2, AlertCircle, X, Sun, Moon, TriangleAlert, GripVertical, FolderOpen, Copy, Check, XCircle, MapPin, ArrowRight, ArrowDown, Info, Box, FolderSync } from 'lucide-svelte';
+	import { Layers, Save, Play, Code, GitGraph, Loader2, AlertCircle, X, Sun, Moon, TriangleAlert, GripVertical, FolderOpen, Copy, Check, XCircle, MapPin, ArrowRight, ArrowDown, Info, Box, FolderSync, CircleQuestionMark } from 'lucide-svelte';
 	import type { Component } from 'svelte';
 	import FilesystemBrowser from './FilesystemBrowser.svelte';
 	import PathBarItem from './PathBarItem.svelte';
@@ -59,6 +59,11 @@
 	let activeTab = $state<'editor' | 'graph'>('editor');
 	let showConfirmClose = $state(false);
 	let editorTheme = $state<'light' | 'dark'>('dark');
+
+	// 1Password service accounts
+	type OpAccountOption = { id: number; name: string };
+	let opAccounts = $state<OpAccountOption[]>([]);
+	let formOpServiceAccountId = $state<number | null>(null);
 
 	// Environment variables state
 	let envVars = $state<EnvVar[]>([]);
@@ -682,7 +687,20 @@
 		// Add global mouse event listeners for split dragging
 		window.addEventListener('mousemove', handleMouseMove);
 		window.addEventListener('mouseup', handleMouseUp);
+
+		fetchOpAccounts();
 	});
+
+	async function fetchOpAccounts() {
+		try {
+			const response = await fetch('/api/onepassword');
+			if (!response.ok) return;
+			const data = await response.json();
+			opAccounts = (data ?? []).map((a: any) => ({ id: a.id, name: a.name }));
+		} catch (e) {
+			console.warn('Failed to load 1Password service accounts:', e);
+		}
+	}
 
 	onDestroy(() => {
 		window.removeEventListener('mousemove', handleMouseMove);
@@ -768,6 +786,19 @@
 			// Track original paths for detecting changes
 			originalComposePath = data.composePath || null;
 			originalEnvPath = data.envPath || null;
+
+			// Load 1Password binding
+			try {
+				const envId = $currentEnvironment?.id ?? null;
+				const sourcesRes = await fetch(appendEnvParam('/api/stacks/sources', envId));
+				if (sourcesRes.ok) {
+					const sourceMap = await sourcesRes.json();
+					const source = sourceMap?.[stackName];
+					formOpServiceAccountId = source?.opServiceAccountId ?? null;
+				}
+			} catch (e) {
+				console.warn('Failed to load stack source for 1Password binding:', e);
+			}
 
 			// Load both env endpoints in parallel, then process results together
 			const [envResponse, rawEnvResponse] = await Promise.all([
@@ -919,6 +950,8 @@
 				requestBody.envPath = envPathToSave;
 			}
 
+			requestBody.opServiceAccountId = formOpServiceAccountId;
+
 			// Create the stack
 			response = await fetch(appendEnvParam('/api/stacks', envId), {
 				method: 'POST',
@@ -1049,6 +1082,8 @@
 			if (moveFromDir) {
 				requestBody.moveFromDir = moveFromDir;
 			}
+
+			requestBody.opServiceAccountId = formOpServiceAccountId;
 
 			// Save env files BEFORE compose to ensure deploy reads fresh values
 			// Save raw content to .env file (non-secrets only, comments preserved)
@@ -1602,6 +1637,46 @@
 							</div>
 							<!-- Environment variables panel -->
 							<div class="flex-1 min-w-0 flex flex-col overflow-hidden bg-zinc-50 dark:bg-zinc-800/50">
+								<!-- 1Password service account selector -->
+								<div class="px-3 py-2 border-b border-zinc-200 dark:border-zinc-700 bg-zinc-100/60 dark:bg-zinc-800/60 flex items-center gap-2 text-xs">
+									<Label for="op-account-select" class="text-xs text-muted-foreground shrink-0">1Password Service Account</Label>
+									<Select.Root
+										type="single"
+										value={formOpServiceAccountId !== null ? String(formOpServiceAccountId) : ''}
+										onValueChange={(v) => {
+											formOpServiceAccountId = v ? parseInt(v) : null;
+											markDirty();
+										}}
+									>
+										<Select.Trigger id="op-account-select" class="h-7 text-xs">
+											{#if formOpServiceAccountId !== null}
+												{opAccounts.find((a) => a.id === formOpServiceAccountId)?.name ?? 'Unknown account'}
+											{:else}
+												<span class="text-muted-foreground">None — disabled</span>
+											{/if}
+										</Select.Trigger>
+										<Select.Content>
+											<Select.Item value="" label="None">
+												<span class="text-muted-foreground">None — disabled</span>
+											</Select.Item>
+											{#each opAccounts as account (account.id)}
+												<Select.Item value={String(account.id)} label={account.name}>
+													{account.name}
+												</Select.Item>
+											{/each}
+										</Select.Content>
+									</Select.Root>
+									<Tooltip.Provider delayDuration={150}>
+										<Tooltip.Root>
+											<Tooltip.Trigger>
+												<CircleQuestionMark class="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+											</Tooltip.Trigger>
+											<Tooltip.Content class="max-w-xs text-xs">
+												Set <code>OP_ENVIRONMENT_ID</code> in env vars to a 1Password Environment ID. Its variables are loaded and injected as secrets.
+											</Tooltip.Content>
+										</Tooltip.Root>
+									</Tooltip.Provider>
+								</div>
 								<StackEnvVarsPanel
 									bind:this={envVarsPanelRef}
 									bind:variables={envVars}

--- a/src/routes/stacks/StackModal.svelte
+++ b/src/routes/stacks/StackModal.svelte
@@ -70,6 +70,17 @@
 	let rawEnvContent = $state(''); // Raw .env file content (comments preserved)
 	let envValidation = $state<ValidationResult | null>(null);
 	let validating = $state(false);
+
+	// OP_ENVIRONMENT_ID is consumed by the 1Password integration, not the compose file,
+	// so it only counts as "used" when a service account is bound to the stack.
+	const effectiveValidation = $derived.by<ValidationResult | null>(() => {
+		if (!envValidation || formOpServiceAccountId === null) return envValidation;
+		if (!envValidation.unused.includes('OP_ENVIRONMENT_ID')) return envValidation;
+		return {
+			...envValidation,
+			unused: envValidation.unused.filter((v) => v !== 'OP_ENVIRONMENT_ID')
+		};
+	});
 	let existingSecretKeys = $state<Set<string>>(new Set());
 	let hadExistingDbVars = $state(false); // Track if DB had any vars on load (for proper cleanup)
 
@@ -1681,7 +1692,7 @@
 									bind:this={envVarsPanelRef}
 									bind:variables={envVars}
 									bind:rawContent={rawEnvContent}
-									validation={envValidation}
+									validation={effectiveValidation}
 									existingSecretKeys={mode === 'edit' ? existingSecretKeys : new Set()}
 									onchange={() => { markDirty(); debouncedValidate(); }}
 									theme={editorTheme}


### PR DESCRIPTION
## Proposed change

This PR adds an integration with 1Password for homelab enthusiasts like myself. It **does not** support 1Password Connect Servers for business users.

Users now have an ability to add 1Password service accounts in their settings:
<img width="3178" height="2166" alt="CleanShot 2026-05-30 at 14 42 25@2x" src="https://github.com/user-attachments/assets/0c4288fd-adc7-407c-87e0-9c7a5ba0871f" />

It's possible to bind a service account to a stack:
<img width="3178" height="2166" alt="CleanShot 2026-05-30 at 14 44 04@2x" src="https://github.com/user-attachments/assets/d47aede1-308f-43ae-93b2-a4e996179a6e" />

1. A dropdown to select a service account.
2. A **non-secret** var with an `op://`-reference as its value (will be replaced with a real secret upon deployment).
3. An ID for the [1Password Environment](https://www.1password.dev/environments) (the whole content will be injected during deployment as secrets).
4. The environment vars from the 1Password Environment that a container needs should (as always) be listed in the compose file.

----
### Results 

<img width="3178" height="2166" alt="CleanShot 2026-05-30 at 14 46 31@2x" src="https://github.com/user-attachments/assets/eb7d25c5-51ec-4e05-b052-809aa3e1b654" />

1. The secrets injected from 1Password Environment.
2. An interpolated op-reference.

----

Works with git stacks and `.env` files too! (Although I haven't tested it much with Hawser yet, it looks like it should work as well).

I tried to keep this feature as non-intrusive as possible.

Closes #1029.

## Type of change

<!--
What type of change does your PR introduce to Dockhand?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain:

