### PR TITLE
fix(git-stacks): ensure deletions in git source are represented in updated stack

### DIFF
--- a/src/lib/server/stacks.ts
+++ b/src/lib/server/stacks.ts
@@ -2296,10 +2296,10 @@ export async function deployStack(options: DeployStackOptions): Promise<StackOpe
 			console.log(`${logPrefix} Files:`, Object.keys(stackFiles).join(', '));
 
 			// Copy git source files to stack directory (overlay, not replace).
-			// Do NOT rmSync first — relative volume mounts (e.g., ./data) live here
-			// and would be destroyed, causing data loss (#831).
+			// Clear directory first to allow full git sync, including deleted files.
 			console.log(`${logPrefix} Copying source directory to stack directory...`);
-			mkdirSync(workingDir, { recursive: true });
+            rmSync(workingDir, { recursive: true, force: true });
+            mkdirSync(workingDir, { recursive: true });
 			cpSync(sourceDir, workingDir, {
 				recursive: true,
 				force: true,


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->
This PR ensures that 'git-sync' mirrors the repository exactly by removing and recreating the working directory before copying the repo contents.

The previous behavior avoids deleting files to preserve container-created data (#831), but that prevents deletions on the remote repo from being applied and breakes the expected mirror behavior of a git sync.

This change breaks persistence inside the stack folder. Files that need persistence should be stored in volumes instead, which are not git-synced. This provides a clear separation between git managed config files and volume manged working data.

Closes #966 

## Type of change

<!--
What type of change does your PR introduce to Dockhand?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [X] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain:

