### PR TITLE
fix: auto-update column showed "daily" for interval crons

### DIFF
--- a/src/lib/stores/containers.ts
+++ b/src/lib/stores/containers.ts
@@ -4,6 +4,7 @@ import type { ContainerInfo, ContainerStats } from '$lib/types';
 import { appendEnvParam, clearStaleEnvironment, environments } from '$lib/stores/environment';
 import { appSettings } from '$lib/stores/settings';
 import { toast } from 'svelte-sonner';
+import cronstrue from 'cronstrue';
 
 export interface AutoUpdateSetting {
 	enabled: boolean;
@@ -59,43 +60,21 @@ function createContainerStore() {
 		update((s) => ({ ...s, ...partial }));
 	}
 
-	function formatSchedule(
-		scheduleType: string,
-		cronExpression: string
-	): { label: string; tooltip: string } {
+	function formatSchedule(cronExpression: string): { label: string; tooltip: string } {
 		if (!cronExpression) return { label: 'on', tooltip: 'Auto-update enabled' };
 
-		const parts = cronExpression.split(' ');
-		if (parts.length < 5) return { label: 'cron', tooltip: cronExpression };
-
-		const [min, hr, , , dow] = parts;
-		const hourNum = parseInt(hr);
-		const minNum = parseInt(min);
 		const is12Hour = get(appSettings).timeFormat === '12h';
 
-		let timeStr: string;
-		if (is12Hour) {
-			const ampm = hourNum >= 12 ? 'PM' : 'AM';
-			const hour12 = hourNum === 0 ? 12 : hourNum > 12 ? hourNum - 12 : hourNum;
-			timeStr = `${hour12}:${minNum.toString().padStart(2, '0')} ${ampm}`;
-		} else {
-			timeStr = `${hourNum.toString().padStart(2, '0')}:${minNum.toString().padStart(2, '0')}`;
+		try {
+			const description = cronstrue.toString(cronExpression, {
+				use24HourTimeFormat: !is12Hour,
+				throwExceptionOnParseError: true,
+				locale: 'en'
+			});
+			return { label: description, tooltip: description };
+		} catch {
+			return { label: 'cron', tooltip: cronExpression };
 		}
-
-		if (scheduleType === 'daily' || dow === '*') {
-			return { label: 'daily', tooltip: `Daily at ${timeStr}` };
-		}
-
-		if (scheduleType === 'weekly') {
-			const days = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
-			const dayName = days[parseInt(dow)] || dow;
-			return {
-				label: dayName,
-				tooltip: `Every ${['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'][parseInt(dow)] || dow} at ${timeStr}`
-			};
-		}
-
-		return { label: 'cron', tooltip: cronExpression };
 	}
 
 	async function checkScannerSettings(envId: number | null) {
@@ -152,10 +131,7 @@ function createContainerStore() {
 							cronExpression: string | null;
 							vulnerabilityCriteria: string;
 						};
-						const { label, tooltip } = formatSchedule(
-							s.scheduleType,
-							s.cronExpression || ''
-						);
+						const { label, tooltip } = formatSchedule(s.cronExpression || '');
 						settings.set(containerName, {
 							enabled: true,
 							label,


### PR DESCRIPTION
## Proposed change

The Containers overview used a hand-rolled formatSchedule that labeled any expression with dow === '*' (e.g. */5 * * * *) as "daily". Switched it to cronstrue — the same library the Edit view uses — so the column and editor always agree.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain:

