### PR TITLE
fix(stacks): pass environment id when loading saved compose for env validation

### DIFF
--- a/src/routes/api/stacks/[name]/env/validate/+server.ts
+++ b/src/routes/api/stacks/[name]/env/validate/+server.ts
@@ -134,7 +134,7 @@ export const POST: RequestHandler = async ({ params, url, cookies, request }) =>
 
 		// If no compose in body, try to load from saved file
 		if (!composeContent) {
-			const savedCompose = await getStackComposeFile(stackName);
+			const savedCompose = await getStackComposeFile(stackName, envIdNum);
 			if (savedCompose.success && savedCompose.content) {
 				composeContent = savedCompose.content;
 			}


### PR DESCRIPTION
## Proposed change

`POST /api/stacks/[name]/env/validate?env=<id>` returns `400 {"error":"No compose content provided and no saved compose file found"}` for **every environment-scoped stack** when the request body contains no compose content — even though the stack has a saved compose file and the endpoint documents this mode ("Can use saved compose file or accept compose content in body").

### Root cause

The handler parses the environment id from the query string and uses it for the permission checks and the env var lookup, but drops it when loading the saved compose file:

```ts
const envId    = url.searchParams.get('env');
const envIdNum = envId ? parseInt(envId) : null;
// ...envIdNum is used for authorize() and getStackEnvVars()...
const savedCompose = await getStackComposeFile(stackName);   // ← env id missing
```

`getStackComposeFile(stackName, envId?)` resolves the stack via `getStackSource(stackName, envId)`, and `getStackSource` treats a missing env id as `isNull(stackSources.environmentId)` — so for a stack with a non-null `environmentId` the lookup finds no row, `getStackComposeFile` returns `needsFileLocation: true`, and the handler responds 400.

### Fix

Pass the already-parsed `envIdNum` through, matching what the sibling compose endpoint (`src/routes/api/stacks/[name]/compose/+server.ts`) already does:

```diff
- const savedCompose = await getStackComposeFile(stackName);
+ const savedCompose = await getStackComposeFile(stackName, envIdNum);
```

For non-env (legacy) stacks `envIdNum` is `null`, which preserves the current `isNull(environmentId)` lookup — their behaviour is unchanged.

### Why this went unnoticed

The Dockhand UI (`StackModal.svelte`) always sends `{ compose, variables }` in the request body, which bypasses the saved-file path entirely. Only API clients using the empty-body mode hit the bug. Discovered while writing end-to-end tests for a CLI client that calls this endpoint.

### How to reproduce / test

Against any stack created in a non-default environment (replace `<id>` with the environment id):

```bash
curl -s -X POST -H "Authorization: Bearer $TOKEN" \
  "https://<host>/api/stacks/<stack>/env/validate?env=<id>"
```

Before: `400 {"error":"No compose content provided and no saved compose file found"}`
After: `200` with the expected `{valid, required, optional, defined, missing, unused}` validation result.

Stacks without an environment scope and UI-driven validation (compose in body) behave exactly as before.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain:
