### PR TITLE
fix(environments): allow deleting disconnected environments

### DIFF
--- a/src/lib/utils/environment-delete.ts
+++ b/src/lib/utils/environment-delete.ts
@@ -1,0 +1,42 @@
+export interface EnvironmentDeleteCounts {
+	stackCount: number;
+	gitStackCount: number;
+	unknown: boolean;
+}
+
+type FetchEnvironmentDeleteCounts = (input: string) => Promise<Response>;
+
+async function readArray(response: Response | null): Promise<{ count: number; unknown: boolean }> {
+	if (!response?.ok) {
+		return { count: 0, unknown: true };
+	}
+
+	try {
+		const value: unknown = await response.json();
+		return Array.isArray(value)
+			? { count: value.length, unknown: false }
+			: { count: 0, unknown: true };
+	} catch {
+		return { count: 0, unknown: true };
+	}
+}
+
+export async function fetchEnvironmentDeleteCounts(
+	environmentId: number,
+	fetcher: FetchEnvironmentDeleteCounts = fetch
+): Promise<EnvironmentDeleteCounts> {
+	const [stacksResponse, gitStacksResponse] = await Promise.all([
+		fetcher(`/api/stacks?env=${environmentId}`).catch(() => null),
+		fetcher(`/api/git/stacks?env=${environmentId}`).catch(() => null)
+	]);
+	const [stacks, gitStacks] = await Promise.all([
+		readArray(stacksResponse),
+		readArray(gitStacksResponse)
+	]);
+
+	return {
+		stackCount: stacks.count,
+		gitStackCount: gitStacks.count,
+		unknown: stacks.unknown || gitStacks.unknown
+	};
+}

--- a/src/routes/settings/environments/EnvironmentsTab.svelte
+++ b/src/routes/settings/environments/EnvironmentsTab.svelte
@@ -37,6 +37,7 @@
 	import EnvironmentModal from './EnvironmentModal.svelte';
 	import { environments as environmentsStore } from '$lib/stores/environment';
 	import { dashboardData } from '$lib/stores/dashboard';
+	import { fetchEnvironmentDeleteCounts } from '$lib/utils/environment-delete';
 
 	interface Props {
 		editEnvId?: string | null;
@@ -110,6 +111,7 @@
 	let deleteStackCount = $state(0);
 	let deleteGitStackCount = $state(0);
 	let deleteCountsUnknown = $state(false);
+	let deleteCountsLoading = $state(false);
 
 	// Track which environments have scanner enabled (for shield indicator)
 	let envScannerStatus = $state<{ [id: number]: boolean }>({});
@@ -208,38 +210,36 @@
 		const env = environments.find(e => e.id === id);
 		if (!env) return;
 
-		const [stacksRes, gitRes] = await Promise.all([
-			fetch(`/api/stacks?env=${id}`).catch(() => null),
-			fetch(`/api/git/stacks?env=${id}`).catch(() => null)
-		]);
-
-		let unknown = false;
-		let stacks: unknown[] = [];
-		let gitStacks: unknown[] = [];
-		if (stacksRes?.ok) {
-			try { stacks = await stacksRes.json(); } catch { unknown = true; }
-		} else {
-			unknown = true;
-		}
-		if (gitRes?.ok) {
-			try { gitStacks = await gitRes.json(); } catch { unknown = true; }
-		} else {
-			unknown = true;
-		}
-		deleteStackCount = Array.isArray(stacks) ? stacks.length : 0;
-		deleteGitStackCount = Array.isArray(gitStacks) ? gitStacks.length : 0;
-		deleteCountsUnknown = unknown;
 		deleteEnvTarget = env;
+		deleteStackCount = 0;
+		deleteGitStackCount = 0;
+		deleteCountsUnknown = true;
+		deleteCountsLoading = true;
 		showDeleteConfirm = true;
+
+		const counts = await fetchEnvironmentDeleteCounts(id);
+		if (deleteEnvTarget?.id !== id || !showDeleteConfirm) return;
+
+		deleteStackCount = counts.stackCount;
+		deleteGitStackCount = counts.gitStackCount;
+		deleteCountsUnknown = counts.unknown;
+		deleteCountsLoading = false;
 	}
 
 	async function confirmAndDelete() {
 		const target = deleteEnvTarget;
 		showDeleteConfirm = false;
 		deleteEnvTarget = null;
+		deleteCountsLoading = false;
 		if (target) {
 			await deleteEnvironment(target.id);
 		}
+	}
+
+	function cancelDelete() {
+		showDeleteConfirm = false;
+		deleteEnvTarget = null;
+		deleteCountsLoading = false;
 	}
 
 	async function testConnection(id: number) {
@@ -718,7 +718,12 @@
 							<code class="whitespace-nowrap">$DATA_DIR/git-repos/{deleteEnvTarget.name}/</code>
 						</div>
 					</div>
-					{#if deleteCountsUnknown}
+					{#if deleteCountsLoading}
+						<p class="flex items-center gap-2">
+							<RefreshCw class="w-3.5 h-3.5 animate-spin" />
+							Checking tracked stacks…
+						</p>
+					{:else if deleteCountsUnknown}
 						<p>
 							Couldn't list the stacks on this environment — proceed only
 							if you're sure what's deployed here.
@@ -748,7 +753,7 @@
 			</Dialog.Description>
 		</Dialog.Header>
 		<div class="flex justify-end gap-2 mt-4">
-			<Button variant="outline" onclick={() => (showDeleteConfirm = false)}>
+			<Button variant="outline" onclick={cancelDelete}>
 				Cancel
 			</Button>
 			<Button variant="destructive" onclick={confirmAndDelete}>

--- a/tests/environment-delete.test.ts
+++ b/tests/environment-delete.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { fetchEnvironmentDeleteCounts } from '../src/lib/utils/environment-delete';
+
+describe('fetchEnvironmentDeleteCounts', () => {
+	it('returns stack counts when both endpoints respond', async () => {
+		const result = await fetchEnvironmentDeleteCounts(42, async (url) => {
+			return new Response(JSON.stringify(url.includes('/api/git/') ? [{}, {}] : [{}]));
+		});
+
+		assert.deepEqual(result, {
+			stackCount: 1,
+			gitStackCount: 2,
+			unknown: false
+		});
+	});
+
+	it('fails closed when a disconnected endpoint rejects', async () => {
+		const result = await fetchEnvironmentDeleteCounts(42, async (url) => {
+			if (url.startsWith('/api/stacks')) {
+				throw new Error('connection timed out');
+			}
+			return new Response(JSON.stringify([]));
+		});
+
+		assert.deepEqual(result, {
+			stackCount: 0,
+			gitStackCount: 0,
+			unknown: true
+		});
+	});
+
+	it('fails closed when an endpoint returns an invalid payload', async () => {
+		const result = await fetchEnvironmentDeleteCounts(42, async (url) => {
+			return url.includes('/api/git/')
+				? new Response('{invalid json')
+				: new Response(JSON.stringify([]));
+		});
+
+		assert.equal(result.unknown, true);
+		assert.equal(result.gitStackCount, 0);
+	});
+});


### PR DESCRIPTION
## Proposed change

Closes #1319

Deleting an environment currently waits for `/api/stacks` and `/api/git/stacks` before opening the confirmation dialog. For a disconnected Docker or Hawser environment, the first request can spend 30 seconds in the remote connection timeout, making the delete button appear inert.

This change opens the fail-closed confirmation dialog immediately and loads stack counts in the background. While loading, the dialog clearly reports that it is checking tracked stacks. If either request times out, rejects, returns an HTTP error, or returns malformed JSON, the existing unknown-count warning is shown and deletion remains available.

Late count responses are ignored after the user cancels, confirms, or switches deletion targets, preventing stale data from leaking into a later dialog.

Validation:

- Added focused tests for successful counts, disconnected endpoint rejection, and malformed payloads: `3 passed`.
- Compiled `EnvironmentsTab.svelte` directly with the Svelte compiler.
- The new helper and test file introduce no `svelte-check` diagnostics. The component only reports its existing Hawser and duplicate `Environment` type diagnostics.
- The repository-wide `svelte-check` and production build are already red on the unchanged `main` revision due to existing generated database/Svelte typing drift and an unrelated TypeScript preprocessing failure; the same build failure was reproduced in a clean `origin/main` worktree.

No remote containers or stacks are stopped by this operation; the existing confirmation text and local cleanup behavior remain unchanged.

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain:
