### PR TITLE
feat: display last commit hash in Git source badge

### DIFF
--- a/src/routes/stacks/+page.svelte
+++ b/src/routes/stacks/+page.svelte
@@ -1751,7 +1751,6 @@
 								<Tooltip.Trigger>
 									<span
 										class="inline-flex items-center justify-center gap-1 text-xs px-1.5 py-0.5 rounded-sm bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200 shadow-sm min-w-[5.5rem]"
-										title={`Commit: ${source.gitStack.lastCommit}${source.repository ? `\n${source.repository.url} (${source.repository.branch})` : ''}`}
 									>
 										<GitBranch class="w-3 h-3" />
 										<span>Git</span>

--- a/src/routes/stacks/+page.svelte
+++ b/src/routes/stacks/+page.svelte
@@ -1746,13 +1746,35 @@
 					</span>
 				{:else if column.id === 'source'}
 					{#if source.sourceType === 'git'}
-						<span
-							class="inline-flex items-center justify-center gap-1 text-xs px-1.5 py-0.5 rounded-sm bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200 shadow-sm min-w-[5.5rem]"
-							title={source.repository ? `${source.repository.url} (${source.repository.branch})` : 'Deployed from Git repository'}
-						>
-							<GitBranch class="w-3 h-3" />
-							Git
-						</span>
+						{#if source.gitStack?.lastCommit}
+							<Tooltip.Root>
+								<Tooltip.Trigger>
+									<span
+										class="inline-flex items-center justify-center gap-1 text-xs px-1.5 py-0.5 rounded-sm bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200 shadow-sm min-w-[5.5rem]"
+										title={`Commit: ${source.gitStack.lastCommit}${source.repository ? `\n${source.repository.url} (${source.repository.branch})` : ''}`}
+									>
+										<GitBranch class="w-3 h-3" />
+										<span>Git</span>
+										<span class="font-mono text-[10px] opacity-75">{source.gitStack.lastCommit}</span>
+									</span>
+								</Tooltip.Trigger>
+								<Tooltip.Content class="whitespace-nowrap">
+									<code class="text-xs">{source.gitStack.lastCommit}</code>
+									{#if source.repository}
+										<br />
+										<span class="text-xs">{source.repository.url} ({source.repository.branch})</span>
+									{/if}
+								</Tooltip.Content>
+							</Tooltip.Root>
+						{:else}
+							<span
+								class="inline-flex items-center justify-center gap-1 text-xs px-1.5 py-0.5 rounded-sm bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200 shadow-sm min-w-[5.5rem]"
+								title={source.repository ? `${source.repository.url} (${source.repository.branch})` : 'Deployed from Git repository'}
+							>
+								<GitBranch class="w-3 h-3" />
+								Git
+							</span>
+						{/if}
 					{:else if source.sourceType === 'internal'}
 						<span
 							class="inline-flex items-center justify-center gap-1 text-xs px-1.5 py-0.5 rounded-sm bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 shadow-sm min-w-[5.5rem]"


### PR DESCRIPTION
## Proposed change

Show the short commit hash next to 'Git' in the stack source column. When a commit hash is available, the badge reads 'Git abc1234' with a tooltip showing the full hash, repo URL, and branch. Falls back to the original 'Git' label when no commit is recorded yet (e.g. before first deploy).

<img width="337" height="99" alt="image" src="https://github.com/user-attachments/assets/23bedabe-3044-437a-b30f-b73ca3b57942" />

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [X] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain:

