### PR TITLE
Ensure unique Docker environments across connection types

### DIFF
--- a/src/lib/server/docker.ts
+++ b/src/lib/server/docker.ts
@@ -6,7 +6,7 @@
  */
 
 import { homedir } from 'node:os';
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 import * as http from 'node:http';
 import * as https from 'node:https';
@@ -21,6 +21,9 @@ import { isSystemContainer, classifyEmptyDigestImage } from './scheduler/tasks/u
 import { deepDiff } from '../utils/diff.js';
 import { getInstanceId } from './backups/identity';
 import { isOwnedBackupHelper } from './backups/reap-core';
+import type { EnvironmentConnectionInput } from '$lib/utils/docker-environment-uniqueness';
+import { normalizeSocketPath as normalizeSocketPathPure } from '$lib/utils/docker-environment-uniqueness';
+import { cleanPem } from '$lib/utils/pem';
 
 /**
  * Custom error for when an environment is not found.
@@ -1024,9 +1027,12 @@ export async function dockerJsonRequest<T>(
 export function clearDockerClientCache(envId?: number) {
 	if (envId !== undefined) {
 		envCache.delete(envId);
+		daemonIdCache.delete(envId);
 	} else {
 		envCache.clear();
+		daemonIdCache.clear();
 	}
+	configDaemonIdCache.clear();
 	// Destroy HTTPS agents (TLS config may have changed)
 	for (const [key, cached] of agentCache.entries()) {
 		cached.agent.destroy();
@@ -3953,6 +3959,178 @@ export async function exportImage(id: string, envId?: number | null): Promise<Re
 	}
 
 	return response;
+}
+
+/** Short timeout for duplicate-env /info lookups — reachable daemons answer in ms. */
+export const DOCKER_ID_LOOKUP_TIMEOUT_MS = 3000;
+
+const DAEMON_ID_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface DaemonIdCacheEntry {
+	id: string | null;
+	expiresAt: number;
+}
+
+const daemonIdCache = new Map<number, DaemonIdCacheEntry>();
+const configDaemonIdCache = new Map<string, DaemonIdCacheEntry>();
+
+function normalizeConnectionSocketPath(socketPath: string): string {
+	return normalizeSocketPathPure(socketPath, existsSync, realpathSync);
+}
+
+function connectionConfigCacheKey(config: EnvironmentConnectionInput): string {
+	const type = config.connectionType || 'socket';
+	if (type === 'socket') {
+		return `socket:${normalizeConnectionSocketPath(config.socketPath || '/var/run/docker.sock')}`;
+	}
+	if (type === 'hawser-edge') {
+		return 'hawser-edge';
+	}
+	const protocol = config.protocol || 'http';
+	const port = config.port ?? (protocol === 'https' ? 2376 : 2375);
+	return [
+		type,
+		config.host || '',
+		String(port),
+		protocol,
+		String(config.tlsSkipVerify ?? false),
+		config.hawserToken || '',
+		cleanPem(config.tlsCa) || '',
+		cleanPem(config.tlsCert) || '',
+		cleanPem(config.tlsKey) || ''
+	].join('\0');
+}
+
+function buildConnectionTlsConfig(config: EnvironmentConnectionInput): DockerClientConfig | null {
+	const protocol = config.protocol || 'http';
+	if (protocol !== 'https') return null;
+
+	return {
+		type: 'https',
+		host: config.host || 'localhost',
+		port: config.port || 2376,
+		ca: cleanPem(config.tlsCa) || undefined,
+		cert: cleanPem(config.tlsCert) || undefined,
+		key: cleanPem(config.tlsKey) || undefined,
+		skipVerify: config.tlsSkipVerify || false
+	};
+}
+
+async function fetchDockerIdFromConfigUncached(config: EnvironmentConnectionInput): Promise<{
+	id: string | null;
+	cacheable: boolean;
+}> {
+	const connectionType = config.connectionType || 'socket';
+	if (connectionType === 'hawser-edge') {
+		return { id: null, cacheable: false };
+	}
+
+	try {
+		let response: Response;
+		const lookupSignal = AbortSignal.timeout(DOCKER_ID_LOOKUP_TIMEOUT_MS);
+
+		if (connectionType === 'socket') {
+			const socketPath = config.socketPath || '/var/run/docker.sock';
+			response = await withDockerLookupTimeout(unixSocketRequest(socketPath, '/info'));
+		} else {
+			const host = config.host;
+			if (!host) return { id: null, cacheable: false };
+
+			const headers: Record<string, string> = {};
+			if (connectionType === 'hawser-standard' && config.hawserToken) {
+				headers['X-Hawser-Token'] = config.hawserToken;
+			}
+
+			const tlsConfig = buildConnectionTlsConfig(config);
+			if (tlsConfig) {
+				response = await withDockerLookupTimeout(
+					httpsAgentRequest(tlsConfig, '/info', { signal: lookupSignal }, false, headers)
+				);
+			} else {
+				const port = config.port || 2375;
+				response = await withDockerLookupTimeout(
+					fetch(`http://${host}:${port}/info`, {
+						headers,
+						signal: lookupSignal,
+						keepalive: false
+					})
+				);
+			}
+		}
+
+		if (!response.ok) return { id: null, cacheable: false };
+
+		const info = await response.json();
+		const id = typeof info?.ID === 'string' && info.ID.length > 0 ? info.ID : null;
+		return { id, cacheable: true };
+	} catch {
+		return { id: null, cacheable: false };
+	}
+}
+
+/**
+ * Docker daemon ID from /info for a not-yet-persisted connection config.
+ * Cached by connection parameters so repeated saves skip redundant /info calls.
+ */
+export async function getDockerDaemonIdFromConfig(
+	config: EnvironmentConnectionInput
+): Promise<string | null> {
+	const connectionType = config.connectionType || 'socket';
+	if (connectionType === 'hawser-edge') {
+		return null;
+	}
+
+	const now = Date.now();
+	const key = connectionConfigCacheKey(config);
+	const cached = configDaemonIdCache.get(key);
+	if (cached && cached.expiresAt > now) {
+		return cached.id;
+	}
+
+	const { id, cacheable } = await fetchDockerIdFromConfigUncached(config);
+	if (cacheable) {
+		configDaemonIdCache.set(key, { id, expiresAt: now + DAEMON_ID_CACHE_TTL_MS });
+	}
+	return id;
+}
+
+function withDockerLookupTimeout<T>(promise: Promise<T>): Promise<T> {
+	return Promise.race([
+		promise,
+		new Promise<T>((_, reject) => {
+			setTimeout(
+				() => reject(new Error('Docker /info lookup timed out')),
+				DOCKER_ID_LOOKUP_TIMEOUT_MS
+			);
+		})
+	]);
+}
+
+/**
+ * Docker daemon ID from /info, with in-memory cache (stable per daemon lifetime).
+ * Used by duplicate-environment validation to avoid N sequential /info round-trips.
+ */
+export async function getDockerDaemonId(envId: number): Promise<string | null> {
+	const now = Date.now();
+	const cached = daemonIdCache.get(envId);
+	if (cached && cached.expiresAt > now) {
+		return cached.id;
+	}
+
+	try {
+		const info = await withDockerLookupTimeout(
+			dockerJsonRequest<{ ID?: string }>(
+				'/info',
+				{ signal: AbortSignal.timeout(DOCKER_ID_LOOKUP_TIMEOUT_MS) },
+				envId
+			)
+		);
+		const id = typeof info?.ID === 'string' && info.ID.length > 0 ? info.ID : null;
+		daemonIdCache.set(envId, { id, expiresAt: now + DAEMON_ID_CACHE_TTL_MS });
+		return id;
+	} catch {
+		return null;
+	}
 }
 
 // System information

--- a/src/lib/server/environment-docker-validation.ts
+++ b/src/lib/server/environment-docker-validation.ts
@@ -1,0 +1,195 @@
+/**
+ * Validation helpers to ensure each Dockhand environment points to a distinct
+ * Docker daemon, regardless of connection type (socket, direct, Hawser).
+ */
+
+import { existsSync, realpathSync } from 'fs';
+import { getEnvironments, type Environment } from '$lib/server/db';
+import {
+	getDockerDaemonId,
+	getDockerDaemonIdFromConfig
+} from '$lib/server/docker';
+import { cleanPem } from '$lib/utils/pem';
+import {
+	areSocketConfigsEquivalent as areSocketConfigsEquivalentPure,
+	normalizeSocketPath as normalizeSocketPathPure,
+	hasConnectionFieldChanges as hasConnectionFieldChangesPure,
+	allowDuplicateDockerEnvironmentsFromEnv,
+	type EnvironmentConnectionInput
+} from '$lib/utils/docker-environment-uniqueness';
+
+export type { EnvironmentConnectionInput } from '$lib/utils/docker-environment-uniqueness';
+
+export type DuplicateDockerValidationResult =
+	| { ok: true }
+	| { ok: false; error: string };
+
+const DUPLICATE_ERROR =
+	'This environment connects to the same Docker instance as "{name}". Each environment must point to a distinct Docker daemon.';
+
+function isDuplicateDockerValidationEnabled(): boolean {
+	return !allowDuplicateDockerEnvironmentsFromEnv(process.env.DOCKHAND_ALLOW_DUPLICATE_ENVS);
+}
+
+function duplicateError(environmentName: string): DuplicateDockerValidationResult {
+	return {
+		ok: false,
+		error: DUPLICATE_ERROR.replace('{name}', environmentName)
+	};
+}
+
+export function normalizeSocketPath(socketPath: string): string {
+	return normalizeSocketPathPure(socketPath, existsSync, realpathSync);
+}
+
+export function areSocketConfigsEquivalent(
+	a: EnvironmentConnectionInput,
+	b: EnvironmentConnectionInput
+): boolean {
+	return areSocketConfigsEquivalentPure(a, b, existsSync, realpathSync);
+}
+
+export function connectionInputFromEnvironment(env: Environment): EnvironmentConnectionInput {
+	return {
+		connectionType: (env.connectionType || 'socket') as EnvironmentConnectionInput['connectionType'],
+		socketPath: env.socketPath,
+		host: env.host,
+		port: env.port,
+		protocol: env.protocol,
+		tlsCa: env.tlsCa,
+		tlsCert: env.tlsCert,
+		tlsKey: env.tlsKey,
+		tlsSkipVerify: env.tlsSkipVerify,
+		hawserToken: env.hawserToken
+	};
+}
+
+export function connectionInputFromRequest(data: {
+	connectionType?: string | null;
+	socketPath?: string | null;
+	host?: string | null;
+	port?: number | null;
+	protocol?: string | null;
+	tlsCa?: string | null;
+	tlsCert?: string | null;
+	tlsKey?: string | null;
+	tlsSkipVerify?: boolean | null;
+	hawserToken?: string | null;
+}): EnvironmentConnectionInput {
+	return {
+		connectionType: (data.connectionType || 'socket') as EnvironmentConnectionInput['connectionType'],
+		socketPath: data.socketPath,
+		host: data.host,
+		port: data.port,
+		protocol: data.protocol,
+		tlsCa: data.tlsCa,
+		tlsCert: data.tlsCert,
+		tlsKey: data.tlsKey,
+		tlsSkipVerify: data.tlsSkipVerify,
+		hawserToken: data.hawserToken
+	};
+}
+
+export function mergeConnectionInput(
+	oldEnv: Environment,
+	data: Record<string, unknown>
+): EnvironmentConnectionInput {
+	return {
+		connectionType: (data.connectionType ?? oldEnv.connectionType ?? 'socket') as EnvironmentConnectionInput['connectionType'],
+		socketPath: (data.socketPath ?? oldEnv.socketPath) as string | null | undefined,
+		host: (data.host ?? oldEnv.host) as string | null | undefined,
+		port: (data.port ?? oldEnv.port) as number | null | undefined,
+		protocol: (data.protocol ?? oldEnv.protocol) as string | null | undefined,
+		tlsCa: data.tlsCa !== undefined ? cleanPem(data.tlsCa as string) : oldEnv.tlsCa,
+		tlsCert: data.tlsCert !== undefined ? cleanPem(data.tlsCert as string) : oldEnv.tlsCert,
+		tlsKey: data.tlsKey !== undefined ? cleanPem(data.tlsKey as string) : oldEnv.tlsKey,
+		tlsSkipVerify: (data.tlsSkipVerify ?? oldEnv.tlsSkipVerify) as boolean | null | undefined,
+		hawserToken: (data.hawserToken ?? oldEnv.hawserToken) as string | null | undefined
+	};
+}
+
+export function hasConnectionFieldChanges(oldEnv: Environment, data: Record<string, unknown>): boolean {
+	return hasConnectionFieldChangesPure(oldEnv as Record<string, unknown>, data, cleanPem);
+}
+
+async function findDuplicateByDaemonId(
+	candidates: Environment[],
+	newDockerId: string
+): Promise<DuplicateDockerValidationResult> {
+	const idResults = await Promise.allSettled(
+		candidates.map(async (env) => ({
+			env,
+			id: await getDockerDaemonId(env.id)
+		}))
+	);
+
+	for (const result of idResults) {
+		if (result.status === 'fulfilled' && result.value.id === newDockerId) {
+			return duplicateError(result.value.env.name);
+		}
+	}
+
+	return { ok: true };
+}
+
+/**
+ * Check whether a connection configuration would duplicate an existing environment.
+ * Compares resolved Unix socket paths and Docker daemon IDs from /info.
+ */
+export async function findDuplicateDockerEnvironment(
+	config: EnvironmentConnectionInput,
+	options?: { excludeEnvId?: number; envIdForEdge?: number }
+): Promise<DuplicateDockerValidationResult> {
+	if (!isDuplicateDockerValidationEnabled()) {
+		return { ok: true };
+	}
+
+	const excludeEnvId = options?.excludeEnvId;
+	const connectionType = config.connectionType || 'socket';
+
+	let newDockerId: string | null = null;
+	if (connectionType === 'hawser-edge' && options?.envIdForEdge) {
+		newDockerId = await getDockerDaemonId(options.envIdForEdge);
+	} else if (connectionType !== 'hawser-edge') {
+		newDockerId = await getDockerDaemonIdFromConfig(config);
+	}
+
+	const allEnvs = await getEnvironments();
+	const candidates = allEnvs.filter(
+		(e) => excludeEnvId === undefined || e.id !== excludeEnvId
+	);
+
+	for (const existing of candidates) {
+		if (areSocketConfigsEquivalent(config, connectionInputFromEnvironment(existing))) {
+			return duplicateError(existing.name);
+		}
+	}
+
+	if (!newDockerId) {
+		return { ok: true };
+	}
+
+	return findDuplicateByDaemonId(candidates, newDockerId);
+}
+
+/**
+ * Validate a Hawser edge agent after it connects. Rejects agents that proxy
+ * to a Docker daemon already represented by another environment.
+ */
+export async function validateEdgeAgentDockerUniqueness(
+	environmentId: number
+): Promise<DuplicateDockerValidationResult> {
+	if (!isDuplicateDockerValidationEnabled()) {
+		return { ok: true };
+	}
+
+	const allEnvs = await getEnvironments();
+	const env = allEnvs.find((e) => e.id === environmentId);
+	if (!env) return { ok: true };
+
+	const dockerId = await getDockerDaemonId(environmentId);
+	if (!dockerId) return { ok: true };
+
+	const others = allEnvs.filter((e) => e.id !== environmentId);
+	return findDuplicateByDaemonId(others, dockerId);
+}

--- a/src/lib/server/hawser.ts
+++ b/src/lib/server/hawser.ts
@@ -14,6 +14,7 @@ import { isHealthTransition } from './subprocess-manager.js';
 import { pushMetric } from './metrics-store.js';
 import { secureGetRandomValues, secureRandomUUID } from './crypto-fallback.js';
 import { hashPassword, verifyPassword } from './auth.js';
+import { validateEdgeAgentDockerUniqueness } from './environment-docker-validation.js';
 
 // Protocol constants
 export const HAWSER_PROTOCOL_VERSION = '1.0';
@@ -397,7 +398,11 @@ export async function revokeHawserToken(tokenId: number): Promise<void> {
  * Close an Edge connection and clean up pending requests.
  * Called when an environment is deleted.
  */
-export function closeEdgeConnection(environmentId: number): void {
+export function closeEdgeConnection(
+	environmentId: number,
+	closeCode = 1000,
+	closeReason = 'Environment deleted'
+): void {
 	const connection = edgeConnections.get(environmentId);
 	if (!connection) {
 		console.log(`[Hawser] No Edge connection to close for environment ${environmentId}`);
@@ -432,7 +437,7 @@ export function closeEdgeConnection(environmentId: number): void {
 
 	// Close the WebSocket
 	try {
-		connection.ws.close(1000, 'Environment deleted');
+		connection.ws.close(closeCode, closeReason);
 	} catch (e) {
 		const errorMsg = e instanceof Error ? e.message : String(e);
 		console.error(`[Hawser] Error closing WebSocket for environment ${environmentId}:`, errorMsg);
@@ -1203,6 +1208,15 @@ async function handleHawserWsMessage(ws: any, msg: any, connId: string, remoteIp
 			// Authenticated — register the connection
 			const connection = handleEdgeConnection(ws, result.environmentId, msg);
 			wsToEnvId.set(ws, result.environmentId);
+
+			const duplicateCheck = await validateEdgeAgentDockerUniqueness(result.environmentId);
+			if (!duplicateCheck.ok) {
+				console.log(`[Hawser WS] Rejecting agent for env ${result.environmentId}: ${duplicateCheck.error}`);
+				ws.send(JSON.stringify({ type: 'error', message: duplicateCheck.error }));
+				closeEdgeConnection(result.environmentId, 1008, 'Duplicate Docker instance');
+				wsToEnvId.delete(ws);
+				return;
+			}
 
 			// Send welcome
 			ws.send(JSON.stringify({

--- a/src/lib/utils/docker-environment-uniqueness.ts
+++ b/src/lib/utils/docker-environment-uniqueness.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure helpers for comparing Docker environment connection settings.
+ * Kept separate from server modules so they can be unit-tested without DB access.
+ */
+
+export interface EnvironmentConnectionInput {
+	connectionType: 'socket' | 'direct' | 'hawser-standard' | 'hawser-edge';
+	socketPath?: string | null;
+	host?: string | null;
+	port?: number | null;
+	protocol?: string | null;
+	tlsCa?: string | null;
+	tlsCert?: string | null;
+	tlsKey?: string | null;
+	tlsSkipVerify?: boolean | null;
+	hawserToken?: string | null;
+}
+
+/**
+ * Resolve a socket path to its canonical filesystem path when it exists.
+ */
+export function normalizeSocketPath(
+	socketPath: string,
+	exists: (path: string) => boolean = () => false,
+	realpath: (path: string) => string = (path) => path
+): string {
+	try {
+		if (exists(socketPath)) {
+			return realpath(socketPath);
+		}
+	} catch {
+		// Fall back to the literal path when resolution fails.
+	}
+	return socketPath;
+}
+
+/**
+ * True when two socket configurations resolve to the same Unix socket.
+ */
+export function areSocketConfigsEquivalent(
+	a: EnvironmentConnectionInput,
+	b: EnvironmentConnectionInput,
+	exists: (path: string) => boolean = () => false,
+	realpath: (path: string) => string = (path) => path
+): boolean {
+	if ((a.connectionType || 'socket') !== 'socket' || (b.connectionType || 'socket') !== 'socket') {
+		return false;
+	}
+
+	const pathA = normalizeSocketPath(a.socketPath || '/var/run/docker.sock', exists, realpath);
+	const pathB = normalizeSocketPath(b.socketPath || '/var/run/docker.sock', exists, realpath);
+	return pathA === pathB;
+}
+
+export const CONNECTION_FIELDS = [
+	'connectionType',
+	'socketPath',
+	'host',
+	'port',
+	'protocol',
+	'tlsCa',
+	'tlsCert',
+	'tlsKey',
+	'tlsSkipVerify',
+	'hawserToken'
+] as const;
+
+function normalizeConnectionFieldValue(
+	field: (typeof CONNECTION_FIELDS)[number],
+	value: unknown,
+	cleanPem: (pem: string | null | undefined) => string | null
+): unknown {
+	if (field === 'tlsCa' || field === 'tlsCert' || field === 'tlsKey') {
+		return cleanPem(value as string);
+	}
+	return value;
+}
+
+export function hasConnectionFieldChanges(
+	oldValues: Record<string, unknown>,
+	data: Record<string, unknown>,
+	cleanPem: (pem: string | null | undefined) => string | null
+): boolean {
+	return CONNECTION_FIELDS.some((field) => {
+		if (data[field] === undefined) return false;
+
+		const newValue = normalizeConnectionFieldValue(field, data[field], cleanPem);
+		return newValue !== oldValues[field];
+	});
+}
+
+/**
+ * Parse DOCKHAND_ALLOW_DUPLICATE_ENVS — when true/1, duplicate Docker daemon
+ * validation is skipped (used by integration tests that share one daemon).
+ */
+export function allowDuplicateDockerEnvironmentsFromEnv(value: string | undefined): boolean {
+	return value === 'true' || value === '1';
+}

--- a/src/routes/api/environments/+server.ts
+++ b/src/routes/api/environments/+server.ts
@@ -8,6 +8,10 @@ import { refreshSubprocessEnvironments } from '$lib/server/subprocess-manager';
 import { serializeLabels, parseLabels, MAX_LABELS } from '$lib/utils/label-colors';
 import { cleanPem } from '$lib/utils/pem';
 import { validateEnvName } from '$lib/utils/env-name';
+import {
+	connectionInputFromRequest,
+	findDuplicateDockerEnvironment
+} from '$lib/server/environment-docker-validation';
 
 export const GET: RequestHandler = async ({ cookies }) => {
 	const auth = await authorize(cookies);
@@ -97,6 +101,23 @@ export const POST: RequestHandler = async (event) => {
 
 		// Validate labels
 		const labels = Array.isArray(data.labels) ? data.labels.slice(0, MAX_LABELS) : [];
+
+		const connectionConfig = connectionInputFromRequest({
+			connectionType,
+			socketPath: data.socketPath,
+			host: data.host,
+			port: data.port,
+			protocol: data.protocol,
+			tlsCa: data.tlsCa,
+			tlsCert: data.tlsCert,
+			tlsKey: data.tlsKey,
+			tlsSkipVerify: data.tlsSkipVerify,
+			hawserToken: data.hawserToken
+		});
+		const duplicateCheck = await findDuplicateDockerEnvironment(connectionConfig);
+		if (!duplicateCheck.ok) {
+			return json({ error: duplicateCheck.error }, { status: 409 });
+		}
 
 		const env = await createEnvironment({
 			name: data.name,

--- a/src/routes/api/environments/[id]/+server.ts
+++ b/src/routes/api/environments/[id]/+server.ts
@@ -12,6 +12,11 @@ import { refreshSubprocessEnvironments } from '$lib/server/subprocess-manager';
 import { serializeLabels, parseLabels, MAX_LABELS } from '$lib/utils/label-colors';
 import { cleanPem } from '$lib/utils/pem';
 import { validateEnvName } from '$lib/utils/env-name';
+import {
+	findDuplicateDockerEnvironment,
+	hasConnectionFieldChanges,
+	mergeConnectionInput
+} from '$lib/server/environment-docker-validation';
 import { unregisterSchedule } from '$lib/server/scheduler';
 import { closeEdgeConnection } from '$lib/server/hawser';
 import { computeAuditDiff } from '$lib/utils/diff';
@@ -72,6 +77,20 @@ export const PUT: RequestHandler = async (event) => {
 			const nameCheck = validateEnvName(data.name);
 			if (!nameCheck.ok) {
 				return json({ error: nameCheck.reason }, { status: 400 });
+			}
+		}
+
+		// Validate connection uniqueness before any filesystem changes so a
+		// rejected duplicate cannot leave stacks/<env>/ renamed while the DB
+		// still holds the old name.
+		if (hasConnectionFieldChanges(oldEnv, data)) {
+			const connectionConfig = mergeConnectionInput(oldEnv, data);
+			const duplicateCheck = await findDuplicateDockerEnvironment(connectionConfig, {
+				excludeEnvId: id,
+				envIdForEdge: id
+			});
+			if (!duplicateCheck.ok) {
+				return json({ error: duplicateCheck.error }, { status: 409 });
 			}
 		}
 


### PR DESCRIPTION
## Proposed change

Validate new/updated environment connections against existing ones so no two environments target the same Docker daemon. Compares realpath-resolved socket paths and daemon IDs from /info (3s timeout), fetched in parallel and cached in-memory (5min TTL) by env ID and connection config. POST/PUT return 409 on duplicates; hawser-edge agents are rejected on connect with WS close 1008. Disable via `DOCKHAND_ALLOW_DUPLICATE_ENVS=true`.

## Type of change

* [x] Bug fix: non-breaking change which fixes an issue.
