### PR TITLE
fix(stacks): apply env override file on stop/down for git stacks

### DIFF
--- a/src/lib/server/stacks.ts
+++ b/src/lib/server/stacks.ts
@@ -2212,9 +2212,13 @@ export async function stopStack(
 		return fallback;
 	}
 
+	// Check if this is a git stack - git stacks need useOverrideFile to write .env.dockhand
+	const source = await getStackSource(stackName, envId);
+	const isGitStack = source?.sourceType === 'git';
+
 	const composeResult = await executeComposeCommand(
 		'stop',
-		{ stackName, envId, workingDir: result.stackDir, composePath: result.composePath, envPath: result.envPath },
+		{ stackName, envId, workingDir: result.stackDir, composePath: result.composePath, envPath: result.envPath, useOverrideFile: isGitStack },
 		result.content!,
 		result.nonSecretVars,
 		result.secretVars
@@ -2289,9 +2293,13 @@ export async function downStack(
 		return withContainerFallback(stackName, envId, 'stop');
 	}
 
+	// Check if this is a git stack - git stacks need useOverrideFile to write .env.dockhand
+	const source = await getStackSource(stackName, envId);
+	const isGitStack = source?.sourceType === 'git';
+
 	const composeResult = await executeComposeCommand(
 		'down',
-		{ stackName, envId, removeVolumes, workingDir: result.stackDir, composePath: result.composePath, envPath: result.envPath },
+		{ stackName, envId, removeVolumes, workingDir: result.stackDir, composePath: result.composePath, envPath: result.envPath, useOverrideFile: isGitStack },
 		result.content!,
 		result.nonSecretVars,
 		result.secretVars

--- a/src/lib/server/stacks.ts
+++ b/src/lib/server/stacks.ts
@@ -479,6 +479,8 @@ export interface GetComposeFileResult {
 	composePath?: string | null;
 	envPath?: string | null;
 	suggestedEnvPath?: string;
+	/** Stack source type (internal/git/external), from the stack_sources lookup already done here */
+	sourceType?: StackSourceType;
 }
 
 /**
@@ -538,7 +540,8 @@ export async function getStackComposeFile(
 				stackDir,
 				composePath: source.composePath,
 				envPath: source.envPath,
-				suggestedEnvPath
+				suggestedEnvPath,
+				sourceType: source.sourceType
 			};
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
@@ -572,7 +575,8 @@ export async function getStackComposeFile(
 					stackDir,
 					// Always return the actual resolved paths for display
 					composePath: actualComposePath,
-					envPath: envExists ? envFilePath : null
+					envPath: envExists ? envFilePath : null,
+					sourceType: source.sourceType
 				};
 			}
 		}
@@ -2013,6 +2017,8 @@ export interface RequireComposeResult {
 	composePath?: string;
 	/** Full path to the env file (for --env-file flag) */
 	envPath?: string;
+	/** Stack source type (internal/git/external), plumbed through from getStackComposeFile to avoid a redundant getStackSource lookup in callers */
+	sourceType?: StackSourceType;
 }
 
 /**
@@ -2087,7 +2093,8 @@ export async function requireComposeFile(
 		nonSecretVars,
 		stackDir: composeResult.stackDir,
 		composePath: composeResult.composePath ?? undefined,
-		envPath: envFilePath ?? undefined
+		envPath: envFilePath ?? undefined,
+		sourceType: composeResult.sourceType
 	};
 }
 
@@ -2172,9 +2179,10 @@ export async function startStack(
 		return fallback;
 	}
 
-	// Check if this is a git stack - git stacks need useOverrideFile to write .env.dockhand
-	const source = await getStackSource(stackName, envId);
-	const isGitStack = source?.sourceType === 'git';
+	// Git stacks need useOverrideFile to write .env.dockhand with DB overrides.
+	// sourceType is plumbed through from requireComposeFile (which already looked
+	// it up via getStackComposeFile/getStackSource) to avoid a redundant DB lookup.
+	const isGitStack = result.sourceType === 'git';
 
 	const opts: ComposeCommandOptions = { stackName, envId, workingDir: result.stackDir, composePath: result.composePath, envPath: result.envPath, useOverrideFile: isGitStack };
 
@@ -2212,9 +2220,9 @@ export async function stopStack(
 		return fallback;
 	}
 
-	// Check if this is a git stack - git stacks need useOverrideFile to write .env.dockhand
-	const source = await getStackSource(stackName, envId);
-	const isGitStack = source?.sourceType === 'git';
+	// Git stacks need useOverrideFile to write .env.dockhand with DB overrides.
+	// sourceType is plumbed through from requireComposeFile to avoid a redundant DB lookup.
+	const isGitStack = result.sourceType === 'git';
 
 	const composeResult = await executeComposeCommand(
 		'stop',
@@ -2256,8 +2264,8 @@ export async function restartStack(
 	// Git stacks need useOverrideFile to write .env.dockhand with DB overrides.
 	// Non-git stacks still pass nonSecretVars for legacy support (stacks without
 	// .env files on disk get vars injected via shell env at executeLocalCompose).
-	const source = await getStackSource(stackName, envId);
-	const isGitStack = source?.sourceType === 'git';
+	// sourceType is plumbed through from requireComposeFile to avoid a redundant DB lookup.
+	const isGitStack = result.sourceType === 'git';
 
 	const opts: ComposeCommandOptions = { stackName, envId, workingDir: result.stackDir, composePath: result.composePath, envPath: result.envPath, useOverrideFile: isGitStack };
 
@@ -2293,9 +2301,9 @@ export async function downStack(
 		return withContainerFallback(stackName, envId, 'stop');
 	}
 
-	// Check if this is a git stack - git stacks need useOverrideFile to write .env.dockhand
-	const source = await getStackSource(stackName, envId);
-	const isGitStack = source?.sourceType === 'git';
+	// Git stacks need useOverrideFile to write .env.dockhand with DB overrides.
+	// sourceType is plumbed through from requireComposeFile to avoid a redundant DB lookup.
+	const isGitStack = result.sourceType === 'git';
 
 	const composeResult = await executeComposeCommand(
 		'down',


### PR DESCRIPTION
## Proposed change

`stopStack` and `downStack` in `src/lib/server/stacks.ts` never set `useOverrideFile` when calling `executeComposeCommand`, unlike `startStack` and `restartStack`, which compute `isGitStack` from the stack source and pass it through.

**Impact:** for a git stack whose repository already ships a `.env` file next to `compose.yaml` (even one that only covers *some* of the variables used by the compose file), `executeLocalCompose` sees `hasEnvFile = true` and disables its legacy shell-env fallback for **all** Dockhand panel overrides — not just the ones already present in the committed `.env`. Because `useOverrideFile` is never set on stop/down, `.env.dockhand` (which is where Dockhand writes panel-only, non-secret overrides for git stacks) is also never written or attached via `--env-file` for these two operations.

The practical result: a required variable that only exists as a Dockhand panel override (not in the repo's committed `.env`) interpolates fine on deploy/start, but fails with `required variable ... is missing a value` on stop/down — even though the container is later stopped/removed anyway via the orphan-container cleanup path, so the failure is silent in terms of actual effect but still reports `success: false` and leaves the wrong impression that the operation did nothing.

This matches the behavior reported in #1313.

### Root cause

- `executeLocalCompose` (same file): `hasEnvFile` gates the legacy shell-env injection (`if (!hasEnvFile && envVars) Object.assign(spawnEnv, envVars)`), and `.env.dockhand` is only written/attached when `useOverrideFile` is `true`.
- `startStack` / `restartStack` already compute `isGitStack` and set `useOverrideFile: isGitStack` — `stopStack` / `downStack` do not.

### Fix

Mirror `startStack`/`restartStack` exactly: compute `isGitStack` from `getStackSource(...)` and pass `useOverrideFile: isGitStack` into the `ComposeCommandOptions` for both `stopStack` and `downStack`. Minimal, no behavior change for non-git stacks or for stacks without a `.env` file on disk.

### Not affected: Hawser

Verified against both sides of the Hawser path: on the Dockhand (TS) side, `executeComposeCommand`'s hawser branch always merges `.env`-file vars with DB overrides into `envVars` regardless of `useOverrideFile`. On the Hawser agent side (`internal/docker/compose.go`), every entry of `op.EnvVars` is unconditionally appended to `cmd.Env` for the compose subprocess, with no `hasEnvFile`-style gate. Docker Compose gives shell-env precedence over `--env-file`, so Hawser-connected stacks are not affected by this issue on any operation.

### Nebenbefund / scope note

The underlying gap is not strictly git-stack specific: `requireComposeFile` reads non-secret override vars from the database regardless of stack source type, but only `startStack`/`restartStack`/`deployStack` (and now, with this PR, `stopStack`/`downStack`) gate `useOverrideFile` on `isGitStack`. An internal (non-git) stack with a DB-only non-secret override sitting on top of an already-existing, incomplete `.env` file would still fail on every operation, including start/up — that's a separate, broader design question (whether `useOverrideFile`/`.env.dockhand` should trigger based on "are there DB overrides not already covered by the on-disk `.env`" rather than on stack source type) that's out of scope for this minimal fix.

Closes #1313

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain: