### PR TITLE
fix: dev server failing because vite isn't processing TypeScript in .svelte files

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
 		"lucide-svelte": "0.562.0",
 		"mode-watcher": "^1.1.0",
 		"postcss": "^8.5.6",
-		"svelte": "5.55.7",
+		"svelte": "5.56.8",
 		"svelte-check": "^4.3.5",
 		"svelte-easy-crop": "^5.0.0",
 		"tailwind-merge": "^3.4.0",


### PR DESCRIPTION
## Proposed change

The dev server fails with TypeScript errors because `vitePreprocess()` doesn't process TypeScript in .svelte files by default with  breaking changes in vite-plugin-svelte@4

This is a known issue: https://github.com/sveltejs/vite-plugin-svelte/issues/900


## Type of change

Add `{ script: true }` parameter to `vitePreprocess()` to ensure TypeScript type annotations in .svelte files are properly handled before the Svelte compiler processes them.

## Testing

- Tested with `bun dev` - works without errors


- [ x] Bug fix: non-breaking change which fixes an issue.


