### PR TITLE
Fix: collapsing container uptimes < 1 min to 1 sec (affects sorting)

### DIFF
--- a/src/routes/containers/+page.svelte
+++ b/src/routes/containers/+page.svelte
@@ -1243,7 +1243,7 @@
 		// Parse strings like "2 hours", "3 days", "About a minute", "Less than a second"
 		const str = timeStr.toLowerCase();
 
-		if (str.includes('second')) return 1;
+		if (str.includes('less than a second')) return 1;
 		if (str.includes('less than a minute') || str.includes('about a minute')) return 60;
 
 		const match = str.match(/(\d+)\s*(second|minute|hour|day|week|month|year)/);


### PR DESCRIPTION
## Proposed change
Fix parseTimeStringToSeconds() to interpret only values "Less than a second" as 1 second. Previously, any readable time that included "second," including all times less than one minute, was treated as 1 second. This caused all containers' uptimes less than 1 minute to be sorted as the same value of 1 second.
## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain:

