### PR TITLE
Ensure Typescript enabled for preprocessing to handle `?` arguments

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -3,7 +3,7 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	preprocess: vitePreprocess(),
+	preprocess: vitePreprocess({ script: true }),
 
 	kit: {
 		adapter: adapter({


### PR DESCRIPTION
## Proposed change

To circumvent client runtime errors incurred with Svelte code that specified ts-style optional arguments (e.g., `arg?`), we need to enable Typescript processing to translate that syntax. This affected the ability for other to successfully build Dockhand.

## Type of change

- [X] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain:

