### PR TITLE
Add root filesystem disk stats to `/api/host` (#976)

### DIFF
--- a/src/lib/server/host-disk-core.ts
+++ b/src/lib/server/host-disk-core.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure disk-space helper. NO db / docker import, so unit-testable directly
+ * (importing docker.ts pulls in Docker-socket detection and the whole
+ * Docker-client layer — see host-path-core.ts for the same pattern).
+ */
+import { statfs } from 'node:fs/promises';
+
+export interface HostDiskInfo {
+	diskTotal: number;
+	diskFree: number;
+	diskAvailable: number;
+}
+
+/**
+ * Disk space of a filesystem path, via Node's `fs.statfs` (available since
+ * Node 18.15). Defaults to measuring `/` when `rootPath` is omitted or an
+ * empty string.
+ *
+ * Callers should pass the Docker daemon's data-root (`DockerRootDir` from
+ * Docker's `/info`) instead of relying on the `/` default whenever it's
+ * known: on setups where `data-root` in daemon.json points at a separate
+ * disk/mount, `/` and the actual data-root can report very different
+ * capacity (#976) — measuring `/` alone doesn't tell you whether Docker
+ * itself (images, containers, volumes) is about to run out of space.
+ *
+ * Returns null if the stat fails (e.g. platform without statfs support, or
+ * an unreadable/nonexistent path) rather than throwing, since this is a
+ * supplementary field on an otherwise-successful response.
+ */
+export async function getHostDiskInfo(rootPath?: string): Promise<HostDiskInfo | null> {
+	const path = rootPath && rootPath.length > 0 ? rootPath : '/';
+	try {
+		const stats = await statfs(path);
+		return {
+			diskTotal: stats.blocks * stats.bsize,
+			diskFree: stats.bfree * stats.bsize,
+			// bavail excludes blocks reserved for the superuser - what's actually
+			// usable, and what `df`'s "Avail" column shows.
+			diskAvailable: stats.bavail * stats.bsize
+		};
+	} catch (error) {
+		console.warn(`[Host] Failed to read disk stats for "${path}":`, error instanceof Error ? error.message : error);
+		return null;
+	}
+}

--- a/src/routes/api/host/+server.ts
+++ b/src/routes/api/host/+server.ts
@@ -4,8 +4,8 @@ import { getDockerInfo, getHawserInfo } from '$lib/server/docker';
 import { getEnvironment } from '$lib/server/db';
 import { authorize } from '$lib/server/authorize';
 import { getEdgeConnectionInfo } from '$lib/server/hawser';
+import { getHostDiskInfo } from '$lib/server/host-disk-core';
 import os from 'node:os';
-import { statfs } from 'node:fs/promises';
 
 export interface HostInfo {
 	hostname: string;
@@ -15,7 +15,9 @@ export interface HostInfo {
 	cpus: number;
 	totalMemory: number;
 	freeMemory: number;
-	// null for remote/Hawser environments — see getHostDiskInfo().
+	// Disk stats for the Docker daemon's data-root (DockerRootDir), not
+	// necessarily '/'. Null for remote/Hawser environments — see
+	// getHostDiskInfo() in host-disk-core.ts.
 	diskTotal: number | null;
 	diskFree: number | null;
 	diskAvailable: number | null;
@@ -33,28 +35,6 @@ export interface HostInfo {
 		hawserVersion?: string;
 		highlightChanges?: boolean;
 	};
-}
-
-/**
- * Disk space of the root filesystem Dockhand itself is running on, via
- * Node's `fs.statfs` (available since Node 18.15). Returns null if the stat
- * fails (e.g. platform without statfs support) rather than throwing, since
- * this is a supplementary field on an otherwise-successful response.
- */
-async function getHostDiskInfo(): Promise<{ diskTotal: number; diskFree: number; diskAvailable: number } | null> {
-	try {
-		const stats = await statfs('/');
-		return {
-			diskTotal: stats.blocks * stats.bsize,
-			diskFree: stats.bfree * stats.bsize,
-			// bavail excludes blocks reserved for the superuser - what's actually
-			// usable, and what `df`'s "Avail" column shows.
-			diskAvailable: stats.bavail * stats.bsize
-		};
-	} catch (error) {
-		console.warn('[Host] Failed to read disk stats:', error instanceof Error ? error.message : error);
-		return null;
-	}
 }
 
 function getLocalIpAddress(): string {
@@ -79,7 +59,7 @@ function getLocalIpAddress(): string {
  * summary: Return host info (hostname, IP, CPU, memory, disk, uptime, Docker counts) for the daemon behind an environment
  * query: env:integer ID of the environment to describe (basic local info is returned when omitted) (from GET /api/environments)
  * resp-200: {hostname:string!, ipAddress:string!, platform:string!, arch:string!, cpus:integer!, totalMemory:integer!, freeMemory:integer!, diskTotal:integer, diskFree:integer, diskAvailable:integer, uptime:integer!, dockerVersion:string, dockerContainers:integer!, dockerContainersRunning:integer!, dockerImages:integer!, environment:object}
- * resp-200-desc: diskTotal/diskFree/diskAvailable are null unless env resolves to a local socket connection (see the getHostDiskInfo() doc comment)
+ * resp-200-desc: diskTotal/diskFree/diskAvailable are null unless env resolves to a local socket connection; measured against the Docker data-root (DockerRootDir from /info), not necessarily '/' (see the getHostDiskInfo() doc comment in host-disk-core.ts)
  * resp-200-example: {"hostname":"docker-host","ipAddress":"192.168.1.10","platform":"linux","arch":"x64","cpus":8,"totalMemory":16777216000,"freeMemory":8388608000,"diskTotal":107374182400,"diskFree":53687091200,"diskAvailable":50000000000,"uptime":123456,"dockerVersion":"27.0.3","dockerContainers":10,"dockerContainersRunning":8,"dockerImages":25,"environment":{"id":1,"name":"local","connectionType":"socket"}}
  * resp-403: Permission denied, or (enterprise) no access to this environment
  * resp-500: Failed to get host info
@@ -107,7 +87,10 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 		}
 
 		if (!env) {
-			// No environment specified - return basic local info
+			// No environment specified - return basic local info. There's no envId
+			// here, so we can't call Docker's /info for DockerRootDir (getDockerConfig()
+			// throws without an envId) — fall back to measuring '/' instead of the
+			// actual Docker data-root.
 			const diskInfo = await getHostDiskInfo();
 			return json({
 				hostname: os.hostname(),
@@ -132,10 +115,6 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 		// Determine if this is a truly local connection (socket without remote host)
 		const isSocketType = env.connectionType === 'socket' || !env.connectionType;
 		const isLocalConnection = isSocketType && (!env.host || env.host === 'localhost' || env.host === '127.0.0.1');
-
-		// Disk stats are only meaningful for a local connection - see the
-		// getHostDiskInfo() doc comment for why remote/Hawser hosts are skipped.
-		const diskInfoPromise = isLocalConnection ? getHostDiskInfo() : Promise.resolve(null);
 
 		// Fetch Docker info and Hawser info in parallel for hawser-standard mode
 		let dockerInfo: any;
@@ -171,7 +150,13 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 			// For 'direct' connections without Hawser, uptime remains 0 (not available)
 		}
 
-		const diskInfo = await diskInfoPromise;
+		// Disk stats are only meaningful for a local connection - see the
+		// getHostDiskInfo() doc comment in host-disk-core.ts for why remote/Hawser
+		// hosts are skipped. Measured against Docker's own data-root (DockerRootDir
+		// from /info) rather than '/' — the two can differ when `data-root` in
+		// daemon.json points at a separate disk/mount (#976). This needs dockerInfo,
+		// so it runs after the fetch above instead of in parallel with it.
+		const diskInfo = isLocalConnection ? await getHostDiskInfo(dockerInfo?.DockerRootDir) : null;
 
 		const hostInfo: HostInfo = {
 			// Hostname/IP describe the Docker DAEMON's host, NOT Dockhand's own

--- a/src/routes/api/host/+server.ts
+++ b/src/routes/api/host/+server.ts
@@ -77,6 +77,18 @@ function getLocalIpAddress(): string {
 	return '127.0.0.1';
 }
 
+/**
+ * GET /api/host - Host and environment info for the Docker daemon
+ *
+ * @openapi
+ * summary: Return host info (hostname, IP, CPU, memory, disk, uptime, Docker counts) for the daemon behind an environment
+ * query: env:integer ID of the environment to describe (basic local info is returned when omitted) (from GET /api/environments)
+ * resp-200: {hostname:string!, ipAddress:string!, platform:string!, arch:string!, cpus:integer!, totalMemory:integer!, freeMemory:integer!, diskTotal:integer, diskFree:integer, diskAvailable:integer, uptime:integer!, dockerVersion:string, dockerContainers:integer!, dockerContainersRunning:integer!, dockerImages:integer!, environment:object}
+ * resp-200-desc: diskTotal/diskFree/diskAvailable are null unless env resolves to a local socket connection (see the getHostDiskInfo() doc comment)
+ * resp-200-example: {"hostname":"docker-host","ipAddress":"192.168.1.10","platform":"linux","arch":"x64","cpus":8,"totalMemory":16777216000,"freeMemory":8388608000,"diskTotal":107374182400,"diskFree":53687091200,"diskAvailable":50000000000,"uptime":123456,"dockerVersion":"27.0.3","dockerContainers":10,"dockerContainersRunning":8,"dockerImages":25,"environment":{"id":1,"name":"local","connectionType":"socket"}}
+ * resp-403: Permission denied, or (enterprise) no access to this environment
+ * resp-500: Failed to get host info
+ */
 export const GET: RequestHandler = async ({ url, cookies }) => {
 	const auth = await authorize(cookies);
 

--- a/src/routes/api/host/+server.ts
+++ b/src/routes/api/host/+server.ts
@@ -15,12 +15,7 @@ export interface HostInfo {
 	cpus: number;
 	totalMemory: number;
 	freeMemory: number;
-	// Disk stats are for the root filesystem ('/') of the machine Dockhand itself
-	// runs on — not the Docker daemon's host. For a local socket connection those
-	// are the same machine, so this covers the common case (issue #976, e.g. an
-	// LXC running Dockhand). For remote/Hawser-connected environments they'd
-	// diverge (and `/var/lib/docker` can itself be a different filesystem than
-	// `/` on either side), so these are omitted rather than shown misleadingly.
+	// null for remote/Hawser environments — see getHostDiskInfo().
 	diskTotal: number | null;
 	diskFree: number | null;
 	diskAvailable: number | null;

--- a/src/routes/api/host/+server.ts
+++ b/src/routes/api/host/+server.ts
@@ -5,6 +5,7 @@ import { getEnvironment } from '$lib/server/db';
 import { authorize } from '$lib/server/authorize';
 import { getEdgeConnectionInfo } from '$lib/server/hawser';
 import os from 'node:os';
+import { statfs } from 'node:fs/promises';
 
 export interface HostInfo {
 	hostname: string;
@@ -14,6 +15,15 @@ export interface HostInfo {
 	cpus: number;
 	totalMemory: number;
 	freeMemory: number;
+	// Disk stats are for the root filesystem ('/') of the machine Dockhand itself
+	// runs on — not the Docker daemon's host. For a local socket connection those
+	// are the same machine, so this covers the common case (issue #976, e.g. an
+	// LXC running Dockhand). For remote/Hawser-connected environments they'd
+	// diverge (and `/var/lib/docker` can itself be a different filesystem than
+	// `/` on either side), so these are omitted rather than shown misleadingly.
+	diskTotal: number | null;
+	diskFree: number | null;
+	diskAvailable: number | null;
 	uptime: number;
 	dockerVersion: string;
 	dockerContainers: number;
@@ -28,6 +38,28 @@ export interface HostInfo {
 		hawserVersion?: string;
 		highlightChanges?: boolean;
 	};
+}
+
+/**
+ * Disk space of the root filesystem Dockhand itself is running on, via
+ * Node's `fs.statfs` (available since Node 18.15). Returns null if the stat
+ * fails (e.g. platform without statfs support) rather than throwing, since
+ * this is a supplementary field on an otherwise-successful response.
+ */
+async function getHostDiskInfo(): Promise<{ diskTotal: number; diskFree: number; diskAvailable: number } | null> {
+	try {
+		const stats = await statfs('/');
+		return {
+			diskTotal: stats.blocks * stats.bsize,
+			diskFree: stats.bfree * stats.bsize,
+			// bavail excludes blocks reserved for the superuser - what's actually
+			// usable, and what `df`'s "Avail" column shows.
+			diskAvailable: stats.bavail * stats.bsize
+		};
+	} catch (error) {
+		console.warn('[Host] Failed to read disk stats:', error instanceof Error ? error.message : error);
+		return null;
+	}
 }
 
 function getLocalIpAddress(): string {
@@ -69,6 +101,7 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 
 		if (!env) {
 			// No environment specified - return basic local info
+			const diskInfo = await getHostDiskInfo();
 			return json({
 				hostname: os.hostname(),
 				ipAddress: getLocalIpAddress(),
@@ -77,6 +110,9 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 				cpus: os.cpus().length,
 				totalMemory: os.totalmem(),
 				freeMemory: os.freemem(),
+				diskTotal: diskInfo?.diskTotal ?? null,
+				diskFree: diskInfo?.diskFree ?? null,
+				diskAvailable: diskInfo?.diskAvailable ?? null,
 				uptime: os.uptime(),
 				dockerVersion: null,
 				dockerContainers: 0,
@@ -89,6 +125,10 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 		// Determine if this is a truly local connection (socket without remote host)
 		const isSocketType = env.connectionType === 'socket' || !env.connectionType;
 		const isLocalConnection = isSocketType && (!env.host || env.host === 'localhost' || env.host === '127.0.0.1');
+
+		// Disk stats are only meaningful for a local connection - see the
+		// getHostDiskInfo() doc comment for why remote/Hawser hosts are skipped.
+		const diskInfoPromise = isLocalConnection ? getHostDiskInfo() : Promise.resolve(null);
 
 		// Fetch Docker info and Hawser info in parallel for hawser-standard mode
 		let dockerInfo: any;
@@ -124,6 +164,8 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 			// For 'direct' connections without Hawser, uptime remains 0 (not available)
 		}
 
+		const diskInfo = await diskInfoPromise;
+
 		const hostInfo: HostInfo = {
 			// Hostname/IP describe the Docker DAEMON's host, NOT Dockhand's own
 			// container. `os.hostname()` / getLocalIpAddress() run INSIDE this
@@ -144,6 +186,9 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 			cpus: isLocalConnection ? os.cpus().length : (dockerInfo.NCPU || 0),
 			totalMemory: isLocalConnection ? os.totalmem() : (dockerInfo.MemTotal || 0),
 			freeMemory: isLocalConnection ? os.freemem() : 0, // Not available from Docker API
+			diskTotal: diskInfo?.diskTotal ?? null,
+			diskFree: diskInfo?.diskFree ?? null,
+			diskAvailable: diskInfo?.diskAvailable ?? null,
 			uptime,
 			dockerVersion: dockerInfo.ServerVersion || 'unknown',
 			dockerContainers: dockerInfo.Containers || 0,

--- a/src/routes/api/host/+server.ts
+++ b/src/routes/api/host/+server.ts
@@ -81,10 +81,11 @@ function getLocalIpAddress(): string {
  * GET /api/host - Host and environment info for the Docker daemon
  *
  * @openapi
- * summary: Return host info (hostname, IP, CPU, memory, uptime, Docker counts) for the daemon behind an environment
+ * summary: Return host info (hostname, IP, CPU, memory, disk, uptime, Docker counts) for the daemon behind an environment
  * query: env:integer ID of the environment to describe (basic local info is returned when omitted) (from GET /api/environments)
- * resp-200: {hostname:string!, ipAddress:string!, platform:string!, arch:string!, cpus:integer!, totalMemory:integer!, freeMemory:integer!, uptime:integer!, dockerVersion:string, dockerContainers:integer!, dockerContainersRunning:integer!, dockerImages:integer!, environment:object}
- * resp-200-example: {"hostname":"docker-host","ipAddress":"192.168.1.10","platform":"linux","arch":"x64","cpus":8,"totalMemory":16777216000,"freeMemory":8388608000,"uptime":123456,"dockerVersion":"27.0.3","dockerContainers":10,"dockerContainersRunning":8,"dockerImages":25,"environment":{"id":1,"name":"local","connectionType":"socket"}}
+ * resp-200: {hostname:string!, ipAddress:string!, platform:string!, arch:string!, cpus:integer!, totalMemory:integer!, freeMemory:integer!, diskTotal:integer, diskFree:integer, diskAvailable:integer, uptime:integer!, dockerVersion:string, dockerContainers:integer!, dockerContainersRunning:integer!, dockerImages:integer!, environment:object}
+ * resp-200-desc: diskTotal/diskFree/diskAvailable are null unless env resolves to a local socket connection (see the getHostDiskInfo() doc comment)
+ * resp-200-example: {"hostname":"docker-host","ipAddress":"192.168.1.10","platform":"linux","arch":"x64","cpus":8,"totalMemory":16777216000,"freeMemory":8388608000,"diskTotal":107374182400,"diskFree":53687091200,"diskAvailable":50000000000,"uptime":123456,"dockerVersion":"27.0.3","dockerContainers":10,"dockerContainersRunning":8,"dockerImages":25,"environment":{"id":1,"name":"local","connectionType":"socket"}}
  * resp-403: Permission denied, or (enterprise) no access to this environment
  * resp-500: Failed to get host info
  */

--- a/src/routes/api/host/+server.ts
+++ b/src/routes/api/host/+server.ts
@@ -5,6 +5,7 @@ import { getEnvironment } from '$lib/server/db';
 import { authorize } from '$lib/server/authorize';
 import { getEdgeConnectionInfo } from '$lib/server/hawser';
 import os from 'node:os';
+import { statfs } from 'node:fs/promises';
 
 export interface HostInfo {
 	hostname: string;
@@ -14,6 +15,15 @@ export interface HostInfo {
 	cpus: number;
 	totalMemory: number;
 	freeMemory: number;
+	// Disk stats are for the root filesystem ('/') of the machine Dockhand itself
+	// runs on — not the Docker daemon's host. For a local socket connection those
+	// are the same machine, so this covers the common case (issue #976, e.g. an
+	// LXC running Dockhand). For remote/Hawser-connected environments they'd
+	// diverge (and `/var/lib/docker` can itself be a different filesystem than
+	// `/` on either side), so these are omitted rather than shown misleadingly.
+	diskTotal: number | null;
+	diskFree: number | null;
+	diskAvailable: number | null;
 	uptime: number;
 	dockerVersion: string;
 	dockerContainers: number;
@@ -28,6 +38,28 @@ export interface HostInfo {
 		hawserVersion?: string;
 		highlightChanges?: boolean;
 	};
+}
+
+/**
+ * Disk space of the root filesystem Dockhand itself is running on, via
+ * Node's `fs.statfs` (available since Node 18.15). Returns null if the stat
+ * fails (e.g. platform without statfs support) rather than throwing, since
+ * this is a supplementary field on an otherwise-successful response.
+ */
+async function getHostDiskInfo(): Promise<{ diskTotal: number; diskFree: number; diskAvailable: number } | null> {
+	try {
+		const stats = await statfs('/');
+		return {
+			diskTotal: stats.blocks * stats.bsize,
+			diskFree: stats.bfree * stats.bsize,
+			// bavail excludes blocks reserved for the superuser - what's actually
+			// usable, and what `df`'s "Avail" column shows.
+			diskAvailable: stats.bavail * stats.bsize
+		};
+	} catch (error) {
+		console.warn('[Host] Failed to read disk stats:', error instanceof Error ? error.message : error);
+		return null;
+	}
 }
 
 function getLocalIpAddress(): string {
@@ -80,6 +112,7 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 
 		if (!env) {
 			// No environment specified - return basic local info
+			const diskInfo = await getHostDiskInfo();
 			return json({
 				hostname: os.hostname(),
 				ipAddress: getLocalIpAddress(),
@@ -88,6 +121,9 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 				cpus: os.cpus().length,
 				totalMemory: os.totalmem(),
 				freeMemory: os.freemem(),
+				diskTotal: diskInfo?.diskTotal ?? null,
+				diskFree: diskInfo?.diskFree ?? null,
+				diskAvailable: diskInfo?.diskAvailable ?? null,
 				uptime: os.uptime(),
 				dockerVersion: null,
 				dockerContainers: 0,
@@ -100,6 +136,10 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 		// Determine if this is a truly local connection (socket without remote host)
 		const isSocketType = env.connectionType === 'socket' || !env.connectionType;
 		const isLocalConnection = isSocketType && (!env.host || env.host === 'localhost' || env.host === '127.0.0.1');
+
+		// Disk stats are only meaningful for a local connection - see the
+		// getHostDiskInfo() doc comment for why remote/Hawser hosts are skipped.
+		const diskInfoPromise = isLocalConnection ? getHostDiskInfo() : Promise.resolve(null);
 
 		// Fetch Docker info and Hawser info in parallel for hawser-standard mode
 		let dockerInfo: any;
@@ -135,6 +175,8 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 			// For 'direct' connections without Hawser, uptime remains 0 (not available)
 		}
 
+		const diskInfo = await diskInfoPromise;
+
 		const hostInfo: HostInfo = {
 			// Hostname/IP describe the Docker DAEMON's host, NOT Dockhand's own
 			// container. `os.hostname()` / getLocalIpAddress() run INSIDE this
@@ -155,6 +197,9 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 			cpus: isLocalConnection ? os.cpus().length : (dockerInfo.NCPU || 0),
 			totalMemory: isLocalConnection ? os.totalmem() : (dockerInfo.MemTotal || 0),
 			freeMemory: isLocalConnection ? os.freemem() : 0, // Not available from Docker API
+			diskTotal: diskInfo?.diskTotal ?? null,
+			diskFree: diskInfo?.diskFree ?? null,
+			diskAvailable: diskInfo?.diskAvailable ?? null,
 			uptime,
 			dockerVersion: dockerInfo.ServerVersion || 'unknown',
 			dockerContainers: dockerInfo.Containers || 0,

--- a/tests/host-disk-core.test.ts
+++ b/tests/host-disk-core.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getHostDiskInfo } from '../src/lib/server/host-disk-core';
+
+describe('getHostDiskInfo', () => {
+	it('defaults to "/" when called without a path', async () => {
+		const result = await getHostDiskInfo();
+
+		assert.ok(result !== null);
+		assert.ok(result!.diskTotal > 0);
+		assert.ok(result!.diskFree >= 0);
+		assert.ok(result!.diskAvailable >= 0);
+	});
+
+	it('defaults to "/" when passed an empty string', async () => {
+		const result = await getHostDiskInfo('');
+
+		assert.ok(result !== null);
+	});
+
+	it('measures the given path, not a hardcoded "/"', async () => {
+		// A directory that definitely exists but is not '/' itself - proves the
+		// argument actually reaches statfs() instead of being ignored.
+		const dir = mkdtempSync(join(tmpdir(), 'dockhand-host-disk-test-'));
+		try {
+			const result = await getHostDiskInfo(dir);
+			assert.ok(result !== null);
+			assert.ok(result!.diskTotal > 0);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('returns null for a path that does not exist, instead of silently falling back to "/"', async () => {
+		const bogusPath = '/this/path/almost-certainly/does-not-exist-dockhand-1397';
+
+		const result = await getHostDiskInfo(bogusPath);
+
+		assert.equal(result, null);
+	});
+});


### PR DESCRIPTION
Closes #976.

### What

`/api/host` now includes `diskTotal`, `diskFree`, and `diskAvailable` (all in bytes) alongside the existing `totalMemory`/`freeMemory` fields, using Node's `fs.statfs` (available since Node 18.15) on the root filesystem (`/`).

- `diskTotal` = `blocks * bsize`
- `diskFree` = `bfree * bsize`
- `diskAvailable` = `bavail * bsize` (excludes blocks reserved for the superuser — matches `df`'s "Avail" column, i.e. what's actually usable)

### Why

#976 asks for the host's used/total disk space, specifically called out for LXC deployments where knowing free disk matters for capacity planning. `/api/system/disk` already exists but reports **Docker's own** storage usage (`docker system df` — images/containers/volumes/build cache), not the underlying filesystem's capacity, so it doesn't answer the question. `node:os` (already used for the memory fields) has no filesystem-stat API.

### Scope of this change (please read before reviewing)

This only reports disk stats for the **local** case — i.e. when Dockhand's own container/host root filesystem is what's being asked about:

- The "no environment specified" branch of `/api/host` (always local).
- The main branch, only when `isLocalConnection` is true (socket connection without a remote host).

For remote/Hawser-connected environments (`hawser-standard`, `hawser-edge`, `direct` with a remote host), the three fields are `null`. Reasoning, left as a comment in the code:

- A `statfs('/')` call from the Dockhand process only ever measures **Dockhand's own** filesystem, never the remote Docker daemon's host — reporting it for a remote environment would silently show the wrong machine's disk space, which is worse than showing nothing.
- Even for a genuinely local Docker daemon, `/var/lib/docker` (where container/image data actually lives) can be a separate mount from `/` — so even the "local" number is an approximation of "disk space on this host", not necessarily "disk space available to Docker" (this mirrors the same caveat that already exists for `totalMemory`/`freeMemory` not being resource-limited to the container's cgroup, and is outside what a single `statfs()` call can resolve; picking the right path would need `DockerRootDir` from `/info`, which is a reasonable follow-up but adds a second data source dependency for very little additional coverage).

I looked at whether the Hawser edge-agent metrics already carry this: the WebSocket `MetricsMessage` the agent sends (`src/lib/server/hawser.ts`, `MetricsMessage['metrics']`) already **includes** `diskTotal`/`diskUsed`/`diskFree` from the agent's own host — but `handleEdgeMetrics()` only copies `uptime`/`cpuUsage`/`memoryTotal`/`memoryUsed` into `EdgeConnection.lastMetrics`, so the disk numbers the agent sends are currently discarded. Wiring that through would give correct (agent-side) disk numbers for `hawser-edge` environments specifically, and is the more complete fix for the LXC-with-a-remote-agent case from the issue — but it's a separate, slightly bigger change (touches `EdgeConnection`'s type, `handleEdgeMetrics`, and this route's `hawser-edge` branch) and I wanted to keep this PR to the straightforward local-host case first. Happy to follow up with that if it's welcome — flagging it here rather than silently leaving it out, since I'd already pointed at this gap in my scoping comment on #976.

### Testing

- `npx svelte-kit sync && npx svelte-check --tsconfig ./tsconfig.json` — clean (no new errors).
- No existing test coverage for this route (`tests/` only has one unrelated test); didn't add a new one since there's no established pattern here for API-route tests and this is a straightforward additive/optional field.

### API documentation

This PR also adds an `@openapi` JSDoc annotation above the `GET` handler in `src/routes/api/host/+server.ts`, documenting the full response shape (including the new `diskTotal`/`diskFree`/`diskAvailable` fields as nullable integers). It follows the same annotation format introduced by the pending OpenAPI-documentation PRs, so `/api/host` — disk fields included — is covered as soon as that convention lands, without a documentation gap after merge.

---

### Update: measure the Docker data-root (`DockerRootDir`), not `/`

Followed up on the "picking the right path would need `DockerRootDir` from `/info`" note above, since it's exactly the gap flagged in my scoping comment on #976: on setups where `data-root` in `daemon.json` points at a separate disk/mount, `statfs('/')` reports the wrong filesystem's capacity for the actual capacity-planning question.

- `getHostDiskInfo()` is now parameterized with an optional `rootPath` (defaulting to `/`), and lives in a new `src/lib/server/host-disk-core.ts` — no `db`/`docker` import, so it's importable directly in a test without booting the DB layer (same pattern as the existing `host-path-core.ts`).
- The main handler branch now resolves `dockerInfo` first, then passes `dockerInfo?.DockerRootDir` into `getHostDiskInfo()` — so `diskTotal`/`diskFree`/`diskAvailable` reflect where images/containers/volumes actually live, not necessarily `/`. This makes `getHostDiskInfo()` run after the `dockerInfo` fetch instead of in parallel with it (it needs `dockerInfo` first), but `statfs()` itself is effectively instant next to a Docker `/info` round trip.
- The "no environment specified" branch still measures `/` — there's no `envId` there, and `getDockerConfig()` throws without one, so there's no way to query `/info` for `DockerRootDir` in that path without a larger change. Left as a comment in the code.
- Added `tests/host-disk-core.test.ts` (`node:test`/`node:assert`, matching the existing `tests/environment-delete.test.ts` style) covering: default-to-`/` when no path is given, an explicit custom path is actually used (not silently ignored), and a nonexistent path returns `null` instead of silently falling back to `/`.

`npx svelte-kit sync && npx svelte-check --tsconfig ./tsconfig.json` still comes back clean for the touched files (the repo-wide baseline has ~490 pre-existing errors unrelated to this change, in files this PR doesn't touch).
