### PR TITLE
feat: allow preserving stack files on removal

### DIFF
--- a/src/lib/server/stack-removal.ts
+++ b/src/lib/server/stack-removal.ts
@@ -1,0 +1,28 @@
+import { existsSync, rmSync } from 'node:fs';
+
+export function getRemoteStackRemovalFiles<T>(
+	deleteFiles: boolean,
+	filesToDelete: T[] | undefined
+): { removeFiles: boolean; filesToDelete: T[] | undefined } {
+	return {
+		removeFiles: deleteFiles,
+		filesToDelete: deleteFiles ? filesToDelete : undefined
+	};
+}
+
+/**
+ * Remove a stack directory already approved by the stack path guard. Returning an error
+ * keeps filesystem failures in the existing best-effort cleanup flow.
+ */
+export function removeStackDirectory(stackDir: string | null, deleteFiles: boolean): string | null {
+	if (!stackDir || !deleteFiles) return null;
+
+	try {
+		rmSync(stackDir, { recursive: true, force: true });
+	} catch (error) {
+		return error instanceof Error ? error.message : String(error);
+	}
+
+	// rmSync with force:true may not throw on every failure.
+	return existsSync(stackDir) ? 'Directory still exists after deletion attempt' : null;
+}

--- a/src/lib/server/stacks.ts
+++ b/src/lib/server/stacks.ts
@@ -46,6 +46,7 @@ import { unregisterSchedule } from './scheduler';
 import { sendEventNotification } from './notifications';
 import { deleteGitStackFiles, parseEnvFileContent } from './git';
 import { isDeletableStackDir } from './stack-delete-guard';
+import { getRemoteStackRemovalFiles, removeStackDirectory } from './stack-removal';
 import { cleanPem } from '$lib/utils/pem';
 import { rewriteComposeVolumePaths, getHostDataDir } from './host-path';
 import { getOrderValue } from './container-labels';
@@ -2523,7 +2524,8 @@ export async function removeStack(
 			const envVars = await getNonSecretEnvVarsAsRecord(stackName, envId);
 			const secretVars = await getSecretEnvVarsAsRecord(stackName, envId);
 
-			// Stack removal cleanup (#1162): the agent deletes ONLY what Dockhand
+			// Stack removal cleanup (#1162): when file deletion is requested, the agent
+			// deletes ONLY what Dockhand
 			// explicitly lists. The list is the local staging dir contents — exactly
 			// the files Dockhand ever wrote for this stack (compose, .env,
 			// .env.dockhand, git files), never user volume data (that exists only on
@@ -2531,7 +2533,7 @@ export async function removeStack(
 			// stack dir is removed only if nothing else remains in it.
 			// Only built for Dockhand-managed staging dirs (inside DATA_DIR/stacks).
 			let removalFiles: FileToDelete[] | undefined;
-			if (composeResult.stackDir) {
+			if (deleteFiles && composeResult.stackDir) {
 				const resolvedStaging = resolve(composeResult.stackDir);
 				if (resolvedStaging.startsWith(resolve(getStacksDir()) + '/')) {
 					removalFiles = Object.entries(hashDirFiles(resolvedStaging)).map(
@@ -2540,6 +2542,7 @@ export async function removeStack(
 				}
 			}
 
+			const remoteFileRemoval = getRemoteStackRemovalFiles(deleteFiles, removalFiles);
 			const downResult = await executeComposeCommand(
 				'down',
 				{
@@ -2550,9 +2553,9 @@ export async function removeStack(
 					composePath: composeResult.composePath ?? undefined,
 					envPath: composeResult.envPath ?? undefined,
 					useOverrideFile: isGitStack,
-					// Full stack removal: the Hawser agent cleans its stack dir (#1162)
-					removeFiles: true,
-					filesToDelete: removalFiles
+					// Keep/delete the Hawser agent's staged stack files using the same choice.
+					removeFiles: remoteFileRemoval.removeFiles,
+					filesToDelete: remoteFileRemoval.filesToDelete
 				},
 				composeResult.content!,
 				envVars,
@@ -2667,20 +2670,11 @@ export async function removeStack(
 
 		// Delete the directory if found — but ONLY when the caller asked to remove files.
 		// "Remove stack" (deleteFiles=false) leaves the compose/.env/data on disk; "Remove
-		// stack + files" (default) deletes them.
-		if (stackDir && deleteFiles) {
-			try {
-				rmSync(stackDir, { recursive: true, force: true });
-			} catch (err: any) {
-				console.error(`Failed to delete stack directory: ${err.message}`);
-				cleanupErrors.push(`directory: ${err.message}`);
-			}
-			// Verify deletion succeeded (rmSync with force:true may not throw on some failures)
-			if (existsSync(stackDir)) {
-				const verifyErr = 'Directory still exists after deletion attempt';
-				console.error(`Failed to delete stack directory: ${verifyErr}`);
-				cleanupErrors.push(`directory: ${verifyErr}`);
-			}
+		// stack + files" deletes them (and remains the API default for compatibility).
+		const directoryCleanupError = removeStackDirectory(stackDir, deleteFiles);
+		if (directoryCleanupError) {
+			console.error(`Failed to delete stack directory: ${directoryCleanupError}`);
+			cleanupErrors.push(`directory: ${directoryCleanupError}`);
 		}
 
 		try {

--- a/src/lib/utils/stack-removal.ts
+++ b/src/lib/utils/stack-removal.ts
@@ -1,0 +1,32 @@
+export interface StackRemovalOptions {
+	deleteFiles: boolean;
+	deleteVolumes: boolean;
+}
+
+export const DEFAULT_STACK_REMOVAL_OPTIONS: Readonly<StackRemovalOptions> = {
+	deleteFiles: false,
+	deleteVolumes: false
+};
+
+export function buildStackRemovalSearchParams(options: StackRemovalOptions): URLSearchParams {
+	const params = new URLSearchParams({
+		force: 'true',
+		files: String(options.deleteFiles)
+	});
+	if (options.deleteVolumes) params.set('volumes', 'true');
+	return params;
+}
+
+/** Parse the existing delete API flags while retaining its legacy file-deletion default. */
+export function parseStackRemovalSearchParams(searchParams: URLSearchParams): {
+	force: boolean;
+	removeVolumes: boolean;
+	deleteFiles: boolean;
+} {
+	return {
+		force: searchParams.get('force') === 'true',
+		removeVolumes: searchParams.get('volumes') === 'true',
+		// Existing clients that omit `files` keep the historical delete-files behavior.
+		deleteFiles: searchParams.get('files') !== 'false'
+	};
+}

--- a/src/routes/api/stacks/[name]/+server.ts
+++ b/src/routes/api/stacks/[name]/+server.ts
@@ -2,6 +2,7 @@ import { json } from '@sveltejs/kit';
 import { removeStack, ComposeFileNotFoundError } from '$lib/server/stacks';
 import { authorize } from '$lib/server/authorize';
 import { auditStack } from '$lib/server/audit';
+import { parseStackRemovalSearchParams } from '$lib/utils/stack-removal';
 import type { RequestHandler } from './$types';
 
 /**
@@ -23,11 +24,7 @@ export const DELETE: RequestHandler = async (event) => {
 	const { params, url, cookies } = event;
 	const auth = await authorize(cookies);
 
-	const force = url.searchParams.get('force') === 'true';
-	const volumes = url.searchParams.get('volumes') === 'true';
-	// files defaults to true (backward-compatible: old callers with no param still delete
-	// files). The delete modal passes files=false for "Remove stack" (keep files on disk).
-	const files = url.searchParams.get('files') !== 'false';
+	const { force, removeVolumes: volumes, deleteFiles: files } = parseStackRemovalSearchParams(url.searchParams);
 	const envId = url.searchParams.get('env');
 	const envIdNum = envId ? parseInt(envId) : undefined;
 

--- a/src/routes/stacks/+page.svelte
+++ b/src/routes/stacks/+page.svelte
@@ -50,6 +50,7 @@
 	import { ErrorDialog } from '$lib/components/ui/error-dialog';
 	import { formatHostPortUrl } from '$lib/utils/url';
 	import { formatBytes, formatBytesCompact } from '$lib/utils/format';
+	import { buildStackRemovalSearchParams } from '$lib/utils/stack-removal';
 
 	type SortField = 'name' | 'containers' | 'status' | 'cpu' | 'memory';
 	type SortDirection = 'asc' | 'desc';
@@ -1079,7 +1080,7 @@
 	async function removeStack(name: string, opts: { deleteFiles: boolean; deleteVolumes: boolean }) {
 		operationError = null;
 		try {
-			const params = `force=true${opts.deleteVolumes ? '&volumes=true' : ''}${opts.deleteFiles ? '' : '&files=false'}`;
+			const params = buildStackRemovalSearchParams(opts);
 			const response = await fetch(appendEnvParam(`/api/stacks/${encodeURIComponent(name)}?${params}`, envId), { method: 'DELETE' });
 			if (!response.ok) {
 				const data = await response.json();

--- a/src/routes/stacks/DeleteStackModal.svelte
+++ b/src/routes/stacks/DeleteStackModal.svelte
@@ -5,6 +5,7 @@
 	import { Trash2, Folder, Database, Loader2, ArrowRight } from 'lucide-svelte';
 	import GitGenericIcon from '$lib/components/icons/GitGenericIcon.svelte';
 	import { appendEnvParam } from '$lib/stores/environment';
+	import { DEFAULT_STACK_REMOVAL_OPTIONS } from '$lib/utils/stack-removal';
 
 	// The parent owns the fetch; onConfirm receives what the user chose to remove.
 	let {
@@ -32,10 +33,10 @@
 	let busy = $state(false);
 
 	// What to remove — the user ticks each. Containers are ALWAYS removed (the point of the
-	// operation), so they aren't a checkbox. Files default ON (the common intent), volumes
-	// default OFF (destructive, unrecoverable).
-	let removeFiles = $state(true);
-	let removeVolumes = $state(false);
+	// operation), so they aren't a checkbox. Destructive file and volume deletion both
+	// require explicit user intent.
+	let removeFiles = $state(DEFAULT_STACK_REMOVAL_OPTIONS.deleteFiles);
+	let removeVolumes = $state(DEFAULT_STACK_REMOVAL_OPTIONS.deleteVolumes);
 
 	const hasFiles = $derived(!!(preview?.stackDir || preview?.gitDir));
 	const hasVolumes = $derived((preview?.namedVolumes?.length ?? 0) > 0);
@@ -44,8 +45,8 @@
 		if (open && stackName) {
 			loading = true;
 			preview = null;
-			removeFiles = true;
-			removeVolumes = false;
+			removeFiles = DEFAULT_STACK_REMOVAL_OPTIONS.deleteFiles;
+			removeVolumes = DEFAULT_STACK_REMOVAL_OPTIONS.deleteVolumes;
 			fetch(appendEnvParam(`/api/stacks/${encodeURIComponent(stackName)}/delete-preview`, envId))
 				.then((r) => (r.ok ? r.json() : null))
 				.then((d) => { preview = d; })
@@ -63,8 +64,8 @@
 		];
 		if (hasFiles) {
 			lines.push(removeFiles
-				? { delete: true, kind: 'files', text: 'Delete the stack files on disk' }
-				: { delete: false, kind: 'files', text: 'Keep the stack files on disk' });
+				? { delete: true, kind: 'files', text: 'Delete Compose / environment files from disk' }
+				: { delete: false, kind: 'files', text: 'Keep Compose / environment files on disk' });
 		}
 		if (hasVolumes) {
 			const n = preview!.namedVolumes.length;
@@ -109,7 +110,7 @@
 						<Checkbox bind:checked={removeFiles} class="mt-0.5" />
 						<Folder class="w-4 h-4 shrink-0 translate-y-0.5 text-amber-500" />
 						<div class="min-w-0">
-							<div class="text-sm">Delete files on disk</div>
+							<div class="text-sm">Delete Compose / environment files from disk</div>
 							{#if preview.stackDir}
 								<code class="block break-all text-xs text-muted-foreground">{preview.stackDir}</code>
 							{/if}

--- a/tests/stack-removal.test.ts
+++ b/tests/stack-removal.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import {
+	DEFAULT_STACK_REMOVAL_OPTIONS,
+	buildStackRemovalSearchParams,
+	parseStackRemovalSearchParams
+} from '../src/lib/utils/stack-removal';
+import {
+	getRemoteStackRemovalFiles,
+	removeStackDirectory
+} from '../src/lib/server/stack-removal';
+
+const testDirs: string[] = [];
+
+function createStackFiles(): { root: string; stackDir: string; unrelatedFile: string } {
+	const root = mkdtempSync(join(tmpdir(), 'dockhand-stack-removal-'));
+	testDirs.push(root);
+	const stackDir = join(root, 'example');
+	const unrelatedDir = join(root, 'unrelated');
+	mkdirSync(stackDir);
+	mkdirSync(unrelatedDir);
+	writeFileSync(join(stackDir, 'compose.yaml'), 'services: {}\n');
+	writeFileSync(join(stackDir, '.env'), 'TOKEN=secret\n');
+	writeFileSync(join(stackDir, 'compose.override.yaml'), 'services: {}\n');
+	const unrelatedFile = join(unrelatedDir, 'keep.txt');
+	writeFileSync(unrelatedFile, 'untouched\n');
+	return { root, stackDir, unrelatedFile };
+}
+
+afterEach(() => {
+	for (const dir of testDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('stack removal files', () => {
+	it('preserves Compose, environment, related, and unrelated files when disabled', () => {
+		const { stackDir, unrelatedFile } = createStackFiles();
+
+		assert.equal(removeStackDirectory(stackDir, false), null);
+		assert.equal(existsSync(join(stackDir, 'compose.yaml')), true);
+		assert.equal(existsSync(join(stackDir, '.env')), true);
+		assert.equal(existsSync(join(stackDir, 'compose.override.yaml')), true);
+		assert.equal(existsSync(unrelatedFile), true);
+	});
+
+	it('retains the existing directory deletion behavior when enabled', () => {
+		const { stackDir, unrelatedFile } = createStackFiles();
+
+		assert.equal(removeStackDirectory(stackDir, true), null);
+		assert.equal(existsSync(stackDir), false);
+		assert.equal(existsSync(unrelatedFile), true);
+	});
+
+	it('propagates the same file choice to remote stack cleanup', () => {
+		const files = [{ path: 'compose.yaml', hash: 'sha256' }];
+		assert.deepEqual(getRemoteStackRemovalFiles(false, files), {
+			removeFiles: false,
+			filesToDelete: undefined
+		});
+		assert.deepEqual(getRemoteStackRemovalFiles(true, files), {
+			removeFiles: true,
+			filesToDelete: files
+		});
+	});
+});
+
+describe('stack removal request options', () => {
+	it('defaults the Dockhand UI to preserving files and volumes', () => {
+		assert.deepEqual(DEFAULT_STACK_REMOVAL_OPTIONS, {
+			deleteFiles: false,
+			deleteVolumes: false
+		});
+		assert.equal(buildStackRemovalSearchParams(DEFAULT_STACK_REMOVAL_OPTIONS).toString(), 'force=true&files=false');
+	});
+
+	it('sends explicit file deletion without changing volume behavior', () => {
+		const params = buildStackRemovalSearchParams({ deleteFiles: true, deleteVolumes: false });
+		assert.equal(params.get('files'), 'true');
+		assert.equal(params.has('volumes'), false);
+	});
+
+	it('keeps volume removal independent from file deletion', () => {
+		const params = buildStackRemovalSearchParams({ deleteFiles: false, deleteVolumes: true });
+		assert.equal(params.get('files'), 'false');
+		assert.equal(params.get('volumes'), 'true');
+	});
+
+	it('keeps the backend default compatible for callers that omit files', () => {
+		assert.deepEqual(parseStackRemovalSearchParams(new URLSearchParams('force=true&volumes=true')), {
+			force: true,
+			removeVolumes: true,
+			deleteFiles: true
+		});
+		assert.deepEqual(parseStackRemovalSearchParams(new URLSearchParams('files=false')), {
+			force: false,
+			removeVolumes: false,
+			deleteFiles: false
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Stack removal can now preserve its Compose and environment files instead of always deleting them. File deletion is an explicit option in the existing removal dialog and defaults to off; container removal behavior remains unchanged.

## Motivation

Compose definitions maintained outside Dockhand may be the infrastructure source of truth. Removing a stack from Dockhand should not implicitly destroy those files.

## Behavior

- Containers are still stopped and removed during stack removal.
- Compose and environment file deletion is independently selectable.
- When file deletion is disabled, the files remain on disk.
- Existing volume semantics remain unchanged.
- Preserved Compose projects can be adopted again later.

## Validation

- 7 focused tests pass.
- Preserve-files and delete-files paths are covered.
- API compatibility and remote-agent propagation are covered.
- Volume behavior is verified unchanged.
- Live functional testing passed for both removal choices.
- A preserved Compose file remained available for re-adoption.

## Screenshots

### Delete Compose/environment files

<img width="671" height="335" alt="Delete-Stack" src="https://github.com/user-attachments/assets/b45439e3-7a4d-4454-9533-7c1ccba119d8" />

*Removing a stack with Compose/environment file deletion explicitly enabled.*

### Preserve Compose/environment files

<img width="671" height="328" alt="Keep-Compose" src="https://github.com/user-attachments/assets/d8797ff7-c46f-48bd-a072-6dee80953dd1" />

*Removing a stack while preserving its Compose/environment files on disk.*

### Re-adopt preserved stack

<img width="901" height="248" alt="Adopt-delete-Stack" src="https://github.com/user-attachments/assets/67ee1c19-dc58-4ed6-b694-0a0e7620bfae" />

*The preserved `compose.yaml` remains available and can be adopted again after removal.*

Repository-wide validation contains pre-existing failures that reproduce unchanged on the upstream baseline and are unrelated to this change.

Closes #1401
