### PR TITLE
ci: add OpenAPI drift-gate workflow (follow-up to #1342)

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,54 @@
+name: OpenAPI spec check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/routes/**'
+      - 'src/hooks.server.ts'
+      - 'src/routes/+layout.server.ts'
+      - 'scripts/generate-openapi.ts'
+      - 'scripts/openapi/**'
+      - 'package.json'
+  pull_request:
+    paths:
+      - 'src/routes/**'
+      - 'src/hooks.server.ts'
+      - 'src/routes/+layout.server.ts'
+      - 'scripts/generate-openapi.ts'
+      - 'scripts/openapi/**'
+      - 'package.json'
+
+permissions:
+  contents: read
+
+jobs:
+  openapi-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      # Hard gate: path-param consistency, query/status drift, orphan JSDoc,
+      # and spec validity (@redocly/cli lint) must all pass. Coverage stays a
+      # warning on purpose (see scripts/generate-openapi.ts) — un-annotated
+      # endpoints must not block the pipeline; they remain fully functional
+      # generic stubs.
+      - name: Generate + validate OpenAPI spec
+        run: npm run generate:openapi:check
+
+      - name: Upload generated spec (debug artifact)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-spec
+          path: static/openapi.json
+          retention-days: 7


### PR DESCRIPTION
## Proposed change

Adds `.github/workflows/openapi.yml` — the OpenAPI drift gate that #1341/#1342 introduced alongside the generator. The cherry-pick pulled in `scripts/generate-openapi.ts` and the `generate:openapi:check` script, but not this workflow, so nothing currently enforces the check in CI. At runtime it's harmless (the `prebuild` hook regenerates the spec on every build), but a stale committed `src/lib/openapi.generated.json` / `static/openapi.json` would not be caught.

The job runs `npm run generate:openapi:check` on pushes to `main` and on PRs that touch the route code, hooks, or the generator, and fails if the committed spec drifts from the route code. It also uploads the generated `static/openapi.json` as a debug artifact.

Two small cleanups vs. the copy in #1341/#1342:
- Dropped a stale code comment that pointed to a research doc living in an external repo (not present here).
- Added `permissions: contents: read` (least privilege — the job only checks out and runs the generator), matching the explicit-permissions style already used in `release.yml`.

CI only — no runtime or app-code changes.

Follow-up to #1342 (no separate issue).

## Type of change

- [x] Other. Please explain: CI-only — adds the drift-gate workflow that was left out of the #1342 cherry-pick.