### PR TITLE
sync adopted/internal stack directory to Hawser on deploy

### DIFF
--- a/src/lib/server/git-deletions.ts
+++ b/src/lib/server/git-deletions.ts
@@ -1,11 +1,11 @@
 /**
- * Git stack deletion sync (#966, #1162).
+ * Git stack deletion sync (#966, #1162) and adopted/internal Hawser dir sync.
  *
- * Propagates upstream file deletions to the stack deploy directory using the
- * per-stack manifest: a file is deleted ONLY when the manifest of files
- * Dockhand wrote on the previous sync lists it, the new clone no longer
- * contains it, AND the bytes on disk still match what Dockhand wrote
- * (nobody modified it locally).
+ * Propagates file deletions to the stack deploy directory using a per-stack
+ * manifest: a file is deleted ONLY when the manifest of files Dockhand wrote
+ * on the previous sync lists it, the new payload/clone no longer contains it,
+ * AND the bytes on disk still match what Dockhand wrote (nobody modified it
+ * locally).
  *
  * Every failure mode degrades to "delete less" — never to user-data loss:
  * - user-created files (volume data) → never in the manifest → untouchable
@@ -162,6 +162,24 @@ export function serializeManifest(manifest: SyncManifest): string {
 
 export function hashContent(content: Buffer | string): string {
 	return createHash('sha256').update(content).digest('hex');
+}
+
+/**
+ * Hash a Hawser `files` payload the same way the agent writes it to disk:
+ * `base64:` values hash over their decoded bytes; everything else hashes over
+ * the UTF-8 bytes of the string content the agent writes. Used by
+ * adopted/internal stack dir sync so deletion hashes match remote bytes.
+ */
+export function hashShippedFiles(files: Record<string, string>): Record<string, string> {
+	const result: Record<string, string> = {};
+	for (const [path, content] of Object.entries(files)) {
+		if (content.startsWith('base64:')) {
+			result[path] = hashContent(Buffer.from(content.slice('base64:'.length), 'base64'));
+		} else {
+			result[path] = hashContent(content);
+		}
+	}
+	return result;
 }
 
 /**

--- a/src/lib/server/stacks.ts
+++ b/src/lib/server/stacks.ts
@@ -11,7 +11,11 @@ import { spawn as nodeSpawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import {
 	applyFileDeletions,
+	computeDeletions,
+	deletionSafetyCheck,
 	hashDirFiles,
+	hashShippedFiles,
+	parseManifest,
 	skipReasonMessage,
 	normalizeSkipReason,
 	type FileToDelete,
@@ -38,7 +42,9 @@ import {
 	getAutoUpdateSetting,
 	getStackSourceByComposePath,
 	getSecretProviderById,
-	setStackInjectedSecretKeys
+	setStackInjectedSecretKeys,
+	getEnvSetting,
+	setEnvSetting
 } from './db';
 import { getProvider } from './secretproviders';
 import { resolveComposeDockerHost, buildComposeBaseArgs } from './compose-docker-args';
@@ -329,6 +335,11 @@ async function lifecycleStackFiles(stackDir?: string): Promise<Record<string, st
 	} catch {
 		return undefined;
 	}
+}
+
+/** Settings key holding the last shipped-file manifest for a stack, per environment. */
+function stackFileManifestKey(stackName: string): string {
+	return `stackfiles:${stackName}`;
 }
 
 // =============================================================================
@@ -2689,6 +2700,16 @@ export async function removeStack(
 			cleanupErrors.push(`stack source: ${err.message}`);
 		}
 
+		// Clear the shipped-file manifest for the removed stack so a future stack
+		// reusing this name+env starts with a clean slate (no stale deletions).
+		if (envId != null) {
+			try {
+				await setEnvSetting(stackFileManifestKey(stackName), null, envId);
+			} catch (err: any) {
+				cleanupErrors.push(`file manifest: ${err.message}`);
+			}
+		}
+
 		try {
 			await deleteStackEnvVars(stackName, envId);
 		} catch (err: any) {
@@ -2921,13 +2942,31 @@ export async function deployStack(options: DeployStackOptions): Promise<StackOpe
 
 		}
 
+		// Hawser adopted/internal deploy: ship the whole compose directory (same
+		// map git deploy already uses) so relative binds and sibling files exist
+		// under STACKS_DIR/<stack>/. Git already populated stackFiles above.
+		let adoptedHawserSync = false;
+		let dirWalkCount = 0;
+		if (!stackFiles && existsSync(workingDir) && typeof envId === 'number') {
+			const hawserEnv = await getEnvironment(envId);
+			if (hawserEnv?.connectionType === 'hawser-standard' || hawserEnv?.connectionType === 'hawser-edge') {
+				stackFiles = await readDirFilesAsMap(workingDir);
+				dirWalkCount = Object.keys(stackFiles).length;
+				adoptedHawserSync = true;
+				console.log(`${logPrefix} Read ${dirWalkCount} files from compose directory for Hawser`);
+			}
+		}
+
 		// For Hawser deployments: include compose and .env in stackFiles
 		// Hawser writes files from the files map to disk at STACKS_DIR/{stackName}/
 		if (!stackFiles) {
 			stackFiles = {};
 		}
 		const composeFilename = actualComposePath ? basename(actualComposePath) : 'compose.yaml';
-		if (!stackFiles[composeFilename]) {
+		// Git: keep the clone copy when already in the map. Adopted/internal Hawser:
+		// overlay the compose body this deploy is applying (the previous sparse
+		// payload always sent that content).
+		if (!stackFiles[composeFilename] || adoptedHawserSync) {
 			stackFiles[composeFilename] = compose;
 			console.log(`${logPrefix} Added ${composeFilename} to stackFiles for Hawser (${compose.length} chars)`);
 		}
@@ -2940,6 +2979,42 @@ export async function deployStack(options: DeployStackOptions): Promise<StackOpe
 				console.log(`${logPrefix} Added .env to stackFiles for Hawser (${envFileContent.length} chars)`);
 			} catch (err) {
 				console.warn(`${logPrefix} Failed to read .env file at ${actualEnvPath}:`, err);
+			}
+		}
+
+		// Adopted/internal Hawser: reuse git deletion sync against the shipped map.
+		let hawserFilesToDelete = filesToDelete;
+		let adoptedManifestToPersist: Record<string, string> | undefined;
+		if (adoptedHawserSync && typeof envId === 'number') {
+			const newShipped = hashShippedFiles(stackFiles);
+			const raw = await getEnvSetting(stackFileManifestKey(name), envId);
+			const previous = parseManifest(
+				typeof raw === 'string' ? raw : raw != null ? JSON.stringify(raw) : null
+			);
+			// The compose overlay above guarantees newShipped is non-empty even when
+			// the dir walk was empty, so the emptiness guard must be explicit rather
+			// than left to deletionSafetyCheck.
+			const emptyWalk = dirWalkCount === 0;
+			const blocked = emptyWalk
+				? 'the stack directory walk was empty — skipping all deletions this deploy'
+				: deletionSafetyCheck(previous.files, newShipped, composeFilename);
+			if (blocked) {
+				console.warn(`${logPrefix} Deletion sync: ${blocked}`);
+			} else {
+				const plan = computeDeletions(previous.files, newShipped);
+				if (plan.toDelete.length > 0) {
+					hawserFilesToDelete = [...(hawserFilesToDelete ?? []), ...plan.toDelete];
+				}
+				for (const file of plan.toDelete) {
+					console.log(`${logPrefix} Deletion sync: will remove "${file.path}" — deleted from the compose directory`);
+				}
+				for (const skip of plan.skipped) {
+					if (skip.reason === 'already-absent') continue;
+					console.warn(`${logPrefix} Deletion sync: keeping "${skip.path}" — ${skipReasonMessage(skip.reason)}`);
+				}
+			}
+			if (!emptyWalk) {
+				adoptedManifestToPersist = newShipped;
 			}
 		}
 
@@ -2988,7 +3063,7 @@ export async function deployStack(options: DeployStackOptions): Promise<StackOpe
 				useOverrideFile: isGitStack,
 				// Pass compose filename for Hawser (extracted from path or provided explicitly)
 				composeFileName: composeFileName || (actualComposePath ? basename(actualComposePath) : undefined),
-				filesToDelete
+				filesToDelete: hawserFilesToDelete
 			},
 			compose,
 			isGitStack ? dbNonSecretVars : undefined,
@@ -3008,6 +3083,13 @@ export async function deployStack(options: DeployStackOptions): Promise<StackOpe
 		// for local deployments the local applier's result is the truth.
 		if (!result.deletion && localDeletionResult) {
 			result.deletion = localDeletionResult;
+		}
+		if (result.success && adoptedManifestToPersist && typeof envId === 'number') {
+			try {
+				await setEnvSetting(stackFileManifestKey(name), { commit: null, files: adoptedManifestToPersist }, envId);
+			} catch (err) {
+				console.warn(`${logPrefix} Failed to persist stack file manifest:`, err);
+			}
 		}
 		// Fire stack_deployed / stack_deploy_failed. This is the single point every deploy
 		// path funnels through, so all of them notify (#1295). A git deploy suppresses the

--- a/tests/git-deletions.test.ts
+++ b/tests/git-deletions.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Unit tests for shipped-file hashing and deletion planning used by git sync
+ * and adopted/internal Hawser directory sync.
+ */
+
+// @ts-expect-error -- bun:test is a runtime built-in with no types installed
+import { test, expect, describe } from 'bun:test';
+import { computeDeletions, hashContent, hashShippedFiles } from '../src/lib/server/git-deletions';
+
+describe('hashShippedFiles', () => {
+	test('text entries hash to the same value as hashContent of the UTF-8 bytes the agent writes', () => {
+		const text = 'FOO=bar\n# comment\n';
+		const hashed = hashShippedFiles({ '.env': text });
+		expect(hashed['.env']).toBe(hashContent(text));
+		expect(hashed['.env']).toBe(hashContent(Buffer.from(text, 'utf8')));
+	});
+
+	test('base64: entries hash the decoded bytes, not the prefixed string', () => {
+		const bytes = Buffer.from([0x00, 0x89, 0xff, 0x0a]);
+		const payload = `base64:${bytes.toString('base64')}`;
+		const hashed = hashShippedFiles({ 'bin/data.dat': payload });
+		expect(hashed['bin/data.dat']).toBe(hashContent(bytes));
+		expect(hashed['bin/data.dat']).not.toBe(hashContent(payload));
+	});
+});
+
+describe('computeDeletions with a shipped-file manifest', () => {
+	test('files absent from the new payload are deletion candidates; still-present files are not', () => {
+		const prev = hashShippedFiles({
+			'compose.yaml': 'services: {}\n',
+			'config.yaml': 'keep: false\n',
+			'scripts/run.sh': '#!/bin/sh\n'
+		});
+		const next = hashShippedFiles({
+			'compose.yaml': 'services: {}\n',
+			'.env': 'A=1\n'
+		});
+		const plan = computeDeletions(prev, next);
+		expect(plan.toDelete.map((f) => f.path).sort()).toEqual(['config.yaml', 'scripts/run.sh']);
+		expect(plan.toDelete.find((f) => f.path === 'config.yaml')?.hash).toBe(prev['config.yaml']);
+		expect(plan.toDelete.some((f) => f.path === 'compose.yaml')).toBe(false);
+	});
+
+	test('compose and .env are load-bearing and never queued for deletion', () => {
+		const prev = hashShippedFiles({
+			'compose.yaml': 'old\n',
+			'.env': 'OLD=1\n',
+			'extra.conf': 'x\n'
+		});
+		const next = hashShippedFiles({ 'other.yaml': 'y\n' });
+		const plan = computeDeletions(prev, next);
+		expect(plan.toDelete.map((f) => f.path)).toEqual(['extra.conf']);
+		expect(plan.skipped.map((s) => s.path).sort()).toEqual(['.env', 'compose.yaml']);
+		expect(plan.skipped.every((s) => s.reason === 'load-bearing')).toBe(true);
+	});
+});


### PR DESCRIPTION
Adopted/imported stacks deployed to Hawser now ship the entire local compose directory instead of only compose, `.env`, and override files. This fixes missing sibling files referenced by relative binds (e.g. configs, scripts, and certs) and aligns adopted stacks with Git stack deployment.

Stale files are also removed by reusing the existing Git deletion-sync flow, with per-stack/env file manifests persisted and hash-verified deletions applied on the Hawser. Manifests are updated only after a successful deploy and cleared when the stack is removed.

Git stack behavior remains unchanged. Added unit tests covering the new sync behavior.

## Type of change

<!--
What type of change does your PR introduce to Dockhand?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain:

