### PR TITLE
fix(openapi): correct /api/stacks/{name}/env body & response schema (#1454)

### DIFF
--- a/src/lib/openapi.generated.json
+++ b/src/lib/openapi.generated.json
@@ -24446,7 +24446,7 @@
         "tags": [
           "stacks"
         ],
-        "summary": "Get a stack's env vars (non-secrets from file, secrets masked from DB) plus injected provider keys",
+        "summary": "Get a stack's env vars plus injected provider keys",
         "parameters": [
           {
             "name": "name",
@@ -24478,7 +24478,23 @@
                     "variables": {
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          },
+                          "isSecret": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "value",
+                          "isSecret"
+                        ]
                       }
                     },
                     "injectedSecretKeys": {
@@ -24497,7 +24513,11 @@
                 },
                 "example": {
                   "variables": [
-                    "string"
+                    {
+                      "key": "string",
+                      "value": "string",
+                      "isSecret": true
+                    }
                   ],
                   "injectedSecretKeys": [
                     "string"
@@ -24521,14 +24541,15 @@
           {
             "bearerAuth": []
           }
-        ]
+        ],
+        "description": "Behavior depends on the stack source. For git stacks, ALL vars (overrides and secrets) come from the DB via this endpoint. For internal/adopted stacks, non-secrets come from the .env file and secrets from the DB (masked as '***'). Each variable is an object with key, value and isSecret."
       },
       "put": {
         "operationId": "put_api_stacks_name_env",
         "tags": [
           "stacks"
         ],
-        "summary": "Save a stack's secret env vars to the DB (secrets never hit disk)",
+        "summary": "Save a stack's env vars to the DB",
         "parameters": [
           {
             "name": "name",
@@ -24571,6 +24592,7 @@
             "bearerAuth": []
           }
         ],
+        "description": "Stores the received variables in the DB via this endpoint. For git stacks the DB is the canonical store for ALL vars (overrides and secrets) that the UI and deploys read. For internal/adopted stacks, non-secrets live in the .env file (written via PUT /env/raw) and secrets are stored here. A secret whose value is '***' keeps its existing DB value.",
         "requestBody": {
           "required": true,
           "content": {
@@ -24581,7 +24603,22 @@
                   "variables": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "isSecret": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "value"
+                      ]
                     }
                   }
                 },
@@ -24591,7 +24628,16 @@
               },
               "example": {
                 "variables": [
-                  "string"
+                  {
+                    "key": "FOO",
+                    "value": "bar",
+                    "isSecret": false
+                  },
+                  {
+                    "key": "TOKEN",
+                    "value": "s3cr3t",
+                    "isSecret": true
+                  }
                 ]
               }
             }

--- a/src/routes/api/stacks/[name]/env/+server.ts
+++ b/src/routes/api/stacks/[name]/env/+server.ts
@@ -36,10 +36,11 @@ function parseEnvFile(content: string): Record<string, string> {
  */
 /**
  * @openapi
- * summary: Get a stack's env vars (non-secrets from file, secrets masked from DB) plus injected provider keys
+ * summary: Get a stack's env vars plus injected provider keys
+ * description: Behavior depends on the stack source. For git stacks, ALL vars (overrides and secrets) come from the DB via this endpoint. For internal/adopted stacks, non-secrets come from the .env file and secrets from the DB (masked as '***'). Each variable is an object with key, value and isSecret.
  * path: name:string The stack name
  * query: env:integer Environment id the stack belongs to
- * resp-200: {variables:array<object>!, injectedSecretKeys:array<string>, secretProvider:object}
+ * resp-200: {variables:array<{key:string!, value:string!, isSecret:boolean!}>!, injectedSecretKeys:array<string>, secretProvider:object}
  * resp-403: Permission denied (needs stacks:view)
  * resp-500: Failed to read env vars
  */
@@ -145,10 +146,12 @@ export const GET: RequestHandler = async ({ params, url, cookies }) => {
  */
 /**
  * @openapi
- * summary: Save a stack's secret env vars to the DB (secrets never hit disk)
+ * summary: Save a stack's env vars to the DB
+ * description: Stores the received variables in the DB via this endpoint. For git stacks the DB is the canonical store for ALL vars (overrides and secrets) that the UI and deploys read. For internal/adopted stacks, non-secrets live in the .env file (written via PUT /env/raw) and secrets are stored here. A secret whose value is '***' keeps its existing DB value.
  * path: name:string The stack name
  * query: env:integer Environment id the stack belongs to
- * body: {variables:array<object>!}
+ * body: {variables:array<{key:string!, value:string!, isSecret:boolean}>!}
+ * body-example: {"variables":[{"key":"FOO","value":"bar","isSecret":false},{"key":"TOKEN","value":"s3cr3t","isSecret":true}]}
  * resp-400: Invalid variables payload
  * resp-403: Permission denied (needs stacks:edit)
  * resp-500: Failed to save env vars

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -24441,7 +24441,7 @@
         "tags": [
           "stacks"
         ],
-        "summary": "Get a stack's env vars (non-secrets from file, secrets masked from DB) plus injected provider keys",
+        "summary": "Get a stack's env vars plus injected provider keys",
         "parameters": [
           {
             "name": "name",
@@ -24473,7 +24473,23 @@
                     "variables": {
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          },
+                          "isSecret": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "value",
+                          "isSecret"
+                        ]
                       }
                     },
                     "injectedSecretKeys": {
@@ -24492,7 +24508,11 @@
                 },
                 "example": {
                   "variables": [
-                    "string"
+                    {
+                      "key": "string",
+                      "value": "string",
+                      "isSecret": true
+                    }
                   ],
                   "injectedSecretKeys": [
                     "string"
@@ -24516,14 +24536,15 @@
           {
             "bearerAuth": []
           }
-        ]
+        ],
+        "description": "Behavior depends on the stack source. For git stacks, ALL vars (overrides and secrets) come from the DB via this endpoint. For internal/adopted stacks, non-secrets come from the .env file and secrets from the DB (masked as '***'). Each variable is an object with key, value and isSecret."
       },
       "put": {
         "operationId": "put_api_stacks_name_env",
         "tags": [
           "stacks"
         ],
-        "summary": "Save a stack's secret env vars to the DB (secrets never hit disk)",
+        "summary": "Save a stack's env vars to the DB",
         "parameters": [
           {
             "name": "name",
@@ -24566,6 +24587,7 @@
             "bearerAuth": []
           }
         ],
+        "description": "Stores the received variables in the DB via this endpoint. For git stacks the DB is the canonical store for ALL vars (overrides and secrets) that the UI and deploys read. For internal/adopted stacks, non-secrets live in the .env file (written via PUT /env/raw) and secrets are stored here. A secret whose value is '***' keeps its existing DB value.",
         "requestBody": {
           "required": true,
           "content": {
@@ -24576,7 +24598,22 @@
                   "variables": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "isSecret": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "value"
+                      ]
                     }
                   }
                 },
@@ -24586,7 +24623,16 @@
               },
               "example": {
                 "variables": [
-                  "string"
+                  {
+                    "key": "FOO",
+                    "value": "bar",
+                    "isSecret": false
+                  },
+                  {
+                    "key": "TOKEN",
+                    "value": "s3cr3t",
+                    "isSecret": true
+                  }
                 ]
               }
             }

--- a/tests/openapi-body-annotations.test.ts
+++ b/tests/openapi-body-annotations.test.ts
@@ -118,4 +118,30 @@ describe('buildSpec: emits requestBody for non-JSON bodies', () => {
 		expect(mp.schema.properties.files.items.format).toBe('binary');
 		expect(mp.schema.required).toEqual(['files']);
 	});
+
+	// Regression for #1454: `PUT /api/stacks/{name}/env` documented its body as
+	// `array<object>` (-> items:{type:string}), which contradicts the handler
+	// requiring objects `{key, value, isSecret}` and 400ing otherwise. The body
+	// mini-schema must emit a nested-object array so clients target the right store.
+	test('array<{...}> body -> requestBody with a typed nested-object array', () => {
+		const spec = specFor(
+			'/z/+server.ts',
+			'/api/stacks/{name}/env',
+			'PUT',
+			' * @openapi\n * summary: Save env vars\n * body: {variables:array<{key:string!, value:string!, isSecret:boolean}>!}'
+		);
+		const rb: any = spec.paths['/api/stacks/{name}/env'].put.requestBody;
+		expect(rb.required).toBe(true);
+		const schema = rb.content['application/json'].schema;
+		expect(schema.type).toBe('object');
+		expect(schema.required).toEqual(['variables']);
+		const items = schema.properties.variables.items;
+		// The bug produced items:{type:'string'}; a valid spec has an object here.
+		expect(schema.properties.variables.type).toBe('array');
+		expect(items.type).toBe('object');
+		expect(items.properties.key.type).toBe('string');
+		expect(items.properties.value.type).toBe('string');
+		expect(items.properties.isSecret.type).toBe('boolean');
+		expect(items.required).toEqual(['key', 'value']);
+	});
 });


### PR DESCRIPTION
## What

Fixes the OpenAPI document for `GET`/`PUT /api/stacks/{name}/env` (served with `FEAT_API_DOCS=true`), which contradicted the actual handler. Closes #1454.

## Fix

The `variables` array was documented as `array<object>`, which the generator renders as `items: { "type": "string" }` — an array of bare strings. But the handler:

- **PUT** requires each variable to be an object `{ key, value, isSecret }` and `400`s otherwise (`key` required string, `value` required string, `isSecret` optional bool).
- **GET** returns the same object shape.
- For **git stacks** the DB is the canonical store for **all** vars (overrides *and* secrets) via this endpoint — not "secrets only / non-secrets in the file" (that wording is true only for internal/adopted stacks).

Clients built from the old spec (e.g. `strausmann/mcp-dockhand`, tracked at `strausmann/mcp-dockhand#231`) therefore route git-stack non-secrets to the wrong store, making them invisible to the UI and deploys.

Changes (via the `@openapi` JSDoc annotation on `src/routes/api/stacks/[name]/env/+server.ts`):

- Model `variables` as `array<{key:string!, value:string!, isSecret:boolean}>` for both the GET response and the PUT request body.
- Split the "secrets only" wording into per-source-type `description`s (git → all vars in DB; internal/adopted → non-secrets via `/env/raw`, secrets here).
- Add a realistic PUT `body-example`.
- Regenerate the committed spec (`src/lib/openapi.generated.json`, `static/openapi.json`) — **only** the `/api/stacks/{name}/env` operation changed; the rest is untouched.

## Tests

Added a regression test in `tests/openapi-body-annotations.test.ts` asserting the `PUT` body renders as a typed nested-object array (`items.type === 'object'` with `key`/`value`/`isSecret` and `required: ['key','value']`), guarding against the `array<object> → items:{type:string}` regression.

## Validation (real results on this machine)

```
$ bun test tests/openapi-body-annotations.test.ts
 11 pass  0 fail  36 expect() calls

$ tsx scripts/generate-openapi.ts --check   (node 22 + local @redocly/cli)
[Gate 1] Coverage: 359/359 handlers annotated (100.0%)
[Gate 2] Path-param consistency: 0 issue(s)
[Gate 3] Query-param drift: 0 issue(s)
[Gate 4] Status-code drift: 0 issue(s)
[Gate 5] Orphan @openapi blocks: 0 file(s)
[Gate 6] Spec validity (@redocly/cli lint): OK
Hard failures: 0
```

RED→GREEN on the real generator: reverting the annotation back to `array<object>` regenerates `items: {"type":"string"}` (the bug); with the fix it regenerates the typed object array.

I could not run the full `bun test tests/` suite here because `better-sqlite3`'s native addon fails to build on this host (no build toolchain); the OpenAPI test file imports only the pure-TS generator modules and runs standalone.

First-time contributor — happy to adjust wording or scope.
