### PR TITLE
Fix dashboard image disk usage calculation

### DIFF
--- a/src/lib/server/docker-disk-usage-core.ts
+++ b/src/lib/server/docker-disk-usage-core.ts
@@ -1,0 +1,32 @@
+export interface DockerDiskUsageLike {
+	LayersSize?: unknown;
+	ImageUsage?: {
+		TotalSize?: unknown;
+	} | null;
+	Images?: Array<{
+		Size?: unknown;
+	}> | null;
+}
+
+function asNonNegativeFiniteNumber(value: unknown): number | null {
+	return typeof value === 'number' && Number.isFinite(value) && value >= 0
+		? value
+		: null;
+}
+
+/**
+ * Return Docker's aggregate image disk usage without double-counting shared layers.
+ *
+ * `Images[].Size` is each image's virtual size (shared + unique), so adding those
+ * values overstates disk usage whenever images share layers. Docker exposes the
+ * deduplicated total as `ImageUsage.TotalSize` in the current API and as
+ * `LayersSize` in the legacy response shape.
+ */
+export function getImageDiskUsageTotalSize(
+	diskUsage: DockerDiskUsageLike | null | undefined
+): number | null {
+	const currentTotal = asNonNegativeFiniteNumber(diskUsage?.ImageUsage?.TotalSize);
+	if (currentTotal !== null) return currentTotal;
+
+	return asNonNegativeFiniteNumber(diskUsage?.LayersSize);
+}

--- a/src/routes/api/dashboard/stats/+server.ts
+++ b/src/routes/api/dashboard/stats/+server.ts
@@ -242,7 +242,9 @@ export const GET: RequestHandler = async ({ cookies, url }) => {
 				if (diskUsage) {
 					// Images: use Docker's aggregate size so shared layers are counted once
 					envStats.images.total = diskUsage.Images?.length || images.length;
-					envStats.images.totalSize = getImageDiskUsageTotalSize(diskUsage) ?? 0;
+					envStats.images.totalSize = getImageDiskUsageTotalSize(diskUsage)
+						?? diskUsage.Images?.reduce((sum: number, img: any) => sum + getValidSize(img.Size), 0)
+						?? 0;
 
 					// Volumes: use UsageData.Size from /system/df
 					envStats.volumes.total = diskUsage.Volumes?.length || volumes.length;
@@ -254,10 +256,9 @@ export const GET: RequestHandler = async ({ cookies, url }) => {
 					// Build cache: total size
 					envStats.buildCacheSize = diskUsage.BuildCache?.reduce((sum: number, bc: any) => sum + getValidSize(bc.Size), 0) || 0;
 				} else {
-					// Image list sizes are virtual and cannot be summed without double-counting
-					// shared layers. Keep disk usage unavailable when /system/df fails.
+					// Fallback to original method if /system/df failed
 					envStats.images.total = images.length;
-					envStats.images.totalSize = 0;
+					envStats.images.totalSize = images.reduce((sum: number, img: any) => sum + getValidSize(img.size), 0);
 					envStats.volumes.total = volumes.length;
 					envStats.volumes.totalSize = 0;
 				}

--- a/src/routes/api/dashboard/stats/+server.ts
+++ b/src/routes/api/dashboard/stats/+server.ts
@@ -18,6 +18,7 @@ import {
 } from '$lib/server/docker';
 import { listComposeStacks } from '$lib/server/stacks';
 import { countLivePending } from '$lib/server/pending-updates-core';
+import { getImageDiskUsageTotalSize } from '$lib/server/docker-disk-usage-core';
 import { authorize } from '$lib/server/authorize';
 import { parseLabels } from '$lib/utils/label-colors';
 
@@ -239,9 +240,9 @@ export const GET: RequestHandler = async ({ cookies, url }) => {
 
 				// Process disk usage from /system/df for accurate size data
 				if (diskUsage) {
-					// Images: use Size from /system/df
+					// Images: use Docker's aggregate size so shared layers are counted once
 					envStats.images.total = diskUsage.Images?.length || images.length;
-					envStats.images.totalSize = diskUsage.Images?.reduce((sum: number, img: any) => sum + getValidSize(img.Size), 0) || 0;
+					envStats.images.totalSize = getImageDiskUsageTotalSize(diskUsage) ?? 0;
 
 					// Volumes: use UsageData.Size from /system/df
 					envStats.volumes.total = diskUsage.Volumes?.length || volumes.length;
@@ -253,9 +254,10 @@ export const GET: RequestHandler = async ({ cookies, url }) => {
 					// Build cache: total size
 					envStats.buildCacheSize = diskUsage.BuildCache?.reduce((sum: number, bc: any) => sum + getValidSize(bc.Size), 0) || 0;
 				} else {
-					// Fallback to original method if /system/df failed
+					// Image list sizes are virtual and cannot be summed without double-counting
+					// shared layers. Keep disk usage unavailable when /system/df fails.
 					envStats.images.total = images.length;
-					envStats.images.totalSize = images.reduce((sum: number, img: any) => sum + getValidSize(img.size), 0);
+					envStats.images.totalSize = 0;
 					envStats.volumes.total = volumes.length;
 					envStats.volumes.totalSize = 0;
 				}

--- a/src/routes/api/dashboard/stats/stream/+server.ts
+++ b/src/routes/api/dashboard/stats/stream/+server.ts
@@ -26,6 +26,7 @@ import { prefersJSON, sseToJSON } from '$lib/server/sse';
 import type { EnvironmentStats } from '../+server';
 import { parseLabels } from '$lib/utils/label-colors';
 import { isEdgeConnected } from '$lib/server/hawser';
+import { getImageDiskUsageTotalSize } from '$lib/server/docker-disk-usage-core';
 
 
 // Skip disk usage collection (Synology NAS performance fix)
@@ -360,7 +361,8 @@ async function getEnvironmentStatsProgressive(
 		const imagesPromise = withTimeout(listImages(env.id).catch(() => []), 10000, [])
 			.then((images) => {
 				envStats.images.total = images.length;
-				envStats.images.totalSize = images.reduce((sum: number, img: any) => sum + getValidSize(img.size), 0);
+				// Per-image sizes include shared layers. Wait for /system/df before
+				// publishing aggregate disk usage instead of showing an inflated total.
 				envStats.loading!.images = false;
 
 				onPartialUpdate({
@@ -434,9 +436,9 @@ async function getEnvironmentStatsProgressive(
 			: getCachedDiskUsage(env.id)
 				.then((diskUsage) => {
 					if (diskUsage) {
-						// Update images with disk usage data (more accurate)
+						// Update images with Docker's deduplicated aggregate size
 						envStats.images.total = diskUsage.Images?.length || envStats.images.total;
-						envStats.images.totalSize = diskUsage.Images?.reduce((sum: number, img: any) => sum + getValidSize(img.Size), 0) || envStats.images.totalSize;
+						envStats.images.totalSize = getImageDiskUsageTotalSize(diskUsage) ?? 0;
 
 						// Volumes from disk usage
 						envStats.volumes.total = diskUsage.Volumes?.length || 0;

--- a/src/routes/api/dashboard/stats/stream/+server.ts
+++ b/src/routes/api/dashboard/stats/stream/+server.ts
@@ -361,8 +361,7 @@ async function getEnvironmentStatsProgressive(
 		const imagesPromise = withTimeout(listImages(env.id).catch(() => []), 10000, [])
 			.then((images) => {
 				envStats.images.total = images.length;
-				// Per-image sizes include shared layers. Wait for /system/df before
-				// publishing aggregate disk usage instead of showing an inflated total.
+				envStats.images.totalSize = images.reduce((sum: number, img: any) => sum + getValidSize(img.size), 0);
 				envStats.loading!.images = false;
 
 				onPartialUpdate({
@@ -438,7 +437,9 @@ async function getEnvironmentStatsProgressive(
 					if (diskUsage) {
 						// Update images with Docker's deduplicated aggregate size
 						envStats.images.total = diskUsage.Images?.length || envStats.images.total;
-						envStats.images.totalSize = getImageDiskUsageTotalSize(diskUsage) ?? 0;
+						envStats.images.totalSize = getImageDiskUsageTotalSize(diskUsage)
+							?? diskUsage.Images?.reduce((sum: number, img: any) => sum + getValidSize(img.Size), 0)
+							?? envStats.images.totalSize;
 
 						// Volumes from disk usage
 						envStats.volumes.total = diskUsage.Volumes?.length || 0;

--- a/tests/docker-disk-usage-core.test.ts
+++ b/tests/docker-disk-usage-core.test.ts
@@ -1,0 +1,53 @@
+// @ts-expect-error -- bun:test is a runtime built-in with no types installed
+import { describe, expect, test } from 'bun:test';
+import { getImageDiskUsageTotalSize } from '../src/lib/server/docker-disk-usage-core';
+
+describe('getImageDiskUsageTotalSize', () => {
+	test('uses Docker aggregate size instead of summing virtual image sizes', () => {
+		const diskUsage = {
+			LayersSize: 70_326_328_267,
+			Images: [
+				{ Size: 189_295_958_800 },
+				{ Size: 82_498_083_216 }
+			]
+		};
+
+		expect(getImageDiskUsageTotalSize(diskUsage)).toBe(70_326_328_267);
+	});
+
+	test('prefers the current ImageUsage.TotalSize response field', () => {
+		expect(getImageDiskUsageTotalSize({
+			ImageUsage: { TotalSize: 42 },
+			LayersSize: 99
+		})).toBe(42);
+	});
+
+	test('supports the legacy LayersSize response field', () => {
+		expect(getImageDiskUsageTotalSize({ LayersSize: 42 })).toBe(42);
+	});
+
+	test('preserves zero as a valid aggregate size', () => {
+		expect(getImageDiskUsageTotalSize({
+			ImageUsage: { TotalSize: 0 },
+			LayersSize: 99
+		})).toBe(0);
+		expect(getImageDiskUsageTotalSize({ LayersSize: 0 })).toBe(0);
+	});
+
+	test('falls back from an invalid current value to a valid legacy value', () => {
+		expect(getImageDiskUsageTotalSize({
+			ImageUsage: { TotalSize: Number.NaN },
+			LayersSize: 42
+		})).toBe(42);
+	});
+
+	test('returns null when no trustworthy aggregate is available', () => {
+		expect(getImageDiskUsageTotalSize(undefined)).toBeNull();
+		expect(getImageDiskUsageTotalSize({})).toBeNull();
+		expect(getImageDiskUsageTotalSize({ LayersSize: -1 })).toBeNull();
+		expect(getImageDiskUsageTotalSize({
+			ImageUsage: { TotalSize: '42' },
+			LayersSize: null
+		})).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- use the Docker aggregate image disk usage instead of summing virtual per-image sizes
- support the current ImageUsage.TotalSize field and the legacy LayersSize field
- preserve the existing per-image fallback when aggregate data or /system/df is unavailable
- apply the same calculation to the regular and streaming dashboard endpoints

## Problem

The dashboard currently sums Images[].Size from the Docker /system/df response. Each value is a virtual image size that includes shared layers, so summing the list counts shared data multiple times.

On a Docker 29.1.3 host used to reproduce the issue:

| Value | Bytes |
| --- | ---: |
| ImageUsage.TotalSize / LayersSize | 70,326,328,267 |
| Sum of Images[].Size | 271,794,042,016 |

This made the dashboard report roughly four times the actual image disk usage.

## Implementation

A small shared helper selects the authoritative aggregate:

1. ImageUsage.TotalSize for current Docker API responses
2. LayersSize for legacy responses
3. the existing per-image calculation when neither aggregate is available

The fallback behavior is intentionally unchanged for compatibility.

## Verification

- bun test tests/docker-disk-usage-core.test.ts — 6 passed
- bun test tests/ — 2649 passed, 0 failed
- OpenAPI drift gates — 6 passed, 0 hard failures