### PR TITLE
Add crossorigin attribute to manifest link to fix CF tunnel not downloading it

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -6,7 +6,7 @@
 		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
 		<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
 		<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-		<link rel="manifest" href="/site.webmanifest" />
+		<link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
Reason why see: https://github.com/cloudflare/cloudflare-docs/blob/production/src/content/docs/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/cors.mdx?utm_source=chatgpt.com and similiar: https://github.com/open-webui/open-webui/issues/1538

## Proposed change
Added crossorigin="use-credentials" to the webmanifest, as that's an error i saw getting logged when accessing dockhand through CF tunnel.

I do want to add i used chatgpt to find out why this happend, ussually i go into the container, edit it and test if it doesn't break anything. But i'm not familiar with sveltekit and not a webdev :P . I can't imagine this breaking anything as i tried this change on other selfhosted apps and the functionality remained intact when access on IP and port.

Closes a minor inconvience

## Type of change
- [x ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain:

