### PR TITLE
fix(openapi): recognize bare `object` type + document `existing` field on validate

### DIFF
--- a/scripts/openapi/lib.ts
+++ b/scripts/openapi/lib.ts
@@ -209,7 +209,8 @@ export function discoverRoutes(rootDirs: string[], routesRoot: string): { routes
 //    * resp-<code>-example: <json>
 //    */
 //
-// mini-schema := 'string'|'integer'|'number'|'boolean' | '{' (name':'type'!'?','?)* '}' | 'array<' type '>'
+// mini-schema := 'string'|'integer'|'number'|'boolean'|'object' | '{' (name':'type'!'?','?)* '}' | 'array<' type '>'
+// (bare 'object' = an opaque object with no declared properties; use '{...}' for a documented shape)
 
 export function parseMiniSchema(str: string): MiniSchema {
 	let i = 0;
@@ -244,6 +245,15 @@ export function parseMiniSchema(str: string): MiniSchema {
 		if (i === start) i++;
 		const word = s.slice(start, i) || 'string';
 		if (word === 'integer' || word === 'number' || word === 'boolean' || word === 'string') return { kind: word };
+		// Bare `object` (no `{...}` shape given) — an opaque/untyped object, used
+		// throughout the codebase for fields whose internal shape isn't part of
+		// the documented contract (e.g. `severity:object`, `envVars:object`,
+		// `config:object`). Without this branch it silently fell through to the
+		// generic `string` fallback below, so every one of these fields was
+		// documented in static/openapi.json as `{ "type": "string" }` instead of
+		// `{ "type": "object" }` — wrong for any client generated strictly from
+		// the spec (a typed SDK, an MCP server mirroring the schema, ...).
+		if (word === 'object') return { kind: 'object', properties: {}, required: [] };
 		return { kind: 'string' };
 	}
 

--- a/src/routes/api/stacks/[name]/validate/+server.ts
+++ b/src/routes/api/stacks/[name]/validate/+server.ts
@@ -35,9 +35,10 @@ async function resolveDockerHostForConfig(envIdNum: number | undefined): Promise
  *
  * @openapi
  * summary: Run the Compose Validate preflight linter on a compose file and return findings with severities and line numbers (requires the 'view' permission)
+ * description: Set existing:true when validating an already-deployed stack, so the stack's own running containers/ports are excluded from the cross-stack collision checks; omit it (or false) for a brand-new stack, where a name/port clash with a running stack of the same name must still be reported.
  * path: name:string! Stack name (used to exclude the stack's own containers from cross-stack collision checks)
  * query: env:integer Environment ID for the context-aware checks (from GET /api/environments)
- * body: {compose:string!, config:{disabled:[string], severity:object}, envVars:object}
+ * body: {compose:string!, existing:boolean, config:{disabled:[string], severity:object}, envVars:object}
  * body-example: {"compose":"services:\n  web:\n    image: nginx:latest\n    ports: [\"8080:80\"]\n"}
  * resp-200: {findings:[{ruleId:string!, severity:string!, message:string!, hint:string, service:string, line:integer, fix:object, fixDescription:string}]!, counts:{error:integer!, warn:integer!, info:integer!}!}
  * resp-200-example: {"findings":[{"ruleId":"LATEST_TAG","severity":"warn","message":"\"web\" uses `:latest` (nginx:latest)","hint":"Pin a version tag for reproducible deploys and to enable newer-version detection.","service":"web","line":3}],"counts":{"error":0,"warn":1,"info":0}}

--- a/tests/openapi-body-annotations.test.ts
+++ b/tests/openapi-body-annotations.test.ts
@@ -41,6 +41,20 @@ describe('parseMiniSchema: always terminates + bracket arrays', () => {
 	test('array<T> long form still works (no regression)', () => {
 		expect(parseMiniSchema('array<string>')).toEqual({ kind: 'array', items: { kind: 'string' } });
 	});
+
+	test('bare `object` parses as an opaque object, not the string fallback', () => {
+		expect(parseMiniSchema('object')).toEqual({ kind: 'object', properties: {}, required: [] });
+	});
+
+	test('nested object with a bare `object` property (the exact string from #1530 — was silently "string")', () => {
+		// This is the real `body:` annotation on POST /api/stacks/{name}/validate.
+		// Before the fix, `severity` and `envVars` both fell through to
+		// `{ kind: 'string' }` because `parseType()` only recognized
+		// integer/number/boolean/string as bare words.
+		const s = parseMiniSchema('{compose:string!, config:{disabled:[string], severity:object}, envVars:object}');
+		expect((s as any).properties.config.properties.severity).toEqual({ kind: 'object', properties: {}, required: [] });
+		expect((s as any).properties.envVars).toEqual({ kind: 'object', properties: {}, required: [] });
+	});
 });
 
 describe('parseAnnotations: non-JSON request bodies', () => {

--- a/tests/openapi-body-annotations.test.ts
+++ b/tests/openapi-body-annotations.test.ts
@@ -46,14 +46,19 @@ describe('parseMiniSchema: always terminates + bracket arrays', () => {
 		expect(parseMiniSchema('object')).toEqual({ kind: 'object', properties: {}, required: [] });
 	});
 
-	test('nested object with a bare `object` property (the exact string from #1530 — was silently "string")', () => {
-		// This is the real `body:` annotation on POST /api/stacks/{name}/validate.
-		// Before the fix, `severity` and `envVars` both fell through to
+	test('nested object with a bare `object` property (the real body: annotation on POST /api/stacks/{name}/validate — was silently "string")', () => {
+		// Before this fix, `severity` and `envVars` both fell through to
 		// `{ kind: 'string' }` because `parseType()` only recognized
-		// integer/number/boolean/string as bare words.
-		const s = parseMiniSchema('{compose:string!, config:{disabled:[string], severity:object}, envVars:object}');
+		// integer/number/boolean/string as bare words. `existing` (added for
+		// #1530) is a plain `boolean` and was never affected by this bug —
+		// included here only to keep this literal in sync with the real
+		// annotation.
+		const s = parseMiniSchema(
+			'{compose:string!, existing:boolean, config:{disabled:[string], severity:object}, envVars:object}'
+		);
 		expect((s as any).properties.config.properties.severity).toEqual({ kind: 'object', properties: {}, required: [] });
 		expect((s as any).properties.envVars).toEqual({ kind: 'object', properties: {}, required: [] });
+		expect((s as any).properties.existing).toEqual({ kind: 'boolean' });
 	});
 });
 


### PR DESCRIPTION
## Proposed change

Two small, related fixes to `POST /api/stacks/{name}/validate`'s `@openapi` annotation accuracy — both found while investigating that endpoint's spec output, tracked as two separate issues since they're distinct root causes on the same annotation line.

### 1. Parser: bare `object` type silently became `string` (#1531)

The `@openapi` annotation parser's `parseMiniSchema()` (`scripts/openapi/lib.ts`) only recognized the bare words `integer`, `number`, `boolean`, and `string` as scalar types. Any other bare word — including `object`, used in 16 route annotations across the codebase — silently fell through to the generic `string` fallback in `parseType()`:

```ts
const word = s.slice(start, i) || 'string';
if (word === 'integer' || word === 'number' || word === 'boolean' || word === 'string') return { kind: word };
return { kind: 'string' };
```

So e.g. this endpoint's `body: {compose:string!, config:{disabled:[string], severity:object}, envVars:object}` documented `severity` and `envVars` in `static/openapi.json` as `{ "type": "string" }` instead of `{ "type": "object" }`. Any client generated strictly from the spec (a typed SDK, an MCP server mirroring the documented shape) would get the wrong type for these fields.

Added a dedicated branch for bare `object`, producing an opaque object schema (no declared properties — a documented shape should use the existing `{...}` form):

```ts
if (word === 'object') return { kind: 'object', properties: {}, required: [] };
```

I confirmed (via `grep -rE ':(object|array)\b' src/routes --include="+server.ts"`, restricted to actual `body:`/`resp-XXX:`/`query:`/`path:` annotation lines) that `object` is the *only* bare non-standard word currently used in any annotation — bare `array` (without the already-handled `array<T>` form) doesn't occur anywhere, so this closes the gap completely for the current codebase without needing a broader "unknown type" warning mechanism.

### 2. Annotation: the `existing` request-body field was undocumented (#1530)

Same endpoint, a different bug: `src/routes/api/stacks/[name]/validate/+server.ts` reads `body.existing` (an optional boolean) to decide whether to exclude the stack's own running containers/ports from the cross-stack collision checks:

```ts
const selfStackName = body.existing ? stackName : null;
```

`existing` is not cosmetic — without it (or with it `false`), the linter treats the stack's own containers as belonging to someone else and can report false-positive collisions against the stack currently being edited, exactly the case the endpoint's summary advertises as handled. It was missing from both the `body:` annotation and the generated spec.

Added `existing:boolean` to the `body:` line, plus a one-line `description:` explaining the true/omitted semantics.

## Test plan

- `tests/openapi-body-annotations.test.ts`:
  - Added `parseMiniSchema('object')` → now `{ kind: 'object', properties: {}, required: [] }` instead of `{ kind: 'string' }`.
  - Added a regression test using the real (now up to date) `body:` annotation string from this endpoint, asserting `severity`/`envVars` are object schemas and `existing` is a boolean.
  - Verified both `object`-related assertions fail (with the pre-fix `{ kind: 'string' }`) when the parser fix is reverted, and pass with it applied.
  - `existing:boolean` itself doesn't exercise new parser behavior (`boolean` was always handled correctly) — it's included in the test literal only to keep it in sync with the real annotation. No dedicated test/snapshot exists for the *generated* validate body schema (no such snapshot exists in this repo for any endpoint), so no additional test was added for the annotation-only change beyond keeping the existing literal accurate.
- `bun test tests/` — full suite: 2853 pass, 0 fail (no regressions).
- `npm run generate:openapi:check` — all 6 gates pass, 0 hard failures (100% coverage, no drift).
- `npx tsc --noEmit` on the three changed files shows no new type errors (3 pre-existing errors in the test file's later, unrelated `buildSpec` tests are unchanged before/after this diff).
- Deliberately did *not* regenerate/commit `static/openapi.json` — the committed copy on `main` is already stale by one release cycle (version field still says `1.0.45` vs. `package.json`'s `1.0.46`, plus several unrelated annotation changes since), and CI's `generate:openapi:check` only runs the drift gates, it doesn't diff against the committed static file. Regenerating it here would have produced ~150 lines of unrelated diff. That regeneration is presumably handled separately as part of release housekeeping (see e.g. `049221c`).

Closes #1530
Closes #1531

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
