### PR TITLE
docs(openapi): restore/preview requires backups:manage (fixes #1534)

### DIFF
--- a/src/lib/openapi.generated.json
+++ b/src/lib/openapi.generated.json
@@ -4301,7 +4301,7 @@
             "description": "Missing required fields (destinationId, snapshotId)"
           },
           "403": {
-            "description": "Permission denied (needs backups:view) or access denied to the target environment"
+            "description": "Permission denied (needs backups:manage) or access denied to the target environment"
           }
         },
         "security": [

--- a/src/routes/api/backup/restore/preview/+server.ts
+++ b/src/routes/api/backup/restore/preview/+server.ts
@@ -15,7 +15,7 @@ import { jobResult } from '$lib/server/sse';
  * resp-200: object
  * resp-200-desc: The snapshot preview, optionally with a resolved targets list
  * resp-400: Missing required fields (destinationId, snapshotId)
- * resp-403: Permission denied (needs backups:view) or access denied to the target environment
+ * resp-403: Permission denied (needs backups:manage) or access denied to the target environment
  */
 export const POST: RequestHandler = async ({ request, cookies }) => {
 	const auth = await authorize(cookies);

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -4301,7 +4301,7 @@
             "description": "Missing required fields (destinationId, snapshotId)"
           },
           "403": {
-            "description": "Permission denied (needs backups:view) or access denied to the target environment"
+            "description": "Permission denied (needs backups:manage) or access denied to the target environment"
           }
         },
         "security": [


### PR DESCRIPTION
## Proposed change

`POST /api/backup/restore/preview` (`src/routes/api/backup/restore/preview/+server.ts`) actually enforces `backups:manage`:

```ts
const rbacDenied = await requireBackups(auth, 'manage');
```

but the `@openapi` annotation's 403 line documented it as needing only `backups:view`:

```
resp-403: Permission denied (needs backups:view) or access denied to the target environment
```

This PR fixes the annotation to say `backups:manage`, matching the file's own convention for the parenthetical `(needs backups:X)` phrasing used by its sibling view-gated endpoints (`snapshots`, `snapshots/[id]/browse`, `snapshots/[id]/dump`). The generated `static/openapi.json` / `src/lib/openapi.generated.json` were regenerated for just this one description string (`npm run generate:openapi`, then hand-isolated to the single relevant line — running the generator against a fresh `npm install` on this repo produces unrelated pre-existing drift in the artifacts that isn't part of this fix).

Docs-only change; no handler logic touched.

Closes #1534

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain: