### PR TITLE
docs(openapi): document backupFlags/restoreFlags on destination create/update

### DIFF
--- a/src/lib/openapi.generated.json
+++ b/src/lib/openapi.generated.json
@@ -3603,6 +3603,12 @@
                   "flags": {
                     "type": "string"
                   },
+                  "backupFlags": {
+                    "type": "string"
+                  },
+                  "restoreFlags": {
+                    "type": "string"
+                  },
                   "hostPath": {
                     "type": "string"
                   },
@@ -3739,6 +3745,12 @@
                     "properties": {}
                   },
                   "flags": {
+                    "type": "string"
+                  },
+                  "backupFlags": {
+                    "type": "string"
+                  },
+                  "restoreFlags": {
                     "type": "string"
                   },
                   "hostPath": {

--- a/src/routes/api/backup/destinations/+server.ts
+++ b/src/routes/api/backup/destinations/+server.ts
@@ -65,7 +65,7 @@ export const GET: RequestHandler = async ({ cookies }) => {
  * @openapi
  * summary: Create a restic backup destination, auto-initialize and test the repository, and register its default maintenance schedules
  * description: Permission denial (403, "backups:manage") is produced by the shared requireBackups route guard.
- * body: {name:string!, repository:string!, password:string!, envVars:{}, flags:string, hostPath:string, cacert:string, tlsClientCert:string, policies:string}
+ * body: {name:string!, repository:string!, password:string!, envVars:{}, flags:string, backupFlags:string, restoreFlags:string, hostPath:string, cacert:string, tlsClientCert:string, policies:string}
  * body-example: {"name":"S3 Offsite","repository":"s3:s3.amazonaws.com/my-bucket/restic","password":"***","envVars":{"AWS_ACCESS_KEY_ID":"***","AWS_SECRET_ACCESS_KEY":"***"}}
  * resp-201: The created backup destination object (includes decrypted envVars since the caller just supplied them; password is stripped)
  * resp-400: Invalid input — missing name/repository/password, unsupported/SSRF-blocked repository, invalid restic flags, or an invalid cron schedule in the policies

--- a/src/routes/api/backup/destinations/[id]/+server.ts
+++ b/src/routes/api/backup/destinations/[id]/+server.ts
@@ -79,7 +79,7 @@ export const GET: RequestHandler = async ({ params, cookies }) => {
  * summary: Update a backup destination, re-validating repository and flags when supplied and re-registering maintenance schedules when policies change
  * description: Permission denial (403, "backups:manage") is produced by the shared requireBackups route guard.
  * path: id:integer! Backup destination id (from GET /api/backup/destinations)
- * body: {name:string, repository:string, password:string, envVars:{}, flags:string, hostPath:string, cacert:string, tlsClientCert:string, policies:string}
+ * body: {name:string, repository:string, password:string, envVars:{}, flags:string, backupFlags:string, restoreFlags:string, hostPath:string, cacert:string, tlsClientCert:string, policies:string}
  * body-example: {"name":"S3 Offsite (renamed)","policies":"{\"pruneEnabled\":true,\"pruneSchedule\":\"0 0 1 * *\"}"}
  * resp-200: The updated backup destination object (password stripped, envVars echoed back to the managing caller)
  * resp-400: Invalid input — invalid id, unsupported/SSRF-blocked repository, invalid restic flags, invalid policy cron, or switching to a local repository used by a remote-environment config

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -3603,6 +3603,12 @@
                   "flags": {
                     "type": "string"
                   },
+                  "backupFlags": {
+                    "type": "string"
+                  },
+                  "restoreFlags": {
+                    "type": "string"
+                  },
                   "hostPath": {
                     "type": "string"
                   },
@@ -3739,6 +3745,12 @@
                     "properties": {}
                   },
                   "flags": {
+                    "type": "string"
+                  },
+                  "backupFlags": {
+                    "type": "string"
+                  },
+                  "restoreFlags": {
                     "type": "string"
                   },
                   "hostPath": {


### PR DESCRIPTION
## Proposed change

Both backup-destination handlers prefer a split `backupFlags`/`restoreFlags` shape over the legacy single `flags` string, but their `@openapi body:` annotations only documented `flags:string`:

**`POST /api/backup/destinations`** (`src/routes/api/backup/destinations/+server.ts:91-100`):
```ts
flagsColumn = (body.backupFlags !== undefined || body.restoreFlags !== undefined)
    ? validateAndSerializeFlags(body.backupFlags, body.restoreFlags)
    : validateAndSerializeFlags(body.flags, '');
```

**`PUT /api/backup/destinations/{id}`** (`src/routes/api/backup/destinations/[id]/+server.ts:122-131`):
```ts
if (body.backupFlags !== undefined || body.restoreFlags !== undefined) {
    flagsColumn = validateAndSerializeFlags(body.backupFlags, body.restoreFlags);
} else if (body.flags !== undefined) {
    flagsColumn = validateAndSerializeFlags(body.flags, '');
}
```

`validateAndSerializeFlags(backup: unknown, restore: unknown)` (`src/lib/server/backups/helpers.ts:586`) coerces non-strings to `''`, so both fields are optional plain `string`s (a raw restic flag string, same shape as the existing `flags` field).

This PR adds `backupFlags:string, restoreFlags:string` to both `body:` annotations, matching the existing mini-schema syntax (`flags:string` sibling). The generated `static/openapi.json` / `src/lib/openapi.generated.json` are updated with just the two new schema properties at each of the two affected request-body schemas — hand-isolated after regeneration, since a full `npm run generate:openapi` on a fresh `npm install` also produces unrelated pre-existing drift in these artifacts.

Docs-only change; no handler logic touched.

Closes #1536

## Type of change

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain: