### PR TITLE
Per-stack/per-environment versioning for the compose YAML and env vars

### DIFF
--- a/drizzle-pg/0016_add_stack_versioning.sql
+++ b/drizzle-pg/0016_add_stack_versioning.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "stack_sources" ADD COLUMN "last_saved_at" text;--> statement-breakpoint
+ALTER TABLE "stack_sources" ADD COLUMN "last_deployed_at" text;

--- a/drizzle-pg/meta/0016_snapshot.json
+++ b/drizzle-pg/meta/0016_snapshot.json
@@ -1,0 +1,3599 @@
+{
+  "id": "61677a10-a05e-4350-8389-10ef5c376308",
+  "prevId": "3e5a7c91-2b4d-4f80-9a1c-6d8e0f2b4c5a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_tokens_user_id_idx": {
+          "name": "api_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_token_prefix_idx": {
+          "name": "api_tokens_token_prefix_idx",
+          "columns": [
+            {
+              "expression": "token_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_logs_user_id_idx": {
+          "name": "audit_logs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_environment_id_environments_id_fk": {
+          "name": "audit_logs_environment_id_environments_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_settings": {
+      "name": "auth_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auth_enabled": {
+          "name": "auth_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "default_provider": {
+          "name": "default_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'local'"
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_update_settings": {
+      "name": "auto_update_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'daily'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_criteria": {
+          "name": "vulnerability_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'never'"
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auto_update_settings_environment_id_environments_id_fk": {
+          "name": "auto_update_settings_environment_id_environments_id_fk",
+          "tableFrom": "auto_update_settings",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auto_update_settings_environment_id_container_name_unique": {
+          "name": "auto_update_settings_environment_id_container_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "environment_id",
+            "container_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backup_configs": {
+      "name": "backup_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'container'"
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "all_volumes": {
+          "name": "all_volumes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "selected_volumes": {
+          "name": "selected_volumes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_before_backup": {
+          "name": "stop_before_backup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retention": {
+          "name": "retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_backup_at": {
+          "name": "last_backup_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_backup_status": {
+          "name": "last_backup_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "backup_configs_environment_id_environments_id_fk": {
+          "name": "backup_configs_environment_id_environments_id_fk",
+          "tableFrom": "backup_configs",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "backup_configs_destination_id_backup_destinations_id_fk": {
+          "name": "backup_configs_destination_id_backup_destinations_id_fk",
+          "tableFrom": "backup_configs",
+          "tableTo": "backup_destinations",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backup_destinations": {
+      "name": "backup_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flags": {
+          "name": "flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_path": {
+          "name": "host_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cacert": {
+          "name": "cacert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls_client_cert": {
+          "name": "tls_client_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policies": {
+          "name": "policies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_test_at": {
+          "name": "last_test_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_test_status": {
+          "name": "last_test_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_test_error": {
+          "name": "last_test_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "backup_destinations_name_unique": {
+          "name": "backup_destinations_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.config_sets": {
+      "name": "config_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ports": {
+          "name": "ports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volumes": {
+          "name": "volumes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network_mode": {
+          "name": "network_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'bridge'"
+        },
+        "restart_policy": {
+          "name": "restart_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'no'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "config_sets_name_unique": {
+          "name": "config_sets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.container_events": {
+      "name": "container_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_attributes": {
+          "name": "actor_attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "container_events_env_timestamp_idx": {
+          "name": "container_events_env_timestamp_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "container_events_environment_id_environments_id_fk": {
+          "name": "container_events_environment_id_environments_id_fk",
+          "tableFrom": "container_events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.container_icon_overrides": {
+      "name": "container_icon_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "container_icon_overrides_environment_id_environments_id_fk": {
+          "name": "container_icon_overrides_environment_id_environments_id_fk",
+          "tableFrom": "container_icon_overrides",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "container_icon_overrides_container_name_environment_id_unique": {
+          "name": "container_icon_overrides_container_name_environment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "container_name",
+            "environment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment_notifications": {
+      "name": "environment_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "environment_notifications_environment_id_environments_id_fk": {
+          "name": "environment_notifications_environment_id_environments_id_fk",
+          "tableFrom": "environment_notifications",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environment_notifications_notification_id_notification_settings_id_fk": {
+          "name": "environment_notifications_notification_id_notification_settings_id_fk",
+          "tableFrom": "environment_notifications",
+          "tableTo": "notification_settings",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "environment_notifications_environment_id_notification_id_unique": {
+          "name": "environment_notifications_environment_id_notification_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "environment_id",
+            "notification_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environments": {
+      "name": "environments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2375
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'http'"
+        },
+        "tls_ca": {
+          "name": "tls_ca",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls_cert": {
+          "name": "tls_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls_key": {
+          "name": "tls_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls_skip_verify": {
+          "name": "tls_skip_verify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'globe'"
+        },
+        "collect_activity": {
+          "name": "collect_activity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "collect_metrics": {
+          "name": "collect_metrics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "highlight_changes": {
+          "name": "highlight_changes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'socket'"
+        },
+        "socket_path": {
+          "name": "socket_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/var/run/docker.sock'"
+        },
+        "hawser_token": {
+          "name": "hawser_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hawser_last_seen": {
+          "name": "hawser_last_seen",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hawser_agent_id": {
+          "name": "hawser_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hawser_agent_name": {
+          "name": "hawser_agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hawser_version": {
+          "name": "hawser_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hawser_capabilities": {
+          "name": "hawser_capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hawser_stacks_dir": {
+          "name": "hawser_stacks_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "environments_name_unique": {
+          "name": "environments_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_credentials": {
+      "name": "git_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssh_private_key": {
+          "name": "ssh_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssh_passphrase": {
+          "name": "ssh_passphrase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_credentials_name_unique": {
+          "name": "git_credentials_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_repositories": {
+      "name": "git_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'main'"
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compose_path": {
+          "name": "compose_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'docker-compose.yml'"
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_update": {
+          "name": "auto_update",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "auto_update_schedule": {
+          "name": "auto_update_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'daily'"
+        },
+        "auto_update_cron": {
+          "name": "auto_update_cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0 3 * * *'"
+        },
+        "webhook_enabled": {
+          "name": "webhook_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_commit": {
+          "name": "last_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "git_repositories_credential_id_git_credentials_id_fk": {
+          "name": "git_repositories_credential_id_git_credentials_id_fk",
+          "tableFrom": "git_repositories",
+          "tableTo": "git_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_repositories_name_unique": {
+          "name": "git_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_stacks": {
+      "name": "git_stacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compose_path": {
+          "name": "compose_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'docker-compose.yml'"
+        },
+        "env_file_path": {
+          "name": "env_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_update": {
+          "name": "auto_update",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "auto_update_schedule": {
+          "name": "auto_update_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'daily'"
+        },
+        "auto_update_cron": {
+          "name": "auto_update_cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0 3 * * *'"
+        },
+        "webhook_enabled": {
+          "name": "webhook_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_dir": {
+          "name": "context_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_on_deploy": {
+          "name": "build_on_deploy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "no_build_cache": {
+          "name": "no_build_cache",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "repull_images": {
+          "name": "repull_images",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "force_redeploy": {
+          "name": "force_redeploy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_commit": {
+          "name": "last_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_files": {
+          "name": "synced_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "git_stacks_environment_id_environments_id_fk": {
+          "name": "git_stacks_environment_id_environments_id_fk",
+          "tableFrom": "git_stacks",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_stacks_repository_id_git_repositories_id_fk": {
+          "name": "git_stacks_repository_id_git_repositories_id_fk",
+          "tableFrom": "git_stacks",
+          "tableTo": "git_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_stacks_stack_name_environment_id_unique": {
+          "name": "git_stacks_stack_name_environment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stack_name",
+            "environment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hawser_tokens": {
+      "name": "hawser_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hawser_tokens_environment_id_environments_id_fk": {
+          "name": "hawser_tokens_environment_id_environments_id_fk",
+          "tableFrom": "hawser_tokens",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hawser_tokens_token_unique": {
+          "name": "hawser_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_metrics": {
+      "name": "host_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_percent": {
+          "name": "cpu_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_percent": {
+          "name": "memory_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_used": {
+          "name": "memory_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_total": {
+          "name": "memory_total",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "host_metrics_env_timestamp_idx": {
+          "name": "host_metrics_env_timestamp_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "host_metrics_environment_id_environments_id_fk": {
+          "name": "host_metrics_environment_id_environments_id_fk",
+          "tableFrom": "host_metrics",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ldap_config": {
+      "name": "ldap_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(uid={{username}})'"
+        },
+        "username_attribute": {
+          "name": "username_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'uid'"
+        },
+        "email_attribute": {
+          "name": "email_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'mail'"
+        },
+        "display_name_attribute": {
+          "name": "display_name_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cn'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_group": {
+          "name": "admin_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls_enabled": {
+          "name": "tls_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "tls_ca": {
+          "name": "tls_ca",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_config": {
+      "name": "oidc_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'openid profile email'"
+        },
+        "username_claim": {
+          "name": "username_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'preferred_username'"
+        },
+        "email_claim": {
+          "name": "email_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'email'"
+        },
+        "display_name_claim": {
+          "name": "display_name_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'name'"
+        },
+        "admin_claim": {
+          "name": "admin_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_value": {
+          "name": "admin_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_mappings_claim": {
+          "name": "role_mappings_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'groups'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_container_updates": {
+      "name": "pending_container_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_image": {
+          "name": "current_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_image_update": {
+          "name": "has_image_update",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "newer_version": {
+          "name": "newer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pending_container_updates_environment_id_environments_id_fk": {
+          "name": "pending_container_updates_environment_id_environments_id_fk",
+          "tableFrom": "pending_container_updates",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_container_updates_environment_id_container_id_unique": {
+          "name": "pending_container_updates_environment_id_container_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "environment_id",
+            "container_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registries": {
+      "name": "registries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registries_name_unique": {
+          "name": "registries_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_ids": {
+          "name": "environment_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_executions": {
+      "name": "schedule_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logs": {
+          "name": "logs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedule_executions_type_id_idx": {
+          "name": "schedule_executions_type_id_idx",
+          "columns": [
+            {
+              "expression": "schedule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_executions_environment_id_environments_id_fk": {
+          "name": "schedule_executions_environment_id_environments_id_fk",
+          "tableFrom": "schedule_executions",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secret_providers": {
+      "name": "secret_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "secret_providers_name_unique": {
+          "name": "secret_providers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stack_environment_variables": {
+      "name": "stack_environment_variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stack_environment_variables_environment_id_environments_id_fk": {
+          "name": "stack_environment_variables_environment_id_environments_id_fk",
+          "tableFrom": "stack_environment_variables",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stack_environment_variables_stack_name_environment_id_key_unique": {
+          "name": "stack_environment_variables_stack_name_environment_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stack_name",
+            "environment_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stack_events": {
+      "name": "stack_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stack_events_environment_id_environments_id_fk": {
+          "name": "stack_events_environment_id_environments_id_fk",
+          "tableFrom": "stack_events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stack_sources": {
+      "name": "stack_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal'"
+        },
+        "git_repository_id": {
+          "name": "git_repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_stack_id": {
+          "name": "git_stack_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compose_path": {
+          "name": "compose_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env_path": {
+          "name": "env_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_provider_id": {
+          "name": "secret_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "injected_secret_keys": {
+          "name": "injected_secret_keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_saved_at": {
+          "name": "last_saved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_deployed_at": {
+          "name": "last_deployed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stack_sources_environment_id_environments_id_fk": {
+          "name": "stack_sources_environment_id_environments_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stack_sources_git_repository_id_git_repositories_id_fk": {
+          "name": "stack_sources_git_repository_id_git_repositories_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "git_repositories",
+          "columnsFrom": [
+            "git_repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stack_sources_git_stack_id_git_stacks_id_fk": {
+          "name": "stack_sources_git_stack_id_git_stacks_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "git_stacks",
+          "columnsFrom": [
+            "git_stack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stack_sources_secret_provider_id_secret_providers_id_fk": {
+          "name": "stack_sources_secret_provider_id_secret_providers_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "secret_providers",
+          "columnsFrom": [
+            "secret_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stack_sources_stack_name_environment_id_unique": {
+          "name": "stack_sources_stack_name_environment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stack_name",
+            "environment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template_sources": {
+      "name": "template_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "builtin": {
+          "name": "builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "template_sources_source_id_unique": {
+          "name": "template_sources_source_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preferences_environment_id_environments_id_fk": {
+          "name": "user_preferences_environment_id_environments_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_environment_id_key_unique": {
+          "name": "user_preferences_user_id_environment_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "environment_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_environment_id_environments_id_fk": {
+          "name": "user_roles_environment_id_environments_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_roles_user_id_role_id_environment_id_unique": {
+          "name": "user_roles_user_id_role_id_environment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "role_id",
+            "environment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'local'"
+        },
+        "mfa_enabled": {
+          "name": "mfa_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "mfa_secret": {
+          "name": "mfa_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vulnerability_scans": {
+      "name": "vulnerability_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_name": {
+          "name": "image_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanner": {
+          "name": "scanner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scan_duration": {
+          "name": "scan_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "critical_count": {
+          "name": "critical_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "high_count": {
+          "name": "high_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "medium_count": {
+          "name": "medium_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "low_count": {
+          "name": "low_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "negligible_count": {
+          "name": "negligible_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "unknown_count": {
+          "name": "unknown_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "vulnerabilities": {
+          "name": "vulnerabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vulnerability_scans_env_image_idx": {
+          "name": "vulnerability_scans_env_image_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vulnerability_scans_environment_id_environments_id_fk": {
+          "name": "vulnerability_scans_environment_id_environments_id_fk",
+          "tableFrom": "vulnerability_scans",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle-pg/meta/_journal.json
+++ b/drizzle-pg/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1788099526949,
       "tag": "0015_deploy_run_index",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1788347695433,
+      "tag": "0016_add_stack_versioning",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/0016_add_stack_versioning.sql
+++ b/drizzle/0016_add_stack_versioning.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `stack_sources` ADD `last_saved_at` text;--> statement-breakpoint
+ALTER TABLE `stack_sources` ADD `last_deployed_at` text;

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,3768 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "db61c2aa-7f06-4c3f-8c28-f65c8ac86e86",
+  "prevId": "7c8e1a20-9b4d-4f3a-8c2e-1f0a6b5d4e3c",
+  "tables": {
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "api_tokens_user_id_idx": {
+          "name": "api_tokens_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "api_tokens_token_prefix_idx": {
+          "name": "api_tokens_token_prefix_idx",
+          "columns": [
+            "token_prefix"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "audit_logs_user_id_idx": {
+          "name": "audit_logs_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_environment_id_environments_id_fk": {
+          "name": "audit_logs_environment_id_environments_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_settings": {
+      "name": "auth_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "auth_enabled": {
+          "name": "auth_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "default_provider": {
+          "name": "default_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 86400
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auto_update_settings": {
+      "name": "auto_update_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'daily'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vulnerability_criteria": {
+          "name": "vulnerability_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'never'"
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "auto_update_settings_environment_id_container_name_unique": {
+          "name": "auto_update_settings_environment_id_container_name_unique",
+          "columns": [
+            "environment_id",
+            "container_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "auto_update_settings_environment_id_environments_id_fk": {
+          "name": "auto_update_settings_environment_id_environments_id_fk",
+          "tableFrom": "auto_update_settings",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "backup_configs": {
+      "name": "backup_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'container'"
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "all_volumes": {
+          "name": "all_volumes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "selected_volumes": {
+          "name": "selected_volumes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stop_before_backup": {
+          "name": "stop_before_backup",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retention": {
+          "name": "retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "options": {
+          "name": "options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_backup_at": {
+          "name": "last_backup_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_backup_status": {
+          "name": "last_backup_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "backup_configs_environment_id_environments_id_fk": {
+          "name": "backup_configs_environment_id_environments_id_fk",
+          "tableFrom": "backup_configs",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "backup_configs_destination_id_backup_destinations_id_fk": {
+          "name": "backup_configs_destination_id_backup_destinations_id_fk",
+          "tableFrom": "backup_configs",
+          "tableTo": "backup_destinations",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "backup_destinations": {
+      "name": "backup_destinations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags": {
+          "name": "flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host_path": {
+          "name": "host_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cacert": {
+          "name": "cacert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tls_client_cert": {
+          "name": "tls_client_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policies": {
+          "name": "policies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_test_at": {
+          "name": "last_test_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_test_status": {
+          "name": "last_test_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_test_error": {
+          "name": "last_test_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "backup_destinations_name_unique": {
+          "name": "backup_destinations_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_sets": {
+      "name": "config_sets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ports": {
+          "name": "ports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "volumes": {
+          "name": "volumes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "network_mode": {
+          "name": "network_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'bridge'"
+        },
+        "restart_policy": {
+          "name": "restart_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'no'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "config_sets_name_unique": {
+          "name": "config_sets_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "container_events": {
+      "name": "container_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_attributes": {
+          "name": "actor_attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "container_events_env_timestamp_idx": {
+          "name": "container_events_env_timestamp_idx",
+          "columns": [
+            "environment_id",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "container_events_environment_id_environments_id_fk": {
+          "name": "container_events_environment_id_environments_id_fk",
+          "tableFrom": "container_events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "container_icon_overrides": {
+      "name": "container_icon_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "container_icon_overrides_container_name_environment_id_unique": {
+          "name": "container_icon_overrides_container_name_environment_id_unique",
+          "columns": [
+            "container_name",
+            "environment_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "container_icon_overrides_environment_id_environments_id_fk": {
+          "name": "container_icon_overrides_environment_id_environments_id_fk",
+          "tableFrom": "container_icon_overrides",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environment_notifications": {
+      "name": "environment_notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "environment_notifications_environment_id_notification_id_unique": {
+          "name": "environment_notifications_environment_id_notification_id_unique",
+          "columns": [
+            "environment_id",
+            "notification_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "environment_notifications_environment_id_environments_id_fk": {
+          "name": "environment_notifications_environment_id_environments_id_fk",
+          "tableFrom": "environment_notifications",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environment_notifications_notification_id_notification_settings_id_fk": {
+          "name": "environment_notifications_notification_id_notification_settings_id_fk",
+          "tableFrom": "environment_notifications",
+          "tableTo": "notification_settings",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 2375
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "tls_ca": {
+          "name": "tls_ca",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tls_cert": {
+          "name": "tls_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tls_key": {
+          "name": "tls_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tls_skip_verify": {
+          "name": "tls_skip_verify",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'globe'"
+        },
+        "collect_activity": {
+          "name": "collect_activity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "collect_metrics": {
+          "name": "collect_metrics",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "highlight_changes": {
+          "name": "highlight_changes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'socket'"
+        },
+        "socket_path": {
+          "name": "socket_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'/var/run/docker.sock'"
+        },
+        "hawser_token": {
+          "name": "hawser_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hawser_last_seen": {
+          "name": "hawser_last_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hawser_agent_id": {
+          "name": "hawser_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hawser_agent_name": {
+          "name": "hawser_agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hawser_version": {
+          "name": "hawser_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hawser_capabilities": {
+          "name": "hawser_capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hawser_stacks_dir": {
+          "name": "hawser_stacks_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "environments_name_unique": {
+          "name": "environments_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "git_credentials": {
+      "name": "git_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ssh_private_key": {
+          "name": "ssh_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ssh_passphrase": {
+          "name": "ssh_passphrase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "git_credentials_name_unique": {
+          "name": "git_credentials_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "git_repositories": {
+      "name": "git_repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'main'"
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compose_path": {
+          "name": "compose_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'docker-compose.yml'"
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_update": {
+          "name": "auto_update",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_update_schedule": {
+          "name": "auto_update_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'daily'"
+        },
+        "auto_update_cron": {
+          "name": "auto_update_cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'0 3 * * *'"
+        },
+        "webhook_enabled": {
+          "name": "webhook_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_commit": {
+          "name": "last_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "git_repositories_name_unique": {
+          "name": "git_repositories_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "git_repositories_credential_id_git_credentials_id_fk": {
+          "name": "git_repositories_credential_id_git_credentials_id_fk",
+          "tableFrom": "git_repositories",
+          "tableTo": "git_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "git_stacks": {
+      "name": "git_stacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compose_path": {
+          "name": "compose_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'docker-compose.yml'"
+        },
+        "env_file_path": {
+          "name": "env_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_update": {
+          "name": "auto_update",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_update_schedule": {
+          "name": "auto_update_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'daily'"
+        },
+        "auto_update_cron": {
+          "name": "auto_update_cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'0 3 * * *'"
+        },
+        "webhook_enabled": {
+          "name": "webhook_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_dir": {
+          "name": "context_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "build_on_deploy": {
+          "name": "build_on_deploy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "no_build_cache": {
+          "name": "no_build_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "repull_images": {
+          "name": "repull_images",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "force_redeploy": {
+          "name": "force_redeploy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_commit": {
+          "name": "last_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_files": {
+          "name": "synced_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "git_stacks_stack_name_environment_id_unique": {
+          "name": "git_stacks_stack_name_environment_id_unique",
+          "columns": [
+            "stack_name",
+            "environment_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "git_stacks_environment_id_environments_id_fk": {
+          "name": "git_stacks_environment_id_environments_id_fk",
+          "tableFrom": "git_stacks",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_stacks_repository_id_git_repositories_id_fk": {
+          "name": "git_stacks_repository_id_git_repositories_id_fk",
+          "tableFrom": "git_stacks",
+          "tableTo": "git_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hawser_tokens": {
+      "name": "hawser_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hawser_tokens_token_unique": {
+          "name": "hawser_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "hawser_tokens_environment_id_environments_id_fk": {
+          "name": "hawser_tokens_environment_id_environments_id_fk",
+          "tableFrom": "hawser_tokens",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_metrics": {
+      "name": "host_metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cpu_percent": {
+          "name": "cpu_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_percent": {
+          "name": "memory_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_used": {
+          "name": "memory_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memory_total": {
+          "name": "memory_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "host_metrics_env_timestamp_idx": {
+          "name": "host_metrics_env_timestamp_idx",
+          "columns": [
+            "environment_id",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "host_metrics_environment_id_environments_id_fk": {
+          "name": "host_metrics_environment_id_environments_id_fk",
+          "tableFrom": "host_metrics",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ldap_config": {
+      "name": "ldap_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'(uid={{username}})'"
+        },
+        "username_attribute": {
+          "name": "username_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'uid'"
+        },
+        "email_attribute": {
+          "name": "email_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'mail'"
+        },
+        "display_name_attribute": {
+          "name": "display_name_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'cn'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_group": {
+          "name": "admin_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tls_enabled": {
+          "name": "tls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "tls_ca": {
+          "name": "tls_ca",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_settings": {
+      "name": "notification_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oidc_config": {
+      "name": "oidc_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'openid profile email'"
+        },
+        "username_claim": {
+          "name": "username_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'preferred_username'"
+        },
+        "email_claim": {
+          "name": "email_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "display_name_claim": {
+          "name": "display_name_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'name'"
+        },
+        "admin_claim": {
+          "name": "admin_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_value": {
+          "name": "admin_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role_mappings_claim": {
+          "name": "role_mappings_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'groups'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pending_container_updates": {
+      "name": "pending_container_updates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_image": {
+          "name": "current_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "has_image_update": {
+          "name": "has_image_update",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "newer_version": {
+          "name": "newer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "pending_container_updates_environment_id_container_id_unique": {
+          "name": "pending_container_updates_environment_id_container_id_unique",
+          "columns": [
+            "environment_id",
+            "container_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pending_container_updates_environment_id_environments_id_fk": {
+          "name": "pending_container_updates_environment_id_environments_id_fk",
+          "tableFrom": "pending_container_updates",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "registries": {
+      "name": "registries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "registries_name_unique": {
+          "name": "registries_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_ids": {
+          "name": "environment_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedule_executions": {
+      "name": "schedule_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logs": {
+          "name": "logs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "schedule_executions_type_id_idx": {
+          "name": "schedule_executions_type_id_idx",
+          "columns": [
+            "schedule_type",
+            "schedule_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedule_executions_environment_id_environments_id_fk": {
+          "name": "schedule_executions_environment_id_environments_id_fk",
+          "tableFrom": "schedule_executions",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_providers": {
+      "name": "secret_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "secret_providers_name_unique": {
+          "name": "secret_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stack_environment_variables": {
+      "name": "stack_environment_variables",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "stack_environment_variables_stack_name_environment_id_key_unique": {
+          "name": "stack_environment_variables_stack_name_environment_id_key_unique",
+          "columns": [
+            "stack_name",
+            "environment_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "stack_environment_variables_environment_id_environments_id_fk": {
+          "name": "stack_environment_variables_environment_id_environments_id_fk",
+          "tableFrom": "stack_environment_variables",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stack_events": {
+      "name": "stack_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stack_events_environment_id_environments_id_fk": {
+          "name": "stack_events_environment_id_environments_id_fk",
+          "tableFrom": "stack_events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stack_sources": {
+      "name": "stack_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "git_repository_id": {
+          "name": "git_repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_stack_id": {
+          "name": "git_stack_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compose_path": {
+          "name": "compose_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_path": {
+          "name": "env_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secret_provider_id": {
+          "name": "secret_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "injected_secret_keys": {
+          "name": "injected_secret_keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_saved_at": {
+          "name": "last_saved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_deployed_at": {
+          "name": "last_deployed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "stack_sources_stack_name_environment_id_unique": {
+          "name": "stack_sources_stack_name_environment_id_unique",
+          "columns": [
+            "stack_name",
+            "environment_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "stack_sources_environment_id_environments_id_fk": {
+          "name": "stack_sources_environment_id_environments_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stack_sources_git_repository_id_git_repositories_id_fk": {
+          "name": "stack_sources_git_repository_id_git_repositories_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "git_repositories",
+          "columnsFrom": [
+            "git_repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stack_sources_git_stack_id_git_stacks_id_fk": {
+          "name": "stack_sources_git_stack_id_git_stacks_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "git_stacks",
+          "columnsFrom": [
+            "git_stack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stack_sources_secret_provider_id_secret_providers_id_fk": {
+          "name": "stack_sources_secret_provider_id_secret_providers_id_fk",
+          "tableFrom": "stack_sources",
+          "tableTo": "secret_providers",
+          "columnsFrom": [
+            "secret_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "template_sources": {
+      "name": "template_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "builtin": {
+          "name": "builtin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "template_sources_source_id_unique": {
+          "name": "template_sources_source_id_unique",
+          "columns": [
+            "source_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_preferences": {
+      "name": "user_preferences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_preferences_user_id_environment_id_key_unique": {
+          "name": "user_preferences_user_id_environment_id_key_unique",
+          "columns": [
+            "user_id",
+            "environment_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_preferences_environment_id_environments_id_fk": {
+          "name": "user_preferences_environment_id_environments_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_roles": {
+      "name": "user_roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_roles_user_id_role_id_environment_id_unique": {
+          "name": "user_roles_user_id_role_id_environment_id_unique",
+          "columns": [
+            "user_id",
+            "role_id",
+            "environment_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_environment_id_environments_id_fk": {
+          "name": "user_roles_environment_id_environments_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "mfa_enabled": {
+          "name": "mfa_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "mfa_secret": {
+          "name": "mfa_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vulnerability_scans": {
+      "name": "vulnerability_scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_name": {
+          "name": "image_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scanner": {
+          "name": "scanner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_duration": {
+          "name": "scan_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "critical_count": {
+          "name": "critical_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "high_count": {
+          "name": "high_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "medium_count": {
+          "name": "medium_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "low_count": {
+          "name": "low_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "negligible_count": {
+          "name": "negligible_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unknown_count": {
+          "name": "unknown_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "vulnerabilities": {
+          "name": "vulnerabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "vulnerability_scans_env_image_idx": {
+          "name": "vulnerability_scans_env_image_idx",
+          "columns": [
+            "environment_id",
+            "image_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "vulnerability_scans_environment_id_environments_id_fk": {
+          "name": "vulnerability_scans_environment_id_environments_id_fk",
+          "tableFrom": "vulnerability_scans",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1788099517358,
       "tag": "0015_deploy_run_index",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1788347662633,
+      "tag": "0016_add_stack_versioning",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/emergency/fresh-postgres-migrate-check.sh
+++ b/scripts/emergency/fresh-postgres-migrate-check.sh
@@ -1,0 +1,154 @@
+#!/bin/sh
+#
+# Operational fresh-Postgres migration check (S01 exit criterion, part c).
+#
+# Spins up a DISPOSITIONABLE (fresh, empty) Postgres, applies the drizzle-pg
+# migrations through the APP'S PG MIGRATE PATH (drizzle-orm/postgres-js/migrator —
+# the exact same call the app makes in db/drizzle.ts), and asserts that
+# stack_sources gained last_saved_at / last_deployed_at on a FRESH database.
+#
+# This is the definitive fresh-Postgres proof that the dual-DB migration applies
+# without drift. It is operational (needs docker + a fresh Postgres) and is NOT
+# runnable under bun test — tests/stack-versioning.test.ts covers the CI-runnable
+# halves (fresh-SQLite apply + PG lockstep parity) instead.
+#
+# Usage:
+#   ./scripts/emergency/fresh-postgres-migrate-check.sh
+#
+# Requirements: docker, a Node runtime (NODE_BIN, default: node) run from the
+# repo root, and drizzle-orm + postgres installed (project deps).
+#
+# Env overrides:
+#   PG_IMAGE     postgres image to pull (default: postgres:16)
+#   PG_PORT      host port to publish  (default: 54331)
+#   PG_USER      (default: postgres)
+#   PG_PASSWORD  (default: dockhand)
+#   PG_DB        (default: dockhand)
+#   NODE_BIN     node binary          (default: node)
+#   KEEP_PG=1    leave the container running for inspection (no auto-teardown)
+
+set -eu
+
+SCRIPT_DIR="$(dirname "$0")"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PG_IMAGE="${PG_IMAGE:-postgres:16}"
+PG_PORT="${PG_PORT:-54331}"
+PG_USER="${PG_USER:-postgres}"
+PG_PASSWORD="${PG_PASSWORD:-dockhand}"
+PG_DB="${PG_DB:-dockhand}"
+NODE_BIN="${NODE_BIN:-node}"
+
+CTN="dockhand-fresh-pg-$$"
+DATABASE_URL="postgres://${PG_USER}:${PG_PASSWORD}@127.0.0.1:${PG_PORT}/${PG_DB}"
+
+cleanup() {
+	if [ "${KEEP_PG:-0}" != "1" ]; then
+		docker rm -f "$CTN" >/dev/null 2>&1 || true
+	fi
+}
+trap cleanup EXIT
+
+echo "========================================"
+echo "  Dockhand - fresh-Postgres migration check"
+echo "========================================"
+echo "image:    $PG_IMAGE"
+echo "port:     $PG_PORT"
+echo "container: $CTN"
+echo "database: ${PG_DB}@127.0.0.1:${PG_PORT}"
+echo ""
+
+# 1. Start a fresh, empty, disposable Postgres.
+docker rm -f "$CTN" >/dev/null 2>&1 || true
+docker run -d --name "$CTN" \
+	-e POSTGRES_USER="$PG_USER" \
+	-e POSTGRES_PASSWORD="$PG_PASSWORD" \
+	-e POSTGRES_DB="$PG_DB" \
+	-p "$PG_PORT:5432" \
+	"$PG_IMAGE" >/dev/null
+
+# 2. Wait until Postgres accepts connections.
+echo "-- waiting for Postgres to become ready --"
+READY=0
+for _ in $(seq 1 90); do
+	if docker exec "$CTN" pg_isready -U "$PG_USER" -d "$PG_DB" >/dev/null 2>&1; then
+		READY=1
+		break
+	fi
+	sleep 1
+done
+if [ "$READY" != "1" ]; then
+	echo "ERROR: fresh Postgres did not become ready within 90s"
+	docker logs "$CTN" 2>&1 | tail -20
+	exit 1
+fi
+
+# 3. Apply the drizzle-pg migrations via the app's PG migrate path, then assert the
+#    pointer columns exist on the fresh database.
+echo "-- applying drizzle-pg migrations via the app's PG migrate path --"
+cd "$REPO_ROOT"
+MIGRATIONS_FOLDER="$REPO_ROOT/drizzle-pg" DATABASE_URL="$DATABASE_URL" \
+"$NODE_BIN" --input-type=module - <<'NODE'
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { migrate } from 'drizzle-orm/postgres-js/migrator';
+
+const url = process.env.DATABASE_URL;
+const folder = process.env.MIGRATIONS_FOLDER;
+if (!url || !folder) {
+	console.error('ERROR: DATABASE_URL and MIGRATIONS_FOLDER must be set');
+	process.exit(1);
+}
+
+const sql = postgres(url, { max: 1, connect_timeout: 10, onnotice: () => {} });
+const db = drizzle(sql);
+let ok = false;
+
+try {
+	// The app's PG migrate path (db/drizzle.ts): migrate the fresh DB from the
+	// drizzle-pg journal. A fresh DB has no _drizzle_migrations rows, so every
+	// migration applies — any drift in a migration file fails here.
+	await migrate(db, { migrationsFolder: folder });
+
+	// Confirm the app's migrate path created its tracking table (proves the
+	// journal-driven migrate actually ran, not a no-op). drizzle's PG migrator
+	// uses __drizzle_migrations by default.
+	const tracking = await sql`
+		SELECT table_schema || '.' || table_name AS t
+		FROM information_schema.tables
+		WHERE table_name = '__drizzle_migrations'
+	`;
+	if (tracking.length > 0) {
+		console.log(`migrate OK: tracking table ${tracking[0].t} present (migrations recorded)`);
+	}
+
+	// Assert the pointer columns exist on the fresh stack_sources table.
+	const cols = await sql`
+		SELECT column_name FROM information_schema.columns
+		WHERE table_name = 'stack_sources'
+		  AND column_name IN ('last_saved_at', 'last_deployed_at')
+		ORDER BY column_name
+	`;
+	const found = cols.map((r) => r.column_name);
+	if (found.length !== 2 || !found.includes('last_saved_at') || !found.includes('last_deployed_at')) {
+		console.error(`FAIL: expected last_saved_at + last_deployed_at, found: ${found.join(', ') || '(none)'}`);
+		process.exitCode = 2;
+	} else {
+		console.log(`fresh stack_sources columns present: ${found.join(', ')}`);
+		ok = true;
+	}
+} catch (e) {
+	console.error(`FAIL: ${e instanceof Error ? e.message : String(e)}`);
+	process.exitCode = 2;
+} finally {
+	await sql.end({ timeout: 5 }).catch(() => {});
+}
+
+process.exit(ok ? 0 : 1);
+NODE
+
+if [ "$?" -eq 0 ]; then
+	echo ""
+	echo "OK: fresh-Postgres migration check passed — drizzle-pg applies cleanly and"
+	echo "    stack_sources has last_saved_at and last_deployed_at on a fresh database."
+fi

--- a/src/lib/components/StackEnvVarsPanel.svelte
+++ b/src/lib/components/StackEnvVarsPanel.svelte
@@ -406,9 +406,6 @@
 			<!-- Actions - right-aligned -->
 			{#if !readonly}
 				<div class="flex items-center gap-1 shrink-0">
-					{#if headerActions}
-						{@render headerActions()}
-					{/if}
 					<Button type="button" size="sm" variant="ghost" onclick={handleLoadFromFile} class="h-6 text-xs px-2">
 						<Upload class="w-3.5 h-3.5" />
 						Load
@@ -441,6 +438,9 @@
 							</Button>
 						{/snippet}
 					</ConfirmPopover>
+					{#if headerActions}
+						{@render headerActions()}
+					{/if}
 				</div>
 				<input
 					bind:this={fileInputRef}

--- a/src/lib/components/StackHistoryPanel.svelte
+++ b/src/lib/components/StackHistoryPanel.svelte
@@ -71,9 +71,10 @@
 	let lastSavedAt = $state<string | null>(null);
 	let lastDeployedAt = $state<string | null>(null);
 	let currentVersionId = $state<string | null>(null);
+	let deployStartedAt = $state<string | null>(null);
 	let revertingId = $state<string | null>(null);
 
-	const status = $derived<HistoryStatus>(historyStatus(versions, lastSavedAt, lastDeployedAt));
+	const status = $derived<HistoryStatus>(historyStatus(versions, lastSavedAt, lastDeployedAt, deployStartedAt));
 
 	// Fetch fresh data each time the popover opens (a cheap single GET).
 	$effect(() => {
@@ -86,7 +87,7 @@
 		try {
 			const target = appendEnvParam(`/api/stacks/${encodeURIComponent(stackName)}/history?type=${type}`, envId);
 			const res = await fetch(target);
-			const data: { error?: string; versions?: StackVersionRef[]; lastSavedAt?: string | null; lastDeployedAt?: string | null; currentVersionId?: string | null } =
+			const data: { error?: string; versions?: StackVersionRef[]; lastSavedAt?: string | null; lastDeployedAt?: string | null; currentVersionId?: string | null; deployStartedAt?: string | null } =
 				await res.json();
 			if (!res.ok) {
 				throw new Error(typeof data.error === 'string' ? data.error : `Failed to load ${type} history (HTTP ${res.status})`);
@@ -95,6 +96,7 @@
 			lastSavedAt = data.lastSavedAt ?? null;
 			lastDeployedAt = data.lastDeployedAt ?? null;
 			currentVersionId = data.currentVersionId ?? null;
+			deployStartedAt = data.deployStartedAt ?? null;
 		} catch (e) {
 			error = e instanceof Error ? e.message : 'Failed to load history';
 			console.error('Error loading stack history:', e);
@@ -128,8 +130,11 @@
 	}
 
 	function isUndeployed(v: StackVersionRef): boolean {
-		if (lastDeployedAt === null) return false;
-		const d = new Date(lastDeployedAt).getTime();
+		// Effective deploy reference: the pointer when set, else the runtime
+		// external-deploy reference (oldest running container's creation time).
+		const ref = lastDeployedAt ?? deployStartedAt;
+		if (ref === null) return false;
+		const d = new Date(ref).getTime();
 		const t = new Date(v.timestamp).getTime();
 		return !Number.isNaN(t) && !Number.isNaN(d) && t > d;
 	}
@@ -162,6 +167,12 @@
 				};
 			case 'never-deployed':
 				return { cls: 'text-zinc-500 dark:text-zinc-400', icon: Circle, label: 'Not yet deployed' };
+			case 'running-unsaved':
+				return {
+					cls: 'text-amber-600 dark:text-amber-400',
+					icon: AlertCircle,
+					label: 'Running - deployed content never saved'
+				};
 			case 'empty':
 				return { cls: 'text-zinc-400 dark:text-zinc-500', icon: Circle, label: 'No versions' };
 			default:
@@ -224,13 +235,23 @@
 					{#if dirty}
 						<Badge variant="outline" class="border-amber-500/40 text-amber-600 dark:text-amber-400 text-[10px] px-1.5 py-0">unsaved changes</Badge>
 				{/if}
-					{#if lastSavedAt || lastDeployedAt}
+					{#if lastSavedAt || lastDeployedAt || deployStartedAt}
 						<span>
 							Saved: {lastSavedAt ? formatRelativeTime(lastSavedAt) : 'never'}
 						</span>
-						<span>
-							Deployed: {lastDeployedAt ? formatRelativeTime(lastDeployedAt) : 'never'}
-						</span>
+						{#if lastDeployedAt}
+							<span>
+								Deployed: {formatRelativeTime(lastDeployedAt)}
+							</span>
+						{:else if deployStartedAt}
+							<span title="Deployed outside Dockhand (docker CLI / compose up) - detected from the running container, not a Dockhand deploy record.">
+								Deployed: {formatRelativeTime(deployStartedAt)} (external)
+							</span>
+						{:else}
+							<span>
+								Deployed: never
+							</span>
+						{/if}
 					{/if}
 				</div>
 			{/if}

--- a/src/lib/components/StackHistoryPanel.svelte
+++ b/src/lib/components/StackHistoryPanel.svelte
@@ -1,0 +1,295 @@
+<script lang="ts">
+	/**
+	 * Self-contained "History" widget for one stack + one version type (M001 S05).
+	 *
+	 * Mirrors RedeployPopover.svelte: a compact ghost trigger (lucide History icon)
+	 * wrapped in a bits-ui Popover. Opening the popover fetches the S04
+	 * GET /api/stacks/[name]/history?type=<type> (secret-free version list + the
+	 * last_saved_at / last_deployed_at pointers) and renders a saved-vs-deployed
+	 * indicator over a newest-first list with a per-row Revert (POST action:'revert').
+	 *
+	 * `type` is a fixed prop (the compose History button passes 'compose', the env
+	 * History button passes 'env') - there is no internal type toggle. The API returns
+	 * a secret-free list with NO content, so this is a list + revert surface, not a
+	 * diff/content-preview surface. `readonly` disables Revert (viewing is always allowed).
+	 */
+	import * as Popover from '$lib/components/ui/popover';
+	import { Button } from '$lib/components/ui/button';
+	import { Badge } from '$lib/components/ui/badge';
+	import { History, RotateCcw, Loader2, Clock, Check, AlertCircle, Circle } from 'lucide-svelte';
+	import { appendEnvParam } from '$lib/stores/environment';
+	import { formatRelativeTime, formatDateTime } from '$lib/stores/settings';
+	import { historyStatus, type StackVersionRef, type HistoryStatus } from '$lib/utils/stack-history';
+
+	interface Props {
+		stackName: string;
+		envId: number | null;
+		type: 'compose' | 'env';
+		readonly?: boolean;
+		side?: 'top' | 'bottom';
+		align?: 'start' | 'center' | 'end';
+		/** Optional text rendered next to the History icon (defaults to icon-only). */
+		label?: string;
+
+		/** Match the muted icon tone of the path-bar action buttons (text-zinc-500 / dark:text-zinc-400). */
+		muted?: boolean;
+
+		/** Extra tone classes for the labeled trigger (e.g. match the Validate/Copy ghost buttons). */
+		toneClass?: string;
+
+		/**
+		 * Whether the host editor for this type has UNSAVED changes. When true the
+		 * editor no longer matches any recorded version, so the "current" row badge
+		 * is hidden and an amber "unsaved changes" chip is shown in the pointers row.
+		 * When false, the row whose timestamp matches last_saved_at gets a "current"
+		 * badge - i.e. the version the editor currently displays (save advances the
+		 * pointer, revert points it at the reverted version).
+		 */
+		dirty?: boolean;
+
+		/** Called after a successful revert so the host can re-read the reverted content in place. */
+		onreverted?: (type: 'compose' | 'env') => void;
+	}
+	let {
+		stackName,
+		envId,
+		type,
+		readonly = false,
+		side = 'bottom',
+		align = 'end',
+		label = '',
+		muted = false,
+		toneClass = '',
+		dirty = false,
+		onreverted,
+	}: Props = $props();
+
+	let open = $state(false);
+	let loading = $state(false);
+	let error = $state<string | null>(null);
+	let versions = $state<StackVersionRef[]>([]);
+	let lastSavedAt = $state<string | null>(null);
+	let lastDeployedAt = $state<string | null>(null);
+	let currentVersionId = $state<string | null>(null);
+	let revertingId = $state<string | null>(null);
+
+	const status = $derived<HistoryStatus>(historyStatus(versions, lastSavedAt, lastDeployedAt));
+
+	// Fetch fresh data each time the popover opens (a cheap single GET).
+	$effect(() => {
+		if (open) void load();
+	});
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			const target = appendEnvParam(`/api/stacks/${encodeURIComponent(stackName)}/history?type=${type}`, envId);
+			const res = await fetch(target);
+			const data: { error?: string; versions?: StackVersionRef[]; lastSavedAt?: string | null; lastDeployedAt?: string | null; currentVersionId?: string | null } =
+				await res.json();
+			if (!res.ok) {
+				throw new Error(typeof data.error === 'string' ? data.error : `Failed to load ${type} history (HTTP ${res.status})`);
+			}
+			versions = data.versions ?? [];
+			lastSavedAt = data.lastSavedAt ?? null;
+			lastDeployedAt = data.lastDeployedAt ?? null;
+			currentVersionId = data.currentVersionId ?? null;
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load history';
+			console.error('Error loading stack history:', e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function revert(versionId: string) {
+		revertingId = versionId;
+		try {
+			const target = appendEnvParam(`/api/stacks/${encodeURIComponent(stackName)}/history`, envId);
+			const res = await fetch(target, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ action: 'revert', type, versionId })
+			});
+			const data: { error?: string } = await res.json();
+			if (!res.ok) {
+				throw new Error(typeof data.error === 'string' ? data.error : `Revert failed (HTTP ${res.status})`);
+			}
+			// last_saved_at advanced on a successful revert -> refresh list + pointers.
+			await load();
+			onreverted?.(type);
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Revert failed';
+			console.error('Error reverting stack version:', e);
+		} finally {
+			revertingId = null;
+		}
+	}
+
+	function isUndeployed(v: StackVersionRef): boolean {
+		if (lastDeployedAt === null) return false;
+		const d = new Date(lastDeployedAt).getTime();
+		const t = new Date(v.timestamp).getTime();
+		return !Number.isNaN(t) && !Number.isNaN(d) && t > d;
+	}
+
+	/**
+	 * Whether a row is the version the editor currently displays. Primary source:
+	 * `currentVersionId` from the history API - the newest version whose content
+	 * equals the LIVE source for this type (a shared last_saved_at pointer cannot
+	 * identify this per type: one column serves both compose and env). Fallback
+	 * (server returned null, e.g. live source missing): the row the last_saved_at
+	 * pointer references. Suppressed while the editor is dirty (content matches no
+	 * version).
+	 */
+	function isCurrent(v: StackVersionRef): boolean {
+		if (dirty) return false;
+		if (currentVersionId !== null) return v.id === currentVersionId;
+		return lastSavedAt !== null && (v.timestamp === lastSavedAt || v.id === lastSavedAt);
+	}
+
+	// Indicator presentation mapping: state -> { cls, icon, label }.
+	function indicatorFor(status: HistoryStatus): { cls: string; icon: any; label: string } {
+		switch (status.state) {
+			case 'in-sync':
+				return { cls: 'text-emerald-600 dark:text-emerald-400', icon: Check, label: 'In sync' };
+			case 'undeployed':
+				return {
+					cls: 'text-amber-600 dark:text-amber-400',
+					icon: AlertCircle,
+					label: status.undeployedCount === 1 ? '1 unsaved change' : `${status.undeployedCount} unsaved changes`
+				};
+			case 'never-deployed':
+				return { cls: 'text-zinc-500 dark:text-zinc-400', icon: Circle, label: 'Not yet deployed' };
+			case 'empty':
+				return { cls: 'text-zinc-400 dark:text-zinc-500', icon: Circle, label: 'No versions' };
+			default:
+				return { cls: 'text-zinc-400', icon: Circle, label: '' };
+		}
+	}
+</script>
+
+<Popover.Root bind:open>
+	<Popover.Trigger asChild>
+		{#snippet child({ props })}
+			{#if label}
+				<Button
+					type="button"
+					variant="ghost"
+					size="sm"
+					{...props}
+					class="h-6 px-2 text-xs {toneClass}"
+					title={`${type === 'compose' ? 'Compose' : 'Env'} version history`}
+					aria-label={`${type === 'compose' ? 'Compose' : 'Env'} version history`}
+				>
+					<History class="w-3.5 h-3.5" />
+					{label}
+				</Button>
+				{:else}
+				<button
+					type="button"
+					{...props}
+					class="px-1.5 py-1 rounded hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors cursor-pointer inline-flex items-center gap-1 {muted ? 'text-zinc-500 dark:text-zinc-400' : ''}"
+					title={`${type === 'compose' ? 'Compose' : 'Env'} version history`}
+					aria-label={`${type === 'compose' ? 'Compose' : 'Env'} version history`}
+				>
+					<History class="w-3.5 h-3.5 shrink-0" />
+				</button>
+			{/if}
+		{/snippet}
+	</Popover.Trigger>
+
+	<Popover.Content class="w-80 p-0 z-[200]" {side} {align} sideOffset={8}>
+		<div class="space-y-3">
+			<!-- Header + saved-vs-deployed indicator -->
+			<div class="px-3 py-2 border-b border-zinc-200 dark:border-zinc-700 flex items-center gap-2">
+				<span class="text-xs font-medium flex-1">{type === 'compose' ? 'Compose' : 'Env'} history</span>
+				<!-- Indicator (only meaningful once a fetch has settled) -->
+				{#if loading}
+					<span class="text-[11px] text-zinc-400 dark:text-zinc-500">loading…</span>
+				{:else if error === null}
+					{@const indicator = indicatorFor(status)}
+					{@const Icon = indicator.icon}
+					<span class="inline-flex items-center gap-1 text-[11px] {indicator.cls}">
+						<Icon class="w-3 h-3" />
+						{indicator.label}
+					</span>
+				{/if}
+			</div>
+
+			<!-- Pointers (last saved / last deployed) + editor state -->
+			{#if !loading && error === null && (lastSavedAt || lastDeployedAt || dirty)}
+				<div class="px-3 flex items-center gap-3 text-[11px] text-zinc-500 dark:text-zinc-400">
+					{#if dirty}
+						<Badge variant="outline" class="border-amber-500/40 text-amber-600 dark:text-amber-400 text-[10px] px-1.5 py-0">unsaved changes</Badge>
+				{/if}
+					{#if lastSavedAt || lastDeployedAt}
+						<span>
+							Saved: {lastSavedAt ? formatRelativeTime(lastSavedAt) : 'never'}
+						</span>
+						<span>
+							Deployed: {lastDeployedAt ? formatRelativeTime(lastDeployedAt) : 'never'}
+						</span>
+					{/if}
+				</div>
+			{/if}
+
+			<!-- Body: loading / error / empty / list -->
+			<div class="px-3 py-2">
+				{#if loading}
+					<div class="flex items-center justify-center gap-2 py-6 text-zinc-400 dark:text-zinc-500">
+						<Loader2 class="w-4 h-4 animate-spin" />
+						<span class="text-xs">Loading history…</span>
+					</div>
+				{:else if error !== null}
+					<div class="flex flex-col items-center gap-2 py-6 text-center">
+						<AlertCircle class="w-5 h-5 text-red-500" />
+						<p class="text-xs text-red-600 dark:text-red-400 max-w-[16rem]">{error}</p>
+						<Button variant="outline" size="sm" class="h-7 text-xs" onclick={() => void load()}>
+							Retry
+						</Button>
+					</div>
+				{:else if versions.length === 0}
+					<div class="flex flex-col items-center gap-2 py-6 text-center">
+						<Circle class="w-5 h-5 text-zinc-300 dark:text-zinc-600" />
+						<p class="text-xs text-zinc-500 dark:text-zinc-400">No saved versions yet.</p>
+					</div>
+				{:else}
+					<ul class="space-y-0.5 max-h-72 overflow-y-auto">
+						{#each versions as v (v.id)}
+							<li class="flex items-center gap-2 rounded px-1.5 py-1 hover:bg-zinc-100 dark:hover:bg-zinc-800/40">
+								<Clock class="w-3 h-3 text-zinc-400 dark:text-zinc-500 shrink-0" />
+								<span class="text-xs flex-1 text-zinc-600 dark:text-zinc-300 truncate" title={formatDateTime(v.timestamp)}>
+									{formatRelativeTime(v.timestamp)}
+								</span>
+								{#if v.id === status.deployedVersionId}
+									<Badge variant="outline" class="border-emerald-500/40 text-emerald-600 dark:text-emerald-400 text-[10px] px-1.5 py-0">deployed</Badge>
+								{:else if isUndeployed(v)}
+									<Badge variant="outline" class="border-amber-500/40 text-amber-600 dark:text-amber-400 text-[10px] px-1.5 py-0">unsaved</Badge>
+								{/if}
+								{#if isCurrent(v)}
+									<Badge variant="outline" class="border-emerald-500/60 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 text-[10px] px-1.5 py-0">current</Badge>
+								{/if}
+								<Button
+									variant="ghost"
+									size="sm"
+									class="h-6 px-2 text-xs"
+									disabled={readonly || revertingId !== null}
+									onclick={() => void revert(v.id)}
+								>
+									{#if revertingId === v.id}
+										<Loader2 class="w-3 h-3 animate-spin" />
+									{:else}
+										<RotateCcw class="w-3 h-3" />
+									{/if}
+									Revert
+								</Button>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</div>
+		</div>
+	</Popover.Content>
+</Popover.Root>

--- a/src/lib/openapi.generated.json
+++ b/src/lib/openapi.generated.json
@@ -26212,6 +26212,230 @@
         }
       }
     },
+    "/api/stacks/{name}/history": {
+      "get": {
+        "operationId": "get_api_stacks_name_history",
+        "tags": [
+          "stacks"
+        ],
+        "summary": "List a stack's saved versions (compose or env) with saved/deployed pointers",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The stack name"
+          },
+          {
+            "name": "env",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Environment id the stack belongs to"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Version kind to list (compose or env); defaults to compose"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "versions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "timestamp": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "timestamp"
+                        ]
+                      }
+                    },
+                    "lastSavedAt": {
+                      "type": "string"
+                    },
+                    "lastDeployedAt": {
+                      "type": "string"
+                    },
+                    "currentVersionId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "versions"
+                  ]
+                },
+                "example": {
+                  "type": "string",
+                  "versions": [
+                    {
+                      "id": "string",
+                      "timestamp": "string"
+                    }
+                  ],
+                  "lastSavedAt": "string",
+                  "lastDeployedAt": "string",
+                  "currentVersionId": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid type (must be compose or env)"
+          },
+          "403": {
+            "description": "Permission denied (needs stacks:view)"
+          },
+          "500": {
+            "description": "Failed to read versions"
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "description": "Returns the bounded, secret-free version list for `type` (compose or env, defaults to compose) newest-first, plus the stack_sources last_saved_at / last_deployed_at pointers so a client can show a saved-vs-deployed indicator. versions are {id, timestamp}; the pointers are ISO-8601 strings or null (never saved / never deployed)."
+      },
+      "post": {
+        "operationId": "post_api_stacks_name_history",
+        "tags": [
+          "stacks"
+        ],
+        "summary": "Save a new stack version or revert to a past version",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The stack name"
+          },
+          {
+            "name": "env",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Environment id the stack belongs to"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "timestamp": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                },
+                "example": {
+                  "success": true,
+                  "timestamp": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid action, type, or missing content/versionId"
+          },
+          "403": {
+            "description": "Permission denied (needs stacks:edit)"
+          },
+          "404": {
+            "description": "Revert target version not found"
+          },
+          "500": {
+            "description": "Failed to save or revert"
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "description": "action=save persists `content` (compose YAML for type=compose; KEY=VALUE .env text for type=env) as a new bounded secret-free version and advances last_saved_at; action=revert restores the version with `versionId` to the live source (internal compose.yaml, or the env .env file for internal stacks / the DB non-secret subset for GIT stacks with existing secrets preserved) and advances last_saved_at. Secrets are never written to a version.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "content": {
+                    "type": "string"
+                  },
+                  "versionId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "action",
+                  "type"
+                ]
+              },
+              "example": {
+                "action": "revert",
+                "type": "compose",
+                "versionId": "abc123"
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/stacks/{name}/icon": {
       "get": {
         "operationId": "get_api_stacks_name_icon",

--- a/src/lib/openapi.generated.json
+++ b/src/lib/openapi.generated.json
@@ -26285,6 +26285,9 @@
                     },
                     "currentVersionId": {
                       "type": "string"
+                    },
+                    "deployStartedAt": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26302,7 +26305,8 @@
                   ],
                   "lastSavedAt": "string",
                   "lastDeployedAt": "string",
-                  "currentVersionId": "string"
+                  "currentVersionId": "string",
+                  "deployStartedAt": "string"
                 }
               }
             }

--- a/src/lib/server/db/schema/index.ts
+++ b/src/lib/server/db/schema/index.ts
@@ -361,6 +361,9 @@ export const stackSources = sqliteTable('stack_sources', {
 	// Per-stack icon: a lucide name ('server'), 'selfhst:<ref>', or 'custom:<file>'.
 	// Null -> UI falls back to a generic icon.
 	icon: text('icon'),
+	// Version pointers (ISO-8601 strings). NULL = never saved / never deployed.
+	lastSavedAt: text('last_saved_at'),
+	lastDeployedAt: text('last_deployed_at'),
 	createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),
 	updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`)
 }, (table) => ({

--- a/src/lib/server/db/schema/pg-schema.ts
+++ b/src/lib/server/db/schema/pg-schema.ts
@@ -364,6 +364,9 @@ export const stackSources = pgTable('stack_sources', {
 	// Per-stack icon: a lucide name ('server'), 'selfhst:<ref>', or 'custom:<file>'.
 	// Null -> UI falls back to a generic icon.
 	icon: text('icon'),
+	// Version pointers (ISO-8601 strings). NULL = never saved / never deployed.
+	lastSavedAt: text('last_saved_at'),
+	lastDeployedAt: text('last_deployed_at'),
 	createdAt: timestamp('created_at', { mode: 'string' }).defaultNow(),
 	updatedAt: timestamp('updated_at', { mode: 'string' }).defaultNow()
 }, (table) => ({

--- a/src/lib/server/stack-source-pointers.ts
+++ b/src/lib/server/stack-source-pointers.ts
@@ -1,0 +1,229 @@
+/**
+ * Version-pointer access helpers for the `stack_sources` table.
+ *
+ * `stack_sources.last_saved_at` / `last_deployed_at` are nullable ISO-8601
+ * timestamps (NULL = never saved / never deployed, added by the
+ * 0016_add_stack_versioning migration). These helpers let the S02 version core
+ * read and advance those pointers without duplicating the dual-DB access logic
+ * that lives in `db.ts` / `stacks.ts`.
+ *
+ * A pointer is keyed by (stack_name, environment_id). Bare internal stacks
+ * (local stacks, no environment) have environment_id = NULL, so the key match
+ * must explicitly use `environment_id IS NULL` for them. We do NOT rely on the
+ * `stackSourceEnvUnique` (stack_name, environment_id) constraint, because
+ * `NULL != NULL` in unique constraints — an ON CONFLICT on that constraint can
+ * never dedupe a (name, NULL) row. The key is therefore matched with an
+ * explicit `environment_id IS NULL` predicate.
+ *
+ * ## Portability contract
+ * The emitted SQL uses portable `?` placeholders and standard SQL only, so the
+ * EXACT same statement text runs verbatim on SQLite (better-sqlite3 at runtime,
+ * and bun:sqlite in the unit test) and, after `?` -> `$1, $2, ...` mapping, on
+ * Postgres (postgres-js). The `buildRead` / `buildUpdate` / `buildInsert`
+ * helpers return `{ sql, params }` so a bun test can mirror the app's SQL and
+ * parameter order one-for-one against an in-memory bun:sqlite database.
+ *
+ * ## Side-effect-free top level (test importability)
+ * The SQL constants and param builders above are pure — no imports at the top
+ * level of this module. Only the high-level `readStackSourcePointer` /
+ * `upsertStackSourcePointer` functions import `./db/drizzle.js`, and they do so
+ * lazily INSIDE the function body. `db/drizzle.ts` performs `await seedDatabase()`
+ * at module load (which opens better-sqlite3 — unsupported in Bun), so keeping
+ * that import out of the top level means a bun test can import the SQL +
+ * builders from this module WITHOUT triggering the better-sqlite3 load, and run
+ * them against bun:sqlite directly.
+ */
+
+/** Pointer values a write may set. `undefined`/`null` for a field = leave it
+ *  unchanged (COALESCE preserves the stored value). */
+export interface StackSourcePointerValues {
+	lastSavedAt?: string | null;
+	lastDeployedAt?: string | null;
+}
+
+/** A read pointer row (or `null` when no keyed row exists). */
+export interface StackSourcePointers {
+	lastSavedAt: string | null;
+	lastDeployedAt: string | null;
+}
+
+/**
+ * Portable key predicate for (stack_name, environment_id).
+ *
+ * - environment_id is a specific value -> `environment_id = ?`
+ * - environment_id is NULL (bare internal stack) -> `environment_id IS NULL`
+ *
+ * The same `?` parameter is bound three times: once for the `IS NOT NULL`
+ * test, once as the `=` value, once for the `IS NULL` test.
+ */
+const ENV_KEY = `((? IS NOT NULL AND environment_id = ?) OR (? IS NULL AND environment_id IS NULL))`;
+
+/** Read the (stack_name, environment_id) pointer row. */
+export const READ_SQL = `
+	SELECT last_saved_at, last_deployed_at
+	FROM stack_sources
+	WHERE stack_name = ? AND ${ENV_KEY}
+`;
+
+/**
+ * Advance the pointers on an existing keyed row. COALESCE keeps any pointer this
+ * call did not provide. No-op (0 rows) when the keyed row does not exist yet.
+ */
+export const UPDATE_SQL = `
+	UPDATE stack_sources
+	SET last_saved_at = COALESCE(?, last_saved_at),
+		last_deployed_at = COALESCE(?, last_deployed_at),
+		updated_at = ?
+	WHERE stack_name = ? AND ${ENV_KEY}
+`;
+
+/**
+ * Create the keyed row when it does not exist (bare internal stack). The
+ * NOT EXISTS guard keeps this idempotent and prevents a duplicate
+ * (name, NULL) row even under a race. source_type defaults to 'internal';
+ * created_at / updated_at are set to `now` (ISO-8601, matching the app-wide
+ * timestamp convention rather than the schema's CURRENT_TIMESTAMP default).
+ */
+export const INSERT_SQL = `
+	INSERT INTO stack_sources (
+		stack_name, environment_id, source_type,
+		last_saved_at, last_deployed_at, created_at, updated_at
+	)
+	SELECT ?, ?, ?, ?, ?, ?, ?
+	WHERE NOT EXISTS (
+		SELECT 1 FROM stack_sources
+		WHERE stack_name = ? AND ${ENV_KEY}
+	)
+`;
+
+/** Read params: [stackName, envId, envId, envId]. */
+export function buildRead(
+	stackName: string,
+	environmentId: number | null
+): { sql: string; params: unknown[] } {
+	return {
+		sql: READ_SQL,
+		params: [stackName, environmentId, environmentId, environmentId]
+	};
+}
+
+/** Update params: [lastSavedAt, lastDeployedAt, now, stackName, envId, envId, envId]. */
+export function buildUpdate(
+	stackName: string,
+	environmentId: number | null,
+	updates: StackSourcePointerValues,
+	now: string
+): { sql: string; params: unknown[] } {
+	return {
+		sql: UPDATE_SQL,
+		params: [
+			updates.lastSavedAt ?? null,
+			updates.lastDeployedAt ?? null,
+			now,
+			stackName,
+			environmentId,
+			environmentId,
+			environmentId
+		]
+	};
+}
+
+/**
+ * Insert params:
+ * [stackName, envId, 'internal', lastSavedAt, lastDeployedAt, now, now,
+ *  stackName, envId, envId, envId]
+ */
+export function buildInsert(
+	stackName: string,
+	environmentId: number | null,
+	updates: StackSourcePointerValues,
+	now: string
+): { sql: string; params: unknown[] } {
+	return {
+		sql: INSERT_SQL,
+		params: [
+			stackName,
+			environmentId,
+			'internal',
+			updates.lastSavedAt ?? null,
+			updates.lastDeployedAt ?? null,
+			now,
+			now,
+			stackName,
+			environmentId,
+			environmentId,
+			environmentId
+		]
+	};
+}
+
+/** Map portable `?` placeholders to Postgres `$1, $2, ...` in left-to-right order. */
+function toPostgresPlaceholders(sqlText: string): string {
+	let n = 0;
+	return sqlText.replace(/\?/g, () => `$${++n}`);
+}
+
+/**
+ * Execute a write statement (UPDATE/INSERT) on the given raw client. The
+ * portable `?` SQL runs verbatim on better-sqlite3; for postgres-js the `?`
+ * placeholders are mapped to `$1, $2, ...`.
+ */
+async function executeRaw(client: unknown, isPostgres: boolean, sqlText: string, params: unknown[]): Promise<void> {
+	if (isPostgres) {
+		await (client as any).unsafe(toPostgresPlaceholders(sqlText), params);
+		return;
+	}
+	(client as any).prepare(sqlText).run(...params);
+}
+
+/** Run a SELECT on the given raw client and return the rows. */
+async function selectRaw(client: unknown, isPostgres: boolean, sqlText: string, params: unknown[]): Promise<Record<string, unknown>[]> {
+	if (isPostgres) {
+		const rows = await (client as any).unsafe(toPostgresPlaceholders(sqlText), params);
+		return rows as Record<string, unknown>[];
+	}
+	return (client as any).prepare(sqlText).all(...params) as Record<string, unknown>[];
+}
+
+/**
+ * Read the (stackName, environmentId) version-pointer row.
+ * Returns `null` when no keyed row exists yet.
+ */
+export async function readStackSourcePointer(
+	stackName: string,
+	environmentId: number | null
+): Promise<StackSourcePointers | null> {
+	const { rawClient, isPostgres } = await import('./db/drizzle.js');
+	const { sql, params } = buildRead(stackName, environmentId);
+	const rows = await selectRaw(rawClient, isPostgres, sql, params);
+	const row = rows[0];
+	if (!row) return null;
+	return {
+		lastSavedAt: row.last_saved_at == null ? null : String(row.last_saved_at),
+		lastDeployedAt: row.last_deployed_at == null ? null : String(row.last_deployed_at)
+	};
+}
+
+/**
+ * Upsert the (stackName, environmentId) version pointers.
+ *
+ * Advances `last_saved_at` and/or `last_deployed_at` (a null/undefined value
+ * leaves that pointer untouched) and stamps `updated_at`. Creates a bare
+ * `source_type = 'internal'` row when none exists yet, so a bare internal stack
+ * with environment_id = NULL is handled without relying on the unique
+ * constraint.
+ */
+export async function upsertStackSourcePointer(
+	stackName: string,
+	environmentId: number | null,
+	updates: StackSourcePointerValues
+): Promise<void> {
+	const { rawClient, isPostgres } = await import('./db/drizzle.js');
+	const now = new Date().toISOString();
+	// Advance the pointers if the keyed row already exists; no-op if missing.
+	const update = buildUpdate(stackName, environmentId, updates, now);
+	await executeRaw(rawClient, isPostgres, update.sql, update.params);
+	// Create the keyed row if it was still missing (idempotent).
+	const insert = buildInsert(stackName, environmentId, updates, now);
+	await executeRaw(rawClient, isPostgres, insert.sql, insert.params);
+}

--- a/src/lib/server/stack-version-wiring.ts
+++ b/src/lib/server/stack-version-wiring.ts
@@ -1,0 +1,323 @@
+/**
+ * Crash-safe stack-version save orchestration + pure env-revert helpers.
+ *
+ * This is the ORCHESTRATION layer that S02's pure version store (stack-versions)
+ * punted to S03:
+ *  - a crash-safe save (live-file-first, then version-record, then best-effort
+ *    pointer-advance, with the live file rolled back on a version-write failure
+ *    so there is never a recorded-but-not-live state),
+ *  - the safe-version identification used for prune (the version live at last
+ *    deploy is never pruned),
+ *  - the pure merge/serialize helpers for env reverts.
+ *
+ * ## Purity / test-importability (same contract as S02 / MEM016)
+ * This module is PURE. It imports only `node:fs` and the pure primitives from
+ * `./stack-versions.js` (saveVersion, listVersions, atomicWriteFile,
+ * filterSecretVars, parseEnvVars) plus their types. It does NOT import
+ * `stacks.ts` / `db.ts` / `better-sqlite3` at the top level — a top-level import
+ * of either would load better-sqlite3 (via db/drizzle.ts's seedDatabase) and
+ * crash every bun test that imports this module. The real wiring call sites
+ * (T02/T03) pass in the actual pointer advancer (upsertStackSourcePointer) and
+ * the real secret keys (getStackInjectedSecretKeys) as injectable functions; this
+ * module never imports them.
+ *
+ * ## Crash-safe save ordering
+ * `saveStackVersion` writes the LIVE file FIRST (writeLive), THEN records the
+ * version (recordVersion), THEN advances the pointer best-effort. Because the
+ * live file is written before the version, a hard crash between the two leaves
+ * the live file correct (new content) with only a missing version record — never
+ * a version that is recorded but not live. On an in-process version-write
+ * FAILURE (a thrown error, not a hard crash), the live file is rolled back to its
+ * previous content (or unlinked if it did not exist before), so the failure
+ * leaves BOTH the live file and the version file at the previous content.
+ *
+ * ## GIT env stacks
+ * For GIT stacks the DB is the live source of env vars (the caller has already
+ * written them); there is no live FILE to write. So `livePath` is omitted and
+ * `saveStackVersion` records the version + advances the pointer without touching
+ * any live file.
+ */
+
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import {
+	DEFAULT_MAX_VERSIONS,
+	atomicWriteFile,
+	collapseHistoryFile,
+	filterSecretVars,
+	listVersions,
+	parseEnvVars,
+	saveVersion,
+	versionContentEquals,
+	type SaveVersionOptions,
+	type StackVersion,
+	type VersionType
+} from './stack-versions.js';
+
+// Re-export the pure env parser + default bound so this module is a convenient
+// single surface for the versioning primitives the T02/T03 call sites consume.
+export { parseEnvVars };
+export { DEFAULT_MAX_VERSIONS };
+
+/** Injectable crash-safe save options. Defaults mirror the S02 primitives. */
+export interface SaveVersionWiringOptions {
+	/** Resolved stack directory (the caller resolves it via getStackDir). */
+	stackDir: string;
+	/** The version kind: a compose YAML string, or a non-secret env record. */
+	type: VersionType;
+	/**
+	 * The new live content. For `compose` this is the compose YAML string (stored
+	 * verbatim). For `env` this is KEY=VALUE .env text — a raw .env for internal
+	 * stacks, or a serialized non-secret Record for GIT env — which is parsed and
+	 * filtered so the STORED version is secret-free.
+	 */
+	content: string;
+	/**
+	 * For `env` versions: the secret key NAMES that must NOT be captured. Supplied
+	 * by the caller (getStackInjectedSecretKeys). Secret values live in the DB and
+	 * are injected at runtime, so they are filtered out of the stored version.
+	 */
+	secretKeys?: string[];
+	/**
+	 * ISO-8601 `last_deployed_at` pointer. The newest version with timestamp <=
+	 * this is the "safe" version that is never pruned (the version live at last
+	 * deploy). When null/undefined, there is no safe version.
+	 */
+	lastDeployedAt?: string | null;
+	/** Bound applied after appending (defaults to DEFAULT_MAX_VERSIONS). */
+	maxVersions?: number;
+	/**
+	 * Path of the live file to write first (crash-safe ordering). OMIT for GIT env
+	 * stacks where the DB is the live source (already written by the caller) — no
+	 * live file is written in that case.
+	 */
+	livePath?: string;
+	/**
+	 * Advance the (stack, env) version pointer best-effort after a successful
+	 * version record. Defaults to a no-op. A pointer-advance failure is swallowed
+	 * (it must NOT fail the save).
+	 */
+	advancePointer?: (values: { lastSavedAt?: string; lastDeployedAt?: string }) => Promise<void>;
+	/**
+	 * Write the live file. Defaults to `atomicWriteFile`. Only invoked when
+	 * `livePath` is provided.
+	 */
+	writeLive?: (livePath: string, content: string) => void;
+	/**
+	 * Record a version. Defaults to `saveVersion` (the S02 pure store). The `safe`
+	 * version (the one live at last deploy) and, for env, the secret keys are
+	 * forwarded so pruning never drops the safe version and a leaked secret fails
+	 * loudly.
+	 */
+	recordVersion?: (
+		stackDir: string,
+		type: VersionType,
+		content: string | Record<string, string>,
+		opts: SaveVersionOptions
+	) => { id: string; timestamp: string };
+}
+
+/** Outcome of a `saveStackVersion` call. */
+export interface SaveVersionResult {
+	/** The id of the recorded version. */
+	id: string;
+	/** The ISO-8601 timestamp of the recorded version. */
+	timestamp: string;
+	/** True when a live file was written (i.e. `livePath` was provided). */
+	liveWritten: boolean;
+	/** Reserved for a future rollback flag; false on the successful path. */
+	rolledBack: boolean;
+	/**
+	 * True when the save was a NO-OP: the newest recorded version already held
+	 * exactly this content, so no version was recorded and `lastSavedAt` was NOT
+	 * advanced. `id`/`timestamp` then reference the pre-existing version.
+	 */
+	skipped: boolean;
+}
+
+/**
+ * Crash-safe stack-version save orchestration.
+ *
+ * Ordering:
+ * 1. Snapshot the current live file (if `livePath` exists) for rollback.
+ * 2. Identify the safe version (live at last deploy) via findSafeVersionId.
+ * 3. Write the LIVE file FIRST (omitted when `livePath` is undefined — GIT env).
+ * 4. Record the version (secret-free for env). On success, advance the pointer
+ *    best-effort (a pointer failure never fails the save).
+ * 5. On a version-write FAILURE, roll the live file back to its previous content
+ *    (or unlink it if it did not exist before) so both the live file and the
+ *    version file remain at the previous content — all-or-nothing.
+ *
+ * See the module header for the crash-safety rationale.
+ */
+export async function saveStackVersion(opts: SaveVersionWiringOptions): Promise<SaveVersionResult> {
+	const { stackDir, type, content, secretKeys, lastDeployedAt, maxVersions, livePath } = opts;
+	const writeLive = opts.writeLive ?? atomicWriteFile;
+	const recordVersion = opts.recordVersion ?? saveVersion;
+	const advancePointer = opts.advancePointer ?? (async () => undefined);
+
+	// For env, the content is KEY=VALUE text: parse it and strip the secret keys
+	// so the STORED version is secret-free. For compose, the content is the YAML
+	// string used verbatim.
+	const contentForRecord: string | Record<string, string> =
+		type === 'env' ? filterSecretVars(parseEnvVars(content), secretKeys ?? []) : content;
+
+	// Snapshot the live file so a version-write failure can roll it back.
+	const prevLive = livePath && existsSync(livePath) ? readFileSync(livePath, 'utf8') : null;
+
+	// Identify the version live at last deploy so pruning never drops it.
+	const safe = findSafeVersionId(listVersions(stackDir, type), lastDeployedAt);
+
+	// CRASH-SAFE ORDERING: the live file is written FIRST. Omitted when livePath
+	// is undefined (GIT env: the DB is the live source, already written by caller).
+	if (livePath) {
+		writeLive(livePath, content);
+	}
+
+	// NO-OP SAVE: when the newest recorded version already holds exactly this
+	// content, recording it again would only bloat the bounded history and churn
+	// last_saved_at. The edit modal saves BOTH compose and env on every save, so
+	// without this the untouched side would add a duplicate entry on every
+	// unrelated edit. For env the comparison runs on the stored (parsed,
+	// secret-free) form, so comment/whitespace-only .env edits also no-op - but
+	// the live file above still picked up the new formatting.
+	const latest = listVersions(stackDir, type)[0];
+	if (latest && latest.content !== undefined && versionContentEquals(latest.content, contentForRecord)) {
+		// Opportunistic normalization: even a skipped (no-op) save collapses any
+		// duplicate-content entries the list accumulated (e.g. saved before the
+		// distinct-content invariant existed, or by pre-fix code). Best-effort -
+		// a cleanup failure never fails the save. No pointer churn, no new entry.
+		try {
+			collapseHistoryFile(stackDir, type, safe);
+		} catch (err) {
+			console.warn(`[StackVersion] Failed to collapse duplicate versions (${type}):`, err);
+		}
+		return {
+			id: latest.id,
+			timestamp: latest.timestamp,
+			liveWritten: !!livePath,
+			rolledBack: false,
+			skipped: true
+		};
+	}
+
+	try {
+		const recorded = recordVersion(stackDir, type, contentForRecord, {
+			safe,
+			secretKeys: type === 'env' ? secretKeys : undefined,
+			maxVersions: maxVersions ?? DEFAULT_MAX_VERSIONS
+		});
+
+		// Advance the pointer best-effort: a pointer failure must NOT fail the save.
+		try {
+			await advancePointer({ lastSavedAt: recorded.timestamp });
+		} catch {
+			// Swallow: pointer advance is best-effort; the version is already
+			// recorded and the live file is live, so the save itself succeeded.
+		}
+
+		return {
+			id: recorded.id,
+			timestamp: recorded.timestamp,
+			liveWritten: !!livePath,
+			rolledBack: false,
+			skipped: false
+		};
+	} catch (err) {
+		// ALL-OR-NOTHING rollback: restore the live file to its previous content so
+		// a mid-write failure leaves BOTH the live file and the version file at the
+		// previous content (no recorded-but-not-live state).
+		if (livePath) {
+			if (prevLive !== null) {
+				try {
+					writeLive(livePath, prevLive);
+				} catch {
+					// Best-effort rollback; the original error is rethrown below.
+				}
+			} else {
+				try {
+					unlinkSync(livePath);
+				} catch {
+					// Best-effort: ignore unlink errors (e.g. the file is already gone).
+				}
+			}
+		}
+		throw err;
+	}
+}
+
+/**
+ * Identify the version that must NEVER be pruned: the newest version whose
+ * timestamp <= `lastDeployedAt` (the version that was live when last deployed).
+ *
+ * Returns `undefined` when `lastDeployedAt` is null/undefined, or when no stored
+ * version has a timestamp <= `lastDeployedAt`. Ties (identical timestamp) are
+ * broken by id (larger id wins) for determinism. This value is passed as `safe`
+ * to saveVersion/prune so boundVersions preserves it.
+ */
+export function findSafeVersionId(
+	versions: StackVersion[],
+	lastDeployedAt?: string | null
+): string | undefined {
+	if (lastDeployedAt == null) return undefined;
+	let best: StackVersion | undefined;
+	for (const v of versions) {
+		if (v.timestamp > lastDeployedAt) continue;
+		if (!best) {
+			best = v;
+		} else if (v.timestamp > best.timestamp || (v.timestamp === best.timestamp && v.id > best.id)) {
+			best = v;
+		}
+	}
+	return best?.id;
+}
+
+/**
+ * Non-destructive merge for a GIT-stack env revert.
+ *
+ * `versionRecord` is the version's non-secret Record (secret-free). The result:
+ * - every (key, value) in `versionRecord` as `{ key, value, isSecret: false }`
+ *   (these OVERRIDE the current values), PLUS
+ * - every current var with `isSecret === true` (secrets are PRESERVED verbatim; a
+ *   secret key cannot appear in the secret-free `versionRecord`, so every current
+ *   secret survives).
+ *
+ * Current NON-secret vars absent from `versionRecord` are DROPPED (the version is
+ * the full non-secret set at that point). The caller feeds this to setStackEnvVars
+ * (which deletes-then-inserts the (stack, env) row), so the merged set is exactly
+ * what ends up in the DB — no existing secret is ever wiped.
+ *
+ * Pure: no DB, no fs.
+ */
+export function computeRevertedEnvVars(
+	currentVars: Array<{ key: string; value: string; isSecret: boolean }>,
+	versionRecord: Record<string, string>
+): Array<{ key: string; value: string; isSecret?: boolean }> {
+	const versionKeys = new Set(Object.keys(versionRecord));
+	const out: Array<{ key: string; value: string; isSecret?: boolean }> = [];
+
+	// 1. Every (key, value) in the version's non-secret record (overrides current).
+	for (const [key, value] of Object.entries(versionRecord)) {
+		out.push({ key, value, isSecret: false });
+	}
+
+	// 2. Every current secret var is preserved verbatim. A secret key cannot appear
+	//    in the secret-free versionRecord, but the guard is cheap and defensive.
+	for (const cv of currentVars) {
+		if (cv.isSecret === true && !versionKeys.has(cv.key)) {
+			out.push({ key: cv.key, value: cv.value, isSecret: true });
+		}
+	}
+
+	return out;
+}
+
+/**
+ * Serialize a non-secret Record back to KEY=VALUE .env text (one line per entry,
+ * joined with \n) — for writing a version's non-secret record to an internal
+ * stack's .env file on revert. Empty record -> empty string.
+ */
+export function serializeEnvVars(record: Record<string, string>): string {
+	return Object.entries(record)
+		.map(([key, value]) => `${key}=${value}`)
+		.join('\n');
+}

--- a/src/lib/server/stack-versions.ts
+++ b/src/lib/server/stack-versions.ts
@@ -1,0 +1,408 @@
+/**
+ * Pure per-stack version store.
+ *
+ * Owns the per-stack `.history/` directory (`compose.json` + `env.json`), each
+ * holding a bounded, secret-free history of versions.
+ *
+ * ## Purity / test-importability
+ * This module is PURE: it imports `node:fs`, `node:path`, and the pure
+ * `parseEnvVars` helper from `./env-parser.js` (itself import-free — pure string
+ * parsing, no DB). It does NOT import `stacks.ts` or `db.ts` at the top level:
+ * `stacks.ts` imports `./db/drizzle.js` whose top-level `seedDatabase()` opens
+ * better-sqlite3, which is NOT loadable under bun test. Keeping those imports
+ * out means every bun test that touches this module runs without the
+ * better-sqlite3 load (a top-level import would crash every such test).
+ *
+ * ## Secret-free
+ * For `env` versions, secret keys are identified BY NAME (the `secretKeys` input,
+ * supplied by the caller — S03 feeds it from `getStackInjectedSecretKeys`) — their
+ * VALUES live in the DB and are injected at runtime, so they must never be
+ * captured in a saved env version. `assertSecretFree` rejects a payload that still
+ * carries a secret key (throwing an error naming the first leaked key);
+ * `filterSecretVars` returns a new object holding only the non-secret keys. When
+ * `type === 'env'` and `secretKeys` is provided, `saveVersion` asserts BEFORE
+ * storing so a leaked secret fails the save loudly. The module never queries the DB
+ * — it stays pure.
+ *
+ * ## Sync + caller-supplied dir
+ * All functions are SYNC and take a RESOLVED `stackDir: string`
+ * (caller-supplied; S03 resolves it via `getStackDir` in the real runtime) and
+ * operate on `join(stackDir, HISTORY_DIRNAME)`. This module never calls
+ * `getStackDir` / `findStackDir` itself — they are async + DB-coupled.
+ *
+ * ## Bounding
+ * Histories are bounded to `maxVersions` (default `DEFAULT_MAX_VERSIONS`). The
+ * safe version (the last-saved / last-deployed version, identified by id OR
+ * timestamp) is NEVER dropped, even when it is the oldest. When over the bound,
+ * the OLDEST non-safe versions are dropped first.
+ *
+ * ## Atomicity
+ * Writes go through `atomicWriteFile`: write to `<file>.tmp`, then `renameSync`
+ * the tmp onto the target (atomic on the same fs). On any failure the tmp is
+ * removed and the original error is rethrown — the target is never left with a
+ * partial file, and a pre-existing stale tmp is REPLACED (writeFileSync
+ * truncates it), never merged or appended to.
+ *
+ * ## Corruption
+ * A missing `.history/` dir or file reads as an empty history. A PRESENT but
+ * MALFORMED history file throws — corruption is surfaced, never masked.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { parseEnvVars } from './env-parser.js';
+
+// Re-export the pure env parser so this module is the single surface for the
+// env-versioning primitives (saveVersion, filterSecretVars, assertSecretFree,
+// parseEnvVars) that S03 will consume when wiring the save/revert/deploy flow.
+// `parseEnvVars` itself is NOT used by the guard functions — the caller parses
+// raw .env content into a record, then this module filters/asserts it.
+export { parseEnvVars };
+
+/** Per-stack history directory name (relative to the resolved stack dir). */
+export const HISTORY_DIRNAME = '.history';
+
+/** Default bound on the number of stored versions per stack/type. */
+export const DEFAULT_MAX_VERSIONS = 20;
+
+/** The kind of version stored: a compose YAML string, or a non-secret env record. */
+export type VersionType = 'compose' | 'env';
+
+/**
+ * A single stored version.
+ * - `compose`: `content` is the compose YAML string.
+ * - `env`: `content` is a non-secret `Record<string, string>` of env vars.
+ */
+export interface StackVersion {
+	id: string;
+	timestamp: string;
+	content: string | Record<string, string>;
+}
+
+/** Optional inputs to `saveVersion`. All injectable for deterministic tests. */
+export interface SaveVersionOptions {
+	/** Bound to apply after appending (defaults to DEFAULT_MAX_VERSIONS). */
+	maxVersions?: number;
+	/** The safe version (id or timestamp) that must never be dropped. */
+	safe?: string;
+	/** Explicit id (defaults to `timestamp`, deduped to stay unique). */
+	id?: string;
+	/** Explicit ISO-8601 timestamp (defaults to now). */
+	timestamp?: string;
+	/**
+	 * For `env` versions only: the secret key NAMES that must NOT appear in
+	 * `content`. When provided (and `type === 'env'`), `saveVersion` asserts the
+	 * payload is secret-free before storing. The module never queries the DB for
+	 * these — the caller supplies the real names (S03 via getStackInjectedSecretKeys).
+	 */
+	secretKeys?: string[];
+}
+
+/**
+ * Resolve the history file path for a stack dir and version type.
+ * `compose` -> `<stackDir>/.history/compose.json`,
+ * `env`     -> `<stackDir>/.history/env.json`.
+ */
+export function historyPath(stackDir: string, type: VersionType): string {
+	return join(stackDir, HISTORY_DIRNAME, type === 'compose' ? 'compose.json' : 'env.json');
+}
+
+/**
+ * Atomically write `data` to `filePath` on the same filesystem.
+ *
+ * Writes to `filePath + '.tmp'` then `renameSync`s it onto `filePath` (atomic).
+ * Ensures the target directory exists first (so the first save creates
+ * `.history/`); an already-existing dir is left alone. On ANY failure the tmp
+ * is removed (if present) and the original error is rethrown. A pre-existing
+ * stale tmp is REPLACED (writeFileSync truncates it), never merged or appended
+ * to.
+ */
+export function atomicWriteFile(filePath: string, data: string): void {
+	const tmpPath = filePath + '.tmp';
+	try {
+		// Ensure the target directory exists (first save creates .history/).
+		// Guarded: an existing dir (e.g. already present in a failure test) is
+		// left alone so we never call mkdir on a dir we cannot write.
+		const dir = dirname(filePath);
+		if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+		writeFileSync(tmpPath, data, 'utf8');
+		renameSync(tmpPath, filePath);
+	} catch (err) {
+		// Best-effort cleanup of the tmp on any failure; swallow a cleanup error
+		// so the original error (below) is what surfaces.
+		try {
+			if (existsSync(tmpPath)) unlinkSync(tmpPath);
+		} catch {
+			// ignore cleanup failure
+		}
+		throw err;
+	}
+}
+
+/**
+ * Read a history file. Returns `{ versions: [] }` when the `.history/` dir or
+ * its file is absent (never an error). Throws when the file is PRESENT but the
+ * JSON is malformed or has the wrong shape — corruption is surfaced, never masked.
+ */
+export function readHistoryFile(stackDir: string, type: VersionType): { versions: StackVersion[] } {
+	const file = historyPath(stackDir, type);
+	if (!existsSync(file)) return { versions: [] };
+	const raw = readFileSync(file, 'utf8');
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err) {
+		throw new Error(`Malformed history file at ${file}: ${err instanceof Error ? err.message : String(err)}`);
+	}
+	if (typeof parsed !== 'object' || parsed === null || !Array.isArray((parsed as { versions?: unknown }).versions)) {
+		throw new Error(`Malformed history file at ${file}: expected a { versions: [...] } object`);
+	}
+	return { versions: (parsed as { versions: StackVersion[] }).versions };
+}
+
+/**
+ * List the last `limit` versions (default DEFAULT_MAX_VERSIONS), NEWEST-FIRST.
+ * Each returned version carries its `id` and ISO `timestamp`. A missing dir/file
+ * yields `[]`.
+ */
+export function listVersions(stackDir: string, type: VersionType, limit?: number): StackVersion[] {
+	const { versions } = readHistoryFile(stackDir, type);
+	const n = limit ?? DEFAULT_MAX_VERSIONS;
+	return versions.slice().sort(compareByTimestampDesc).slice(0, n);
+}
+
+/**
+ * Append a version, bound the history to `maxVersions` (default
+ * DEFAULT_MAX_VERSIONS) via `boundVersions`, atomically write the whole file,
+ * and return the new `{ id, timestamp }`.
+ *
+ * `timestamp` defaults to `new Date().toISOString()`; `id` defaults to
+ * `timestamp`, deduped by appending `-N` on collision so ids stay unique.
+ */
+export function saveVersion(
+	stackDir: string,
+	type: VersionType,
+	content: string | Record<string, string>,
+	opts: SaveVersionOptions = {}
+): { id: string; timestamp: string } {
+	// Defense-in-depth on top of the caller's filterSecretVars: for env versions,
+	// reject a payload that STILL carries a secret key (by name) before storing.
+	if (type === 'env' && opts.secretKeys) {
+		assertSecretFree(content as Record<string, string>, opts.secretKeys);
+	}
+	const { versions } = readHistoryFile(stackDir, type);
+	const maxN = opts.maxVersions ?? DEFAULT_MAX_VERSIONS;
+	const timestamp = opts.timestamp ?? new Date().toISOString();
+	const id = opts.id ?? dedupeId(versions, timestamp);
+	// CROSS-LIST DEDUP (the revert case): when the incoming content already has
+	// an older version entry (e.g. a save right after reverting to an older
+	// version), drop that older duplicate so the history never shows two
+	// identical entries - the newest entry stays the single representative. The
+	// safe (deployed) version is NEVER dropped by dedup: the deployed anchor
+	// takes priority, so a save matching the deployed content simply appends a
+	// new entry next to it.
+		// COLLAPSE (single representative per distinct content): the history is a
+	// DISTINCT-CONTENT timeline - each content appears at most once, the NEWEST
+	// entry being the representative. This subsumes the revert case (saving
+	// content equal to an older version replaces that older entry) and also
+	// normalizes lists that accumulated duplicates (e.g. saved before this
+	// invariant existed). The safe (deployed) version is NEVER collapsed: the
+	// deployed anchor must stay identifiable even when a newer entry holds the
+	// same content.
+	// The incoming entry (newest) is folded INTO the collapse so an older entry
+	// with identical content (the revert case) is dropped in the same pass.
+	const { collapsed } = collapseDuplicateVersions(
+		[...versions, { id, timestamp, content }],
+		opts.safe
+	);
+	const next = collapsed;
+	const bounded = boundVersions(next, maxN, opts.safe);
+	atomicWriteFile(historyPath(stackDir, type), JSON.stringify({ versions: bounded }, null, 2));
+	return { id, timestamp };
+}
+
+/**
+ * Keep at most `maxN` versions, ALWAYS preserving the safe version
+ * (`v.id === safe || v.timestamp === safe`). When over the bound, drop the
+ * OLDEST non-safe versions first (lowest timestamp first). Shared by
+ * `saveVersion` and `prune` so BOTH paths respect the safe version.
+ *
+ * The safe invariant wins: even if more safe versions exist than `maxN`, they
+ * are all preserved (the total may then exceed `maxN`).
+ */
+/**
+ * Collapse a version list so each DISTINCT content appears at most once: the
+ * NEWEST entry is the representative, older entries with equal content are
+ * dropped. The safe (deployed) version is NEVER dropped, even when a newer
+ * entry holds the same content (the deployed anchor must stay identifiable by
+ * its own timestamp).
+ *
+ * Pure: takes and returns plain arrays. Scans newest-first, comparing each
+ * version against the versions already KEPT (not the raw list, so a version
+ * that is itself dropped does not shield an older duplicate).
+ */
+export function collapseDuplicateVersions(
+	versions: StackVersion[],
+	safe?: string
+): { collapsed: StackVersion[]; changed: boolean } {
+	const newestFirst = versions.slice().sort(compareByTimestampDesc);
+	const kept: StackVersion[] = [];
+	let changed = false;
+	for (const v of newestFirst) {
+		const dupOfKeptNewer = kept.some((k) => versionContentEquals(k.content, v.content));
+		if (isSafeVersion(v, safe) || !dupOfKeptNewer) {
+			kept.push(v);
+		} else {
+			changed = true;
+		}
+	}
+	// Stored file keeps the historical OLDEST-FIRST ordering.
+	return { collapsed: kept.reverse(), changed };
+}
+
+/**
+ * Normalize an on-disk history file in place: collapse duplicate-content
+ * entries (see collapseDuplicateVersions) and rewrite the file ONLY when
+ * something actually changed (no mtime churn on already-clean lists). Best-
+ * effort callers can ignore the return.
+ */
+export function collapseHistoryFile(
+	stackDir: string,
+	type: VersionType,
+	safe?: string
+): boolean {
+	const { versions } = readHistoryFile(stackDir, type);
+	const { collapsed, changed } = collapseDuplicateVersions(versions, safe);
+	if (changed) {
+		atomicWriteFile(historyPath(stackDir, type), JSON.stringify({ versions: collapsed }, null, 2));
+	}
+	return changed;
+}
+
+export function boundVersions(versions: StackVersion[], maxN: number, safe?: string): StackVersion[] {
+	if (versions.length <= maxN) return versions;
+
+	const safeVersions = versions.filter((v) => isSafeVersion(v, safe));
+	const nonSafeVersions = versions.filter((v) => !isSafeVersion(v, safe));
+
+	// Keep every safe version unconditionally. Fill the remaining capacity with
+	// the NEWEST non-safe versions so the OLDEST non-safe are dropped first.
+	const maxNonSafe = maxN - safeVersions.length;
+	let keptNonSafe: StackVersion[];
+	if (maxNonSafe < 0) {
+		// More safe versions than the bound allows; the safe invariant wins.
+		keptNonSafe = [];
+	} else if (maxNonSafe >= nonSafeVersions.length) {
+		keptNonSafe = nonSafeVersions;
+	} else {
+		const oldestFirst = [...nonSafeVersions].sort(compareByTimestampAsc);
+		keptNonSafe = oldestFirst.slice(-maxNonSafe);
+	}
+
+	return [...safeVersions, ...keptNonSafe];
+}
+
+/**
+ * Bound an existing history to `maxN`, atomically rewriting ONLY if versions
+ * were actually removed. Returns `{ pruned }` (the number removed; 0 = no-op).
+ * A missing dir/file is a no-op.
+ */
+export function prune(stackDir: string, type: VersionType, maxN: number, safe?: string): { pruned: number } {
+	const { versions } = readHistoryFile(stackDir, type);
+	if (versions.length === 0) return { pruned: 0 };
+	const bounded = boundVersions(versions, maxN, safe);
+	const pruned = versions.length - bounded.length;
+	if (pruned <= 0) return { pruned: 0 };
+	atomicWriteFile(historyPath(stackDir, type), JSON.stringify({ versions: bounded }, null, 2));
+	return { pruned };
+}
+
+/**
+ * Ascending by ISO timestamp (newest last). Ties (identical timestamp) fall back
+ * to id so the order is deterministic.
+ */
+function compareByTimestampAsc(a: StackVersion, b: StackVersion): number {
+	if (a.timestamp < b.timestamp) return -1;
+	if (a.timestamp > b.timestamp) return 1;
+	return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/**
+ * Descending by ISO timestamp (newest first). Ties fall back to id (descending)
+ * so the order is deterministic.
+ */
+	/**
+	 * Whether a version is the protected "safe" (deployed) version for a given
+	 * safe value (matched by id OR timestamp). `safe == null` -> never safe.
+	 * Shared by `boundVersions` and the cross-list dedup in `saveVersion`.
+	 */
+	export function isSafeVersion(v: StackVersion, safe?: string): boolean {
+		return safe != null && (v.id === safe || v.timestamp === safe);
+	}
+
+	/**
+	 * Deep equality for version content: strict equality for strings (compose)
+	 * and key/value equality for env Records. Exported so callers (e.g.
+	 * stack-version-wiring) can compare against stored versions.
+	 */
+	export function versionContentEquals(
+		stored: string | Record<string, string> | undefined,
+		coming: string | Record<string, string>
+	): boolean {
+		if (stored === undefined) return false;
+		if (typeof stored === 'string' || typeof coming === 'string') return stored === coming;
+		const a = stored as Record<string, string>;
+		const b = coming as Record<string, string>;
+		const aKeys = Object.keys(a);
+		if (aKeys.length !== Object.keys(b).length) return false;
+		return aKeys.every((k) => a[k] === b[k]);
+	}
+
+function compareByTimestampDesc(a: StackVersion, b: StackVersion): number {
+	if (a.timestamp < b.timestamp) return 1;
+	if (a.timestamp > b.timestamp) return -1;
+	return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
+}
+
+/**
+ * Pick a unique id: `base` if unused, else `base-1`, `base-2`, ... until unique.
+ * Keeps ids unique so the default `id = timestamp` never collides across two
+ * saves that share a timestamp.
+ */
+function dedupeId(existing: StackVersion[], base: string): string {
+	const existingIds = new Set(existing.map((v) => v.id));
+	if (!existingIds.has(base)) return base;
+	let n = 1;
+	while (existingIds.has(`${base}-${n}`)) n++;
+	return `${base}-${n}`;
+}
+
+/**
+ * Assert that `vars` carries NO secret key (a key present in `secretKeys`).
+ * Secret keys are identified BY NAME — their values live in the DB and are
+ * injected at runtime, so a secret key must never be captured in a saved env
+ * version. Throws an error naming the FIRST leaked key (object key order) when
+ * any key in `vars` is present in `secretKeys`; a clean payload does not throw.
+ */
+export function assertSecretFree(vars: Record<string, string>, secretKeys: string[]): void {
+	if (secretKeys.length === 0) return;
+	const secretSet = new Set(secretKeys);
+	for (const key of Object.keys(vars)) {
+		if (secretSet.has(key)) {
+			throw new Error(`Secret key leaked into env version payload: ${key}`);
+		}
+	}
+}
+
+/**
+ * Return a NEW object containing only the non-secret keys of `vars` (every key
+ * present in `secretKeys` is excluded). The input object is NOT mutated.
+ */
+export function filterSecretVars(vars: Record<string, string>, secretKeys: string[]): Record<string, string> {
+	const secretSet = new Set(secretKeys);
+	const out: Record<string, string> = {};
+	for (const [key, value] of Object.entries(vars)) {
+		if (!secretSet.has(key)) out[key] = value;
+	}
+	return out;
+}

--- a/src/lib/server/stacks.ts
+++ b/src/lib/server/stacks.ts
@@ -46,9 +46,28 @@ import {
 	getAutoUpdateSetting,
 	getStackSourceByComposePath,
 	getSecretProviderById,
-	setStackInjectedSecretKeys
+	setStackInjectedSecretKeys,
+	getStackInjectedSecretKeys
 } from './db';
 import { getProvider } from './secretproviders';
+
+// Version-pointer access (stack_sources.last_saved_at / last_deployed_at) for the
+// S02 version core. Source of truth is the dedicated stack-source-pointers module;
+// re-exported here so the helpers sit alongside the existing stack_sources access.
+// The re-export is safe: stack-source-pointers.ts has a side-effect-free top level,
+// so importing it does not trigger the db/drizzle.js startup seed (better-sqlite3).
+export {
+	readStackSourcePointer,
+	upsertStackSourcePointer,
+	type StackSourcePointerValues,
+	type StackSourcePointers
+} from './stack-source-pointers.js';
+// S03: crash-safe versioned save orchestration (PURE — only node:fs + stack-versions)
+// plus local pointer access for the internal save seams. The pointer import is safe
+// (side-effect-free top level, no better-sqlite3 seed); saveStackVersion is pure.
+import { readStackSourcePointer, upsertStackSourcePointer } from './stack-source-pointers.js';
+import { saveStackVersion, computeRevertedEnvVars, serializeEnvVars } from './stack-version-wiring.js';
+import { listVersions, atomicWriteFile } from './stack-versions.js';
 import { stripSurroundingQuotes } from './secretproviders/shared';
 import { resolveComposeDockerHost, buildComposeBaseArgs } from './compose-docker-args';
 import { unregisterSchedule } from './scheduler';
@@ -224,7 +243,7 @@ if (typeof process !== 'undefined') {
  * Execute a function with exclusive lock on a stack.
  * Prevents race conditions when multiple operations target the same stack.
  */
-async function withStackLock<T>(stackName: string, fn: () => Promise<T>): Promise<T> {
+export async function withStackLock<T>(stackName: string, fn: () => Promise<T>): Promise<T> {
 	const lockKey = stackName;
 
 	// Wait for any existing lock to release
@@ -953,21 +972,33 @@ export async function saveStackComposeFile(
 	}
 
 	if (composePath) {
-		// Write directly to the custom compose file path
-		// Ensure parent directory exists for custom paths
-		const parentDir = dirname(composePath);
-		if (!existsSync(parentDir)) {
-			try {
-				mkdirSync(parentDir, { recursive: true });
-			} catch (err: any) {
-				return { success: false, error: `Failed to create directory for compose file: ${err.message}` };
+		// The edit modal always submits the resolved compose path - including the INTERNAL
+		// default path for internal stacks. Only a genuinely external path is a "custom
+		// path". The internal default must take the versioned save below (which records
+		// the version and advances last_saved_at); the custom-path write here skips
+		// versioning, so routing internal-default saves here left those stacks with no
+		// history at all.
+		const internalDir = create
+			? await getStackDir(name, envId)
+			: await findStackDir(name, envId);
+		const internalDefault = internalDir ? join(internalDir, 'compose.yaml') : null;
+		if (composePath !== internalDefault) {
+			// Write directly to the custom compose file path
+			// Ensure parent directory exists for custom paths
+			const parentDir = dirname(composePath);
+			if (!existsSync(parentDir)) {
+				try {
+					mkdirSync(parentDir, { recursive: true });
+				} catch (err: any) {
+					return { success: false, error: `Failed to create directory for compose file: ${err.message}` };
+				}
 			}
-		}
-		try {
-			writeFileSync(composePath, content);
-			return { success: true };
-		} catch (err: any) {
-			return { success: false, error: `Failed to save compose file: ${err.message}` };
+			try {
+				writeFileSync(composePath, content);
+				return { success: true };
+			} catch (err: any) {
+				return { success: false, error: `Failed to save compose file: ${err.message}` };
+			}
 		}
 	}
 
@@ -1009,11 +1040,30 @@ export async function saveStackComposeFile(
 		}
 	}
 
+	// S03: versioned, locked save for the INTERNAL compose file. Records a bounded
+	// secret-free version (compose YAML verbatim) and advances last_saved_at under
+	// the per-stack lock. The safe-pointer (lastDeployedAt) ensures the deployed
+	// version is never pruned. On a version-write failure the live file is already
+	// rolled back by the orchestration (all-or-nothing), so we just report failure.
+	// Only the internal compose.yaml is versioned here; the custom-path branch above
+	// (composePath set) is out of scope for S03.
+	const pointer = await readStackSourcePointer(name, envId ?? null);
 	try {
-		writeFileSync(composeFile, content);
-		// Return the path actually written so the caller can persist it even when it
-		// supplied no explicit composePath (else the stored path is null while the file
-		// exists at the default location - #1515).
+		await withStackLock(name, async () => {
+			await saveStackVersion({
+				stackDir,
+				livePath: composeFile,
+				type: 'compose',
+				content,
+				// Compose is not secret-filtered — no secretKeys needed.
+				lastDeployedAt: pointer?.lastDeployedAt ?? null,
+				advancePointer: (values) => upsertStackSourcePointer(name, envId ?? null, values),
+			});
+		});
+		// Return the path actually written (saveStackVersion wrote to composeFile) so
+		// the caller can persist it even when it supplied no explicit composePath
+		// (else the stored path is null while the file exists at the default location
+		// - #1515).
 		return { success: true, composePath: composeFile };
 	} catch (err: any) {
 		return { success: false, error: `Failed to ${create ? 'create' : 'save'} compose file: ${err.message}` };
@@ -3265,6 +3315,20 @@ export async function deployStack(options: DeployStackOptions): Promise<StackOpe
 		// stack_* notification (deployGitStack sends git_sync_*).
 		await notifyStackDeploy(name, envId, result, isGitDeploy ?? false);
 
+		// S03: advance the deployed-version pointer on a successful deploy. This is the
+		// single return point every deploy path (local / Hawser / git) funnels through,
+		// and it runs inside the withStackLock body, so the pointer reflects the version
+		// that is now live. Best-effort and success-gated: a pointer-advance failure
+		// must NEVER fail an already-succeeded deploy — it only affects which version is
+		// considered "deployed" (prune-safety + the S05 saved-vs-deployed indicator).
+		if (result.success) {
+			try {
+				await upsertStackSourcePointer(name, envId ?? null, { lastDeployedAt: new Date().toISOString() });
+			} catch (err) {
+				console.warn(`[Stack:${name}] Failed to advance last_deployed_at:`, err);
+			}
+		}
+
 		// Clear stale pending-update badges (#1311). Fire-and-forget with a timeout so a
 		// slow Docker API can't delay or affect the already-succeeded deploy.
 		if (result.success && pullPolicy && typeof envId === 'number') {
@@ -3498,7 +3562,104 @@ export async function writeRawStackEnvFile(
 		mkdirSync(dir, { recursive: true });
 	}
 
-	writeFileSync(envFilePath, rawContent);
+	// S03: versioned, locked save for the INTERNAL env file. Writes the raw .env to
+	// envFilePath AND records a non-secret env version in the internal working dir
+	// (the .history/ lives there even for adopted stacks with a custom envPath).
+	// Secrets are stripped from the stored version (secretKeys from the DB). The
+	// safe-pointer (lastDeployedAt) ensures the deployed version is never pruned.
+	// On error the saveStackVersion throw propagates to the caller (which already
+	// handles it); the live file is rolled back by the orchestration (all-or-nothing).
+	const stackDir = await getStackDir(stackName, envId ?? null);
+	const secretKeys = [...await getStackInjectedSecretKeys(stackName, envId ?? null)];
+	const pointer = await readStackSourcePointer(stackName, envId ?? null);
+	await withStackLock(stackName, async () => {
+		await saveStackVersion({
+			stackDir,
+			livePath: envFilePath,
+			type: 'env',
+			content: rawContent,
+			secretKeys,
+			lastDeployedAt: pointer?.lastDeployedAt ?? null,
+			advancePointer: (values) => upsertStackSourcePointer(stackName, envId ?? null, values),
+		});
+	});
+}
+
+/**
+ * Revert a saved stack version to its live source (S03).
+ *
+ * - `type === 'compose'`: restore the internal `compose.yaml` (S03 versions only the
+ *   internal compose.yaml for the stack dir).
+ * - `type === 'env'`:
+ *   - GIT stack: the DB is the live source. Restore the version's NON-secret subset
+ *     via a NON-destructive merge (computeRevertedEnvVars) so existing secrets are
+ *     PRESERVED — setStackEnvVars deletes-then-inserts the (stack, env) row, so
+ *     feeding only the non-secret subset would WIPE the secrets.
+ *   - internal / adopted: restore the version's non-secret Record to the live `.env`
+ *     file (serializeEnvVars). Comments are lost — a documented S03 limitation.
+ *
+ * Reverting restores an EXISTING version to live; it does NOT create a new version
+ * record. It advances `last_saved_at` so the S05 saved-vs-deployed indicator reflects
+ * the reverted content. Runs under the per-stack lock, so a concurrent save/revert is
+ * last-write-wins.
+ */
+export async function revertStackVersion(
+	stackName: string,
+	envId: number | null | undefined,
+	type: 'compose' | 'env',
+	versionId: string
+): Promise<{ success: boolean; error?: string; timestamp?: string }> {
+	const stackDir =
+		(await findStackDir(stackName, envId ?? null)) ||
+		(await getStackDir(stackName, envId ?? null));
+
+	return withStackLock(stackName, async () => {
+		const versions = listVersions(stackDir, type);
+		const version = versions.find((v) => v.id === versionId);
+		if (!version) {
+			return { success: false, error: `Version ${versionId} not found for ${type}` };
+		}
+
+		if (type === 'env') {
+			const record = version.content as Record<string, string>;
+			const source = await getStackSource(stackName, envId ?? null);
+			if (source?.sourceType === 'git') {
+				// GIT env: the DB is the live source. Read the current vars WITH real
+				// secret values (maskSecrets=false) so the non-destructive merge can
+				// preserve them, merge the version's non-secret subset over them, and
+				// write the merged set back. Secrets survive; nothing secret is wiped.
+				const currentVars = await getStackEnvVars(stackName, envId ?? null, false);
+				const merged = computeRevertedEnvVars(currentVars, record);
+				await setStackEnvVars(stackName, envId ?? null, merged);
+			} else {
+				// internal / adopted: restore the non-secret Record to the live .env file
+				// (same path resolution as writeRawStackEnvFile; comments are lost).
+				const envFilePath = source?.envPath
+					? source.envPath
+					: source?.composePath
+						? join(dirname(source.composePath), '.env')
+						: join(stackDir, '.env');
+				await atomicWriteFile(envFilePath, serializeEnvVars(record));
+			}
+		} else {
+			// type === 'compose': restore the internal compose.yaml.
+			await atomicWriteFile(join(stackDir, 'compose.yaml'), version.content as string);
+		}
+
+		// Point last_saved_at at the REVERTED version's timestamp (not "now"): the
+		// pointer means "the version whose content is live right now", and after a
+		// revert that is exactly this version (live == version content on the
+		// secret-free basis). "now" would point at a time with no version entry.
+		// Best-effort: a pointer failure must NOT fail a revert whose live source
+		// has already been restored.
+		try {
+			await upsertStackSourcePointer(stackName, envId ?? null, { lastSavedAt: version.timestamp });
+		} catch (err) {
+			console.warn(`[Stack:${stackName}] Failed to advance last_saved_at on revert:`, err);
+		}
+
+		return { success: true, timestamp: version.timestamp };
+	});
 }
 
 /**

--- a/src/lib/server/stacks.ts
+++ b/src/lib/server/stacks.ts
@@ -2194,7 +2194,7 @@ export async function listComposeStacks(envId?: number | null): Promise<ComposeS
 /**
  * Get containers for a specific stack by label
  */
-async function getStackContainers(stackName: string, envId?: number | null): Promise<any[]> {
+export async function getStackContainers(stackName: string, envId?: number | null): Promise<any[]> {
 	const { listContainers } = await import('./docker.js');
 	const containers = await listContainers(true, envId);
 	return containers.filter((c) => c.labels['com.docker.compose.project'] === stackName);

--- a/src/lib/utils/stack-history.ts
+++ b/src/lib/utils/stack-history.ts
@@ -18,17 +18,17 @@ export interface StackVersionRef {
 	timestamp: string;
 }
 
-export type HistoryState = 'empty' | 'never-deployed' | 'in-sync' | 'undeployed';
+export type HistoryState = 'empty' | 'never-deployed' | 'in-sync' | 'undeployed' | 'running-unsaved';
 
 export interface HistoryStatus {
 	state: HistoryState;
 	/**
-	 * The newest saved version whose timestamp <= lastDeployedAt (the live/deployed
-	 * one), or null when there is no such version (never deployed, or every saved
-	 * version post-dates the last deploy).
+	 * The newest saved version whose timestamp <= the effective deploy reference
+	 * (lastDeployedAt when set, else deployStartedAt), or null when there is no
+	 * such version (never deployed, or every saved version post-dates the reference).
 	 */
 	deployedVersionId: string | null;
-	/** Number of versions saved strictly after lastDeployedAt. */
+	/** Number of versions saved strictly after the effective deploy reference. */
 	undeployedCount: number;
 }
 
@@ -41,28 +41,43 @@ function toTime(ts: string | null): number | null {
 /**
  * Compute the saved-vs-deployed status for a version list.
  *
+ * The effective deploy reference is `lastDeployedAt` when set (the authoritative
+ * record of a Dockhand-performed deploy), else `deployStartedAt` — the runtime
+ * fallback for stacks deployed OUTSIDE Dockhand (docker CLI, `docker compose up`):
+ * the oldest running container's creation time, i.e. when the stack's live content
+ * became running. The deployed version is the newest saved version at-or-before
+ * that reference.
+ *
  * @param versions  Bounded version refs (newest-first, as returned by the S04 API).
  * @param lastSavedAt  Most recent save time. Accepted for API-shape parity; the
  *   indicator keys off `versions` + `lastDeployedAt`, so this is intentionally
  *   unused (the newest version's timestamp already carries the latest save time).
- * @param lastDeployedAt  Most recent deploy time (null = never deployed).
+ * @param lastDeployedAt  Most recent deploy time (null = never deployed by Dockhand).
+ * @param deployStartedAt  Runtime reference when the stack was deployed outside
+ *   Dockhand (oldest running container's creation time; null = not running or
+ *   unknown). Used only when `lastDeployedAt` is null. Defaults to null.
  */
 export function historyStatus(
 	versions: StackVersionRef[],
 	lastSavedAt: string | null,
-	lastDeployedAt: string | null
+	lastDeployedAt: string | null,
+	deployStartedAt: string | null = null
 ): HistoryStatus {
 	// Accepted for API-shape parity (the panel passes the S04 field through); the
-	// status is derived from the version list + lastDeployedAt, not lastSavedAt.
+	// status is derived from the version list + the effective deploy reference,
+	// not lastSavedAt.
 	void lastSavedAt;
 
 	if (versions.length === 0) {
 		return { state: 'empty', deployedVersionId: null, undeployedCount: 0 };
 	}
 
-	const deployedTime = toTime(lastDeployedAt);
+	// The pointer wins when present; the runtime reference is the external-deploy
+	// fallback (read-only inference, no pointer writes).
+	const reference = lastDeployedAt ?? deployStartedAt;
+	const deployedTime = toTime(reference);
 	if (deployedTime === null) {
-		// Never deployed: every saved version is undeployed.
+		// Never deployed (no pointer, not running): every saved version is undeployed.
 		return { state: 'never-deployed', deployedVersionId: null, undeployedCount: versions.length };
 	}
 
@@ -85,5 +100,13 @@ export function historyStatus(
 		}
 	}
 
-	return { state: undeployedCount === 0 ? 'in-sync' : 'undeployed', deployedVersionId, undeployedCount };
+	if (deployedVersionId !== null) {
+		return { state: undeployedCount === 0 ? 'in-sync' : 'undeployed', deployedVersionId, undeployedCount };
+	}
+
+	// No saved version at-or-before the reference. With the runtime reference that
+	// means the running content was never saved as a version: running-unsaved.
+	// (With the pointer reference this same shape keeps the historical 'undeployed'.)
+	const state: HistoryState = lastDeployedAt === null && deployStartedAt !== null ? 'running-unsaved' : 'undeployed';
+	return { state, deployedVersionId: null, undeployedCount: versions.length };
 }

--- a/src/lib/utils/stack-history.ts
+++ b/src/lib/utils/stack-history.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure saved-vs-deployed status for a stack's bounded version history (M001 S05).
+ *
+ * Pure + side-effect-free (no top-level DB / better-sqlite3 imports) so it can be
+ * imported by a bun test without triggering the better-sqlite3 seed that a
+ * stacks.ts / db.ts import would. Consumed by the History UI to render a
+ * saved-vs-deployed indicator over the S04 `/api/stacks/[name]/history` response
+ * `{ type, versions:[{id,timestamp}], lastSavedAt, lastDeployedAt }`.
+ *
+ * The "deployed" / safe version follows D011: the newest saved version whose
+ * timestamp is <= `last_deployed_at`. Anything saved strictly after the last
+ * deploy is "undeployed".
+ */
+
+export interface StackVersionRef {
+	id: string;
+	/** ISO-8601 timestamp (newest-first as returned by the S04 API). */
+	timestamp: string;
+}
+
+export type HistoryState = 'empty' | 'never-deployed' | 'in-sync' | 'undeployed';
+
+export interface HistoryStatus {
+	state: HistoryState;
+	/**
+	 * The newest saved version whose timestamp <= lastDeployedAt (the live/deployed
+	 * one), or null when there is no such version (never deployed, or every saved
+	 * version post-dates the last deploy).
+	 */
+	deployedVersionId: string | null;
+	/** Number of versions saved strictly after lastDeployedAt. */
+	undeployedCount: number;
+}
+
+function toTime(ts: string | null): number | null {
+	if (ts === null) return null;
+	const t = new Date(ts).getTime();
+	return Number.isNaN(t) ? null : t;
+}
+
+/**
+ * Compute the saved-vs-deployed status for a version list.
+ *
+ * @param versions  Bounded version refs (newest-first, as returned by the S04 API).
+ * @param lastSavedAt  Most recent save time. Accepted for API-shape parity; the
+ *   indicator keys off `versions` + `lastDeployedAt`, so this is intentionally
+ *   unused (the newest version's timestamp already carries the latest save time).
+ * @param lastDeployedAt  Most recent deploy time (null = never deployed).
+ */
+export function historyStatus(
+	versions: StackVersionRef[],
+	lastSavedAt: string | null,
+	lastDeployedAt: string | null
+): HistoryStatus {
+	// Accepted for API-shape parity (the panel passes the S04 field through); the
+	// status is derived from the version list + lastDeployedAt, not lastSavedAt.
+	void lastSavedAt;
+
+	if (versions.length === 0) {
+		return { state: 'empty', deployedVersionId: null, undeployedCount: 0 };
+	}
+
+	const deployedTime = toTime(lastDeployedAt);
+	if (deployedTime === null) {
+		// Never deployed: every saved version is undeployed.
+		return { state: 'never-deployed', deployedVersionId: null, undeployedCount: versions.length };
+	}
+
+	let undeployedCount = 0;
+	let deployedVersionId: string | null = null;
+	let deployedBestTime: number | null = null;
+
+	for (const v of versions) {
+		const t = toTime(v.timestamp);
+		if (t === null) continue; // unparseable timestamp: skip for comparison
+		if (t > deployedTime) {
+			undeployedCount++;
+			continue;
+		}
+		// t <= deployedTime: candidate deployed marker (newest = greatest time; on
+		// exact ties the first-seen wins, which for a newest-first list is the newer).
+		if (deployedBestTime === null || t > deployedBestTime) {
+			deployedBestTime = t;
+			deployedVersionId = v.id;
+		}
+	}
+
+	return { state: undeployedCount === 0 ? 'in-sync' : 'undeployed', deployedVersionId, undeployedCount };
+}

--- a/src/routes/api/stacks/[name]/env/+server.ts
+++ b/src/routes/api/stacks/[name]/env/+server.ts
@@ -1,6 +1,8 @@
 import { json } from '@sveltejs/kit';
-import { getStackEnvVars, setStackEnvVars, getStackSource, getStackInjectedSecretKeys, getSecretProviderById } from '$lib/server/db';
-import { findStackDir } from '$lib/server/stacks';
+import { getStackEnvVars, setStackEnvVars, getStackSource, getStackInjectedSecretKeys, getSecretProviderById, getNonSecretEnvVarsAsRecord } from '$lib/server/db';
+import { findStackDir, getStackDir } from '$lib/server/stacks';
+import { saveStackVersion, serializeEnvVars } from '$lib/server/stack-version-wiring';
+import { upsertStackSourcePointer, readStackSourcePointer } from '$lib/server/stack-source-pointers';
 import { authorize } from '$lib/server/authorize';
 import { existsSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
@@ -217,6 +219,35 @@ export const PUT: RequestHandler = async ({ params, url, cookies, request }) => 
 
 		// Save secrets to database (non-secrets live in the .env file)
 		await setStackEnvVars(stackName, envIdNum, variablesToSave);
+
+		// S03: For a GIT stack the DB is the live source (no on-disk .env), so record a
+		// non-secret env version here (the internal env version is instead recorded by
+		// writeRawStackEnvFile). This is best-effort: a version-record failure must NOT
+		// fail the env save that already succeeded. The safe-pointer (lastDeployedAt)
+		// ensures the deployed version is never pruned.
+		const source = await getStackSource(stackName, envIdNum);
+		if (source?.sourceType === 'git') {
+			try {
+				const stackDir = await getStackDir(stackName, envIdNum ?? null);
+				const secretKeys = [...await getStackInjectedSecretKeys(stackName, envIdNum)];
+				const pointer = await readStackSourcePointer(stackName, envIdNum ?? null);
+				const nonSecret = await getNonSecretEnvVarsAsRecord(stackName, envIdNum);
+				await saveStackVersion({
+					stackDir,
+					type: 'env',
+					// Serialize the non-secret key->value record back to KEY=VALUE content.
+					// The DB is the live source for a GIT stack, so no livePath is set.
+					content: serializeEnvVars(nonSecret),
+					secretKeys,
+					lastDeployedAt: pointer?.lastDeployedAt ?? null,
+					advancePointer: (values) => upsertStackSourcePointer(stackName, envIdNum ?? null, values),
+				});
+			} catch (err) {
+				// Best-effort: the env save already succeeded; a version-record failure
+				// is logged but must not fail the request.
+				console.warn('[env] Failed to record env version:', err);
+			}
+		}
 
 		return json({ success: true, count: variablesToSave.length });
 	} catch (error) {

--- a/src/routes/api/stacks/[name]/env/raw/+server.ts
+++ b/src/routes/api/stacks/[name]/env/raw/+server.ts
@@ -1,6 +1,8 @@
 import { json } from '@sveltejs/kit';
-import { findStackDir, getStackDir } from '$lib/server/stacks';
-import { getStackSource } from '$lib/server/db';
+import { findStackDir, getStackDir, withStackLock } from '$lib/server/stacks';
+import { getStackSource, getStackInjectedSecretKeys } from '$lib/server/db';
+import { saveStackVersion } from '$lib/server/stack-version-wiring';
+import { readStackSourcePointer, upsertStackSourcePointer } from '$lib/server/stack-source-pointers';
 import { authorize } from '$lib/server/authorize';
 import { existsSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
@@ -173,6 +175,34 @@ export const PUT: RequestHandler = async ({ params, url, cookies, request }) => 
 		}
 
 		writeFileSync(envFilePath, content);
+
+		// S05: for internal/adopted stacks, record a secret-free env version so the
+		// env history + revert surface works for plain raw-file saves too (same
+		// mechanism as writeRawStackEnvFile). GIT stacks record env versions via
+		// PUT /env instead - the DB is their live env source. Best-effort: a
+		// version-record failure must NOT fail the env save that already succeeded.
+		if (source?.sourceType !== 'git') {
+			try {
+				const stackDir =
+					(await findStackDir(stackName, envIdNum)) ||
+					(await getStackDir(stackName, envIdNum));
+				const secretKeys = [...await getStackInjectedSecretKeys(stackName, envIdNum)];
+				const pointer = await readStackSourcePointer(stackName, envIdNum);
+				await withStackLock(stackName, async () => {
+					await saveStackVersion({
+						stackDir,
+						livePath: envFilePath,
+						type: 'env',
+						content,
+						secretKeys,
+						lastDeployedAt: pointer?.lastDeployedAt ?? null,
+						advancePointer: (values) => upsertStackSourcePointer(stackName, envIdNum, values)
+					});
+				});
+			} catch (err) {
+				console.warn(`[env/raw] Failed to record env version:`, err);
+			}
+		}
 
 		return json({ success: true });
 	} catch (error) {

--- a/src/routes/api/stacks/[name]/history/+server.ts
+++ b/src/routes/api/stacks/[name]/history/+server.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { authorize } from '$lib/server/authorize';
 import { getStackEnvVars, setStackEnvVars, getStackSource, getStackInjectedSecretKeys } from '$lib/server/db';
-import { getStackDir, revertStackVersion, saveStackComposeFile, writeRawStackEnvFile } from '$lib/server/stacks';
+import { getStackDir, getStackContainers, revertStackVersion, saveStackComposeFile, writeRawStackEnvFile } from '$lib/server/stacks';
 import { saveStackVersion, computeRevertedEnvVars, serializeEnvVars, parseEnvVars } from '$lib/server/stack-version-wiring';
 import { upsertStackSourcePointer, readStackSourcePointer } from '$lib/server/stack-source-pointers';
 import { listVersions, versionContentEquals, filterSecretVars } from '$lib/server/stack-versions';
@@ -69,7 +69,7 @@ async function readLiveContentForType(
  * path: name:string The stack name
  * query: env:integer Environment id the stack belongs to
  * query: type:string Version kind to list (compose or env); defaults to compose
- * resp-200: {type:string!, versions:array<{id:string!, timestamp:string!}>!, lastSavedAt:string, lastDeployedAt:string, currentVersionId:string}
+ * resp-200: {type:string!, versions:array<{id:string!, timestamp:string!}>!, lastSavedAt:string, lastDeployedAt:string, currentVersionId:string, deployStartedAt:string}
  * resp-400: Invalid type (must be compose or env)
  * resp-403: Permission denied (needs stacks:view)
  * resp-500: Failed to read versions
@@ -101,6 +101,22 @@ export const GET: RequestHandler = async ({ params, url, cookies }) => {
 		const versions = listVersions(stackDir, type);
 		const pointer = await readStackSourcePointer(stackName, envIdNum ?? null);
 
+		// External-deploy detection (read-only): when the stack has running containers,
+		// report the OLDEST running container's creation time as `deployStartedAt`.
+		// The panel uses it as the deployed-version reference when the
+		// last_deployed_at pointer is null (the stack was deployed outside Dockhand —
+		// docker CLI, `docker compose up` — so no pointer exists). `created` is epoch
+		// seconds; restarts preserve it (content = deploy-time content), re-creates
+		// update it. Null when no container is running.
+		let deployStartedAt: string | null = null;
+		const runningContainers = (await getStackContainers(stackName, envIdNum ?? null)).filter(
+			(c) => c.state === 'running'
+		);
+		if (runningContainers.length > 0) {
+			const oldest = Math.min(...runningContainers.map((c) => c.created));
+			deployStartedAt = new Date(oldest * 1000).toISOString();
+		}
+
 		// The version whose content is live right now (secret-free basis): match the
 		// live content against the versions (newest-first -> .find yields the NEWEST
 		// match, the single representative after cross-list dedup). A missing live
@@ -118,7 +134,8 @@ export const GET: RequestHandler = async ({ params, url, cookies }) => {
 			versions: versions.map((v) => ({ id: v.id, timestamp: v.timestamp })),
 			lastSavedAt: pointer?.lastSavedAt ?? null,
 			lastDeployedAt: pointer?.lastDeployedAt ?? null,
-			currentVersionId
+			currentVersionId,
+			deployStartedAt
 		});
 	} catch (error) {
 		console.error('Error reading stack versions:', error);

--- a/src/routes/api/stacks/[name]/history/+server.ts
+++ b/src/routes/api/stacks/[name]/history/+server.ts
@@ -1,0 +1,247 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { authorize } from '$lib/server/authorize';
+import { getStackEnvVars, setStackEnvVars, getStackSource, getStackInjectedSecretKeys } from '$lib/server/db';
+import { getStackDir, revertStackVersion, saveStackComposeFile, writeRawStackEnvFile } from '$lib/server/stacks';
+import { saveStackVersion, computeRevertedEnvVars, serializeEnvVars, parseEnvVars } from '$lib/server/stack-version-wiring';
+import { upsertStackSourcePointer, readStackSourcePointer } from '$lib/server/stack-source-pointers';
+import { listVersions, versionContentEquals, filterSecretVars } from '$lib/server/stack-versions';
+
+/**
+ * GET /api/stacks/[name]/history?env=X&type=compose|env
+ *
+ * List a stack's bounded, secret-free saved versions (compose or env) newest-first,
+ * together with the `stack_sources` last_saved_at / last_deployed_at pointers so a
+ * client can show a saved-vs-deployed indicator. An empty version list is a 200 with
+ * `versions: []` (never a 404 — a stack with no saved versions is a valid state).
+ *
+ * Also returns `currentVersionId`: the id of the NEWEST version whose content equals
+ * the live source for `type` right now (secret-free basis), or null when nothing
+ * matches (e.g. the live source is missing). The shared last_saved_at pointer cannot
+ * identify this per type (one column serves both compose and env), so it is computed
+ * here from the live content. The panel uses it to mark the version the editor
+ * currently displays.
+ */
+
+/**
+ * Read the live source for a version type in its STORED form (compose: raw YAML
+ * string; env: secret-free Record<string,string>), or undefined when the live
+ * source is missing (env: no .env file). Path resolution mirrors the save/revert
+ * paths: source.composePath / source.envPath, else the internal defaults.
+ */
+async function readLiveContentForType(
+	type: 'compose' | 'env',
+	stackName: string,
+	envId: number | null,
+	stackDir: string
+): Promise<string | Record<string, string> | undefined> {
+	const source = await getStackSource(stackName, envId);
+	if (type === 'compose') {
+		const composePath = source?.composePath || join(stackDir, 'compose.yaml');
+		if (!existsSync(composePath)) return undefined;
+		return readFileSync(composePath, 'utf8');
+	}
+	// type === 'env'
+	if (source?.sourceType === 'git') {
+		// GIT env: the DB is the live source; non-secret vars only (versions are
+		// secret-free, so the comparison basis must be too).
+		const vars = await getStackEnvVars(stackName, envId, false);
+		const record: Record<string, string> = {};
+		for (const v of vars) {
+			if (!v.isSecret) record[v.key] = v.value;
+		}
+		return record;
+	}
+	// internal / adopted: the live .env file (same resolution as the revert path).
+	const envPath =
+		source?.envPath ||
+		(source?.composePath ? join(dirname(source.composePath), '.env') : join(stackDir, '.env'));
+	if (!existsSync(envPath)) return undefined;
+	const parsed = parseEnvVars(readFileSync(envPath, 'utf8'));
+	return filterSecretVars(parsed, [...(await getStackInjectedSecretKeys(stackName, envId))]);
+}
+/**
+ * @openapi
+ * summary: List a stack's saved versions (compose or env) with saved/deployed pointers
+ * description: Returns the bounded, secret-free version list for `type` (compose or env, defaults to compose) newest-first, plus the stack_sources last_saved_at / last_deployed_at pointers so a client can show a saved-vs-deployed indicator. versions are {id, timestamp}; the pointers are ISO-8601 strings or null (never saved / never deployed).
+ * path: name:string The stack name
+ * query: env:integer Environment id the stack belongs to
+ * query: type:string Version kind to list (compose or env); defaults to compose
+ * resp-200: {type:string!, versions:array<{id:string!, timestamp:string!}>!, lastSavedAt:string, lastDeployedAt:string, currentVersionId:string}
+ * resp-400: Invalid type (must be compose or env)
+ * resp-403: Permission denied (needs stacks:view)
+ * resp-500: Failed to read versions
+ */
+export const GET: RequestHandler = async ({ params, url, cookies }) => {
+	const auth = await authorize(cookies);
+	const env = url.searchParams.get('env');
+	const envIdNum = env ? parseInt(env) : null;
+	const type = url.searchParams.get('type') ?? 'compose';
+
+	// Permission check with environment context
+	if (auth.authEnabled && !await auth.can('stacks', 'view', envIdNum ?? undefined)) {
+		return json({ error: 'Permission denied' }, { status: 403 });
+	}
+
+	// Environment access check (enterprise only)
+	if (envIdNum && auth.isEnterprise && !await auth.canAccessEnvironment(envIdNum)) {
+		return json({ error: 'Access denied to this environment' }, { status: 403 });
+	}
+
+	// `type` must be one of the two version kinds (it defaults to 'compose' above).
+	if (type !== 'compose' && type !== 'env') {
+		return json({ error: 'Invalid type' }, { status: 400 });
+	}
+
+	try {
+		const stackName = decodeURIComponent(params.name);
+		const stackDir = await getStackDir(stackName, envIdNum ?? null);
+		const versions = listVersions(stackDir, type);
+		const pointer = await readStackSourcePointer(stackName, envIdNum ?? null);
+
+		// The version whose content is live right now (secret-free basis): match the
+		// live content against the versions (newest-first -> .find yields the NEWEST
+		// match, the single representative after cross-list dedup). A missing live
+		// source or no match -> null (the panel falls back to the pointer match).
+		let currentVersionId: string | null = null;
+		if (versions.length > 0) {
+			const live = await readLiveContentForType(type, stackName, envIdNum ?? null, stackDir);
+			if (live !== undefined) {
+				currentVersionId = versions.find((v) => versionContentEquals(v.content, live))?.id ?? null;
+			}
+		}
+
+		return json({
+			type,
+			versions: versions.map((v) => ({ id: v.id, timestamp: v.timestamp })),
+			lastSavedAt: pointer?.lastSavedAt ?? null,
+			lastDeployedAt: pointer?.lastDeployedAt ?? null,
+			currentVersionId
+		});
+	} catch (error) {
+		console.error('Error reading stack versions:', error);
+		return json({ error: 'Failed to read versions' }, { status: 500 });
+	}
+};
+
+/**
+ * POST /api/stacks/[name]/history?env=X
+ *
+ * Save a new stack version or revert to a past version.
+ * Body: { action: 'save' | 'revert', type: 'compose' | 'env', content?: string, versionId?: string }.
+ *
+ * - `action=save` persists `content` (compose YAML for type=compose; KEY=VALUE .env text
+ *   for type=env) as a new bounded secret-free version and advances last_saved_at.
+ * - `action=revert` restores the version with `versionId` to the live source and advances
+ *   last_saved_at.
+ *
+ * Secrets are never written to a version: for a GIT stack the DB is the live env source
+ * (existing secrets are preserved via a non-destructive merge), and for an internal /
+ * adopted stack the raw .env file is written via the S03 versioned + locked path.
+ */
+/**
+ * @openapi
+ * summary: Save a new stack version or revert to a past version
+ * description: action=save persists `content` (compose YAML for type=compose; KEY=VALUE .env text for type=env) as a new bounded secret-free version and advances last_saved_at; action=revert restores the version with `versionId` to the live source (internal compose.yaml, or the env .env file for internal stacks / the DB non-secret subset for GIT stacks with existing secrets preserved) and advances last_saved_at. Secrets are never written to a version.
+ * path: name:string The stack name
+ * query: env:integer Environment id the stack belongs to
+ * body: {action:string!, type:string!, content:string, versionId:string}
+ * body-example: {"action":"revert","type":"compose","versionId":"abc123"}
+ * resp-200: {success:boolean!, timestamp:string}
+ * resp-400: Invalid action, type, or missing content/versionId
+ * resp-403: Permission denied (needs stacks:edit)
+ * resp-404: Revert target version not found
+ * resp-500: Failed to save or revert
+ */
+export const POST: RequestHandler = async ({ params, url, cookies, request }) => {
+	const auth = await authorize(cookies);
+	const env = url.searchParams.get('env');
+	const envIdNum = env ? parseInt(env) : null;
+
+	// Permission check with environment context
+	if (auth.authEnabled && !await auth.can('stacks', 'edit', envIdNum ?? undefined)) {
+		return json({ error: 'Permission denied' }, { status: 403 });
+	}
+
+	// Environment access check (enterprise only)
+	if (envIdNum && auth.isEnterprise && !await auth.canAccessEnvironment(envIdNum)) {
+		return json({ error: 'Access denied to this environment' }, { status: 403 });
+	}
+
+	try {
+		const stackName = decodeURIComponent(params.name);
+		const body = await request.json();
+		const { action, type, content, versionId } = body;
+
+		// `action` must be 'save' or 'revert'; `type` must be 'compose' or 'env'.
+		if ((action !== 'save' && action !== 'revert') || (type !== 'compose' && type !== 'env')) {
+			return json({ error: 'Invalid action or type' }, { status: 400 });
+		}
+
+		if (action === 'revert') {
+			// Reverting requires the target version id.
+			if (typeof versionId !== 'string' || !versionId) {
+				return json({ error: 'versionId is required for revert' }, { status: 400 });
+			}
+			const r = await revertStackVersion(stackName, envIdNum ?? null, type, versionId);
+			if (!r.success) {
+				// The version id does not exist in this stack's bounded history.
+				return json({ error: r.error ?? 'Version not found' }, { status: 404 });
+			}
+			return json({ success: true, timestamp: r.timestamp });
+		}
+
+		// action === 'save'
+		if (typeof content !== 'string' || !content) {
+			return json({ error: 'content is required for save' }, { status: 400 });
+		}
+
+		if (type === 'compose') {
+			const r = await saveStackComposeFile(stackName, content, false, envIdNum ?? null, {});
+			if (!r.success) {
+				return json({ error: r.error }, { status: 500 });
+			}
+		} else {
+			// type === 'env'
+			const source = await getStackSource(stackName, envIdNum ?? null);
+			if (source?.sourceType === 'git') {
+				// GIT stack: the DB is the live env source. Merge the submitted non-secret
+				// vars over the current vars so existing secrets are PRESERVED (a secret key
+				// cannot appear in the secret-free parsed record, so every current secret
+				// survives). setStackEnvVars deletes-then-inserts the (stack, env) row.
+				const parsed = parseEnvVars(content);
+				const currentVars = await getStackEnvVars(stackName, envIdNum ?? null, false);
+				const merged = computeRevertedEnvVars(currentVars, parsed);
+				await setStackEnvVars(stackName, envIdNum ?? null, merged);
+
+				// Best-effort: record a secret-free env version + advance last_saved_at.
+				// A version-record failure must NOT fail the env save that already succeeded.
+				try {
+					const stackDir = await getStackDir(stackName, envIdNum ?? null);
+					const secretKeys = [...await getStackInjectedSecretKeys(stackName, envIdNum ?? null)];
+					const pointer = await readStackSourcePointer(stackName, envIdNum ?? null);
+					await saveStackVersion({
+						stackDir,
+						type: 'env',
+						content: serializeEnvVars(parsed),
+						secretKeys,
+						lastDeployedAt: pointer?.lastDeployedAt ?? null,
+						advancePointer: (v) => upsertStackSourcePointer(stackName, envIdNum ?? null, v)
+					});
+				} catch (err) {
+					console.warn('[history] Failed to record env version:', err);
+				}
+			} else {
+				// internal / adopted: write the raw .env file (versioned + locked by S03).
+				await writeRawStackEnvFile(stackName, content, envIdNum ?? null);
+			}
+		}
+
+		return json({ success: true });
+	} catch (error) {
+		console.error('Error saving or reverting stack version:', error);
+		return json({ error: 'Failed to save or revert' }, { status: 500 });
+	}
+};

--- a/src/routes/stacks/StackModal.svelte
+++ b/src/routes/stacks/StackModal.svelte
@@ -6,6 +6,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import CodeEditor, { type VariableMarker } from '$lib/components/CodeEditor.svelte';
 	import StackEnvVarsPanel from '$lib/components/StackEnvVarsPanel.svelte';
+	import StackHistoryPanel from '$lib/components/StackHistoryPanel.svelte';
 	import { type EnvVar, type ValidationResult } from '$lib/components/StackEnvVarsEditor.svelte';
 	import SecretProviderPicker from '$lib/components/SecretProviderPicker.svelte';
 	import { SELECTOR_VARS } from '$lib/utils/bulk-selector';
@@ -83,6 +84,8 @@
 	// Local effective state - can transition from create → edit after failed deploy
 	let mode = $state(propMode);
 	let stackName = $state(propStackName);
+	// Reactive env id for template use (e.g. the History panel's env-scoped fetch).
+	const envId = $derived($currentEnvironment?.id ?? null);
 	let formIcon = $state<string | null>(null);
 	let showIconPicker = $state(false);
 	// Create mode has no stack to POST to yet - stash the pending upload data URL and
@@ -1121,6 +1124,63 @@
 
 		return markers;
 	});
+
+	/**
+	 * On-the-fly revert support: after the history panel successfully reverts a saved
+	 * version (the API already restored the live file + advanced last_saved_at), re-read
+	 * the reverted content into the editor so the change is visible without reopening
+	 * the modal. Unsaved in-editor edits are intentionally overwritten - the user
+	 * explicitly chose to revert.
+	 */
+	async function handleHistoryReverted(type: 'compose' | 'env') {
+		try {
+			if (type === 'compose') {
+				const res = await fetch(
+					appendEnvParam(`/api/stacks/${encodeURIComponent(stackName)}/compose`, envId)
+				);
+				const data = await res.json();
+				if (!res.ok || typeof data.content !== 'string') {
+					console.warn('Failed to re-read reverted compose content:', res.status, data.error);
+					return;
+				}
+				composeContent = data.content;
+				workingComposePath = data.composePath || workingComposePath;
+				isDirty = false;
+				debouncedValidate();
+			} else {
+				// Re-read the MERGED env view (internal stacks: live .env file at request
+				// time + DB secrets; git stacks: DB). It must be the SINGLE source of
+				// truth for the panel sync - re-using the modal's pre-revert envVars
+				// would resurrect vars the revert dropped (syncAfterLoad preserves
+				// loaded-var keys absent from the raw file as "added before first
+				// save", which is exactly the wrong semantics for a revert).
+				const res = await fetch(
+					appendEnvParam(`/api/stacks/${encodeURIComponent(stackName)}/env`, envId)
+				);
+				const data = await res.json();
+				if (!res.ok) {
+					console.warn('Failed to re-read reverted env variables:', res.status, data.error);
+				return;
+				}
+				const newVars: EnvVar[] = (Array.isArray(data.variables) ? data.variables : []).map(
+					(v: { key?: unknown; value?: unknown; isSecret?: unknown }) => ({
+						key: String(v.key ?? ''),
+						value: String(v.value ?? ''),
+						isSecret: !!v.isSecret
+					})
+				);
+				envVars = newVars;
+				await tick();
+				// rawContent intentionally '' - variables are the source of truth after a
+				// revert (the revert API already rewrote the live file/DB); the panel's
+				// text view regenerates from variables.
+				envVarsPanelRef?.syncAfterLoad(newVars, '');
+				isDirty = false;
+			}
+		} catch (e) {
+			console.error('Failed to apply reverted content in editor:', e);
+		}
+	}
 
 	// Stable callback for compose content changes - avoids stale closure issues
 	function handleComposeChange(value: string) {
@@ -2379,10 +2439,11 @@
 									</div>
 								{/if}
 							{/if}
-							<!-- Compose path -->
-							<div class="flex-shrink-0 px-4 py-2" style="width: {splitRatio}%">
-								<PathBarItem
-									label="Compose file"
+							<!-- Compose path (history trigger right after the copy-path button) -->
+							<div class="flex items-center flex-shrink-0 px-4 py-2" style="width: {splitRatio}%">
+								<div class="flex-1 min-w-0">
+									<PathBarItem
+										label="Compose file"
 									path={workingComposePath || null}
 									placeholder="/path/to/compose.yaml"
 									copied={composePathCopied}
@@ -2392,13 +2453,20 @@
 									defaultText={mode === 'create' ? 'Enter stack name above' : 'Not specified'}
 									sourceHint={pathSourceHint}
 								/>
+								</div>
+								{#if mode === 'edit' && !needsFileLocation}
+									<div class="ml-2 flex items-center shrink-0">
+										<StackHistoryPanel stackName={stackName} envId={envId} type="compose" {readonly} dirty={isDirty} side="bottom" align="end" muted onreverted={handleHistoryReverted} />
+									</div>
+								{/if}
 							</div>
 							<!-- Divider spacer -->
 							<div class="w-1 flex-shrink-0"></div>
-							<!-- Env path -->
-							<div class="flex-1 min-w-0 px-4 py-2 bg-zinc-100/50 dark:bg-zinc-800/50">
-								<PathBarItem
-									label="Env file"
+							<!-- Env path (history trigger in the same group as the env item's action buttons) -->
+							<div class="flex items-center flex-1 min-w-0 px-4 py-2 bg-zinc-100/50 dark:bg-zinc-800/50">
+								<div class="flex-1 min-w-0">
+									<PathBarItem
+										label="Env file"
 									path={displayEnvPath || null}
 									selectedPath={workingEnvPath || suggestedEnvPath || ''}
 									placeholder="/path/to/.env (optional)"
@@ -2414,6 +2482,12 @@
 										isDirty = true;
 									}}
 								/>
+								</div>
+								{#if mode === 'edit' && !needsFileLocation}
+									<div class="ml-2 flex items-center shrink-0">
+										<StackHistoryPanel stackName={stackName} envId={envId} type="env" {readonly} dirty={isDirty} side="bottom" align="end" muted onreverted={handleHistoryReverted} />
+									</div>
+								{/if}
 							</div>
 							<!-- Theme toggle -->
 							<div class="flex items-center px-2 shrink-0">
@@ -2503,7 +2577,10 @@
 															<Copy class="w-3 h-3" />
 															Copy
 														{/if}
-													</Button>
+																									</Button>
+													{#if mode === 'edit' && !needsFileLocation}
+														<StackHistoryPanel stackName={stackName} envId={envId} type="compose" {readonly} dirty={isDirty} side="bottom" align="end" label="History" toneClass="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200" onreverted={handleHistoryReverted} />
+													{/if}
 												</div>
 												<div bind:this={editorRowRef} class="flex-1 min-h-0 flex">
 													<CodeEditor
@@ -2587,7 +2664,14 @@
 									onchange={() => { markDirty(); debouncedValidate(); }}
 									theme={editorTheme}
 									infoText="These variables will be written to a .env file in the stack directory and passed to the compose command."
-								/>
+								>
+									{#snippet headerActions()}
+										<!-- Option B: env History copy at the far right of the env header -->
+										{#if mode === 'edit' && !needsFileLocation}
+											<StackHistoryPanel stackName={stackName} envId={envId} type="env" {readonly} dirty={isDirty} side="bottom" align="end" label="History" onreverted={handleHistoryReverted} />
+										{/if}
+									{/snippet}
+								</StackEnvVarsPanel>
 							</div>
 						</div>
 					{:else if activeTab === 'graph'}

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -26212,6 +26212,230 @@
         }
       }
     },
+    "/api/stacks/{name}/history": {
+      "get": {
+        "operationId": "get_api_stacks_name_history",
+        "tags": [
+          "stacks"
+        ],
+        "summary": "List a stack's saved versions (compose or env) with saved/deployed pointers",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The stack name"
+          },
+          {
+            "name": "env",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Environment id the stack belongs to"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Version kind to list (compose or env); defaults to compose"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "versions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "timestamp": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "timestamp"
+                        ]
+                      }
+                    },
+                    "lastSavedAt": {
+                      "type": "string"
+                    },
+                    "lastDeployedAt": {
+                      "type": "string"
+                    },
+                    "currentVersionId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "versions"
+                  ]
+                },
+                "example": {
+                  "type": "string",
+                  "versions": [
+                    {
+                      "id": "string",
+                      "timestamp": "string"
+                    }
+                  ],
+                  "lastSavedAt": "string",
+                  "lastDeployedAt": "string",
+                  "currentVersionId": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid type (must be compose or env)"
+          },
+          "403": {
+            "description": "Permission denied (needs stacks:view)"
+          },
+          "500": {
+            "description": "Failed to read versions"
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "description": "Returns the bounded, secret-free version list for `type` (compose or env, defaults to compose) newest-first, plus the stack_sources last_saved_at / last_deployed_at pointers so a client can show a saved-vs-deployed indicator. versions are {id, timestamp}; the pointers are ISO-8601 strings or null (never saved / never deployed)."
+      },
+      "post": {
+        "operationId": "post_api_stacks_name_history",
+        "tags": [
+          "stacks"
+        ],
+        "summary": "Save a new stack version or revert to a past version",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The stack name"
+          },
+          {
+            "name": "env",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Environment id the stack belongs to"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "timestamp": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                },
+                "example": {
+                  "success": true,
+                  "timestamp": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid action, type, or missing content/versionId"
+          },
+          "403": {
+            "description": "Permission denied (needs stacks:edit)"
+          },
+          "404": {
+            "description": "Revert target version not found"
+          },
+          "500": {
+            "description": "Failed to save or revert"
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "description": "action=save persists `content` (compose YAML for type=compose; KEY=VALUE .env text for type=env) as a new bounded secret-free version and advances last_saved_at; action=revert restores the version with `versionId` to the live source (internal compose.yaml, or the env .env file for internal stacks / the DB non-secret subset for GIT stacks with existing secrets preserved) and advances last_saved_at. Secrets are never written to a version.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "content": {
+                    "type": "string"
+                  },
+                  "versionId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "action",
+                  "type"
+                ]
+              },
+              "example": {
+                "action": "revert",
+                "type": "compose",
+                "versionId": "abc123"
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/stacks/{name}/icon": {
       "get": {
         "operationId": "get_api_stacks_name_icon",

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -26285,6 +26285,9 @@
                     },
                     "currentVersionId": {
                       "type": "string"
+                    },
+                    "deployStartedAt": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26302,7 +26305,8 @@
                   ],
                   "lastSavedAt": "string",
                   "lastDeployedAt": "string",
-                  "currentVersionId": "string"
+                  "currentVersionId": "string",
+                  "deployStartedAt": "string"
                 }
               }
             }

--- a/tests/stack-history.test.ts
+++ b/tests/stack-history.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for the pure saved-vs-deployed status helper (src/lib/utils/stack-history).
+ *
+ * The helper is pure (no DB / better-sqlite3 imports) so it loads cleanly under
+ * bun test. Timestamps are ISO-8601 strings; versions arrive newest-first (the S04
+ * /api/stacks/[name]/history response shape).
+ */
+import { describe, expect, it } from 'bun:test';
+import { historyStatus, type StackVersionRef } from '../src/lib/utils/stack-history';
+
+const v = (id: string, timestamp: string): StackVersionRef => ({ id, timestamp });
+
+describe('historyStatus', () => {
+	it('returns empty for an empty version list', () => {
+		expect(historyStatus([], '2026-01-03T00:00:00Z', '2026-01-02T00:00:00Z')).toEqual({
+			state: 'empty',
+			deployedVersionId: null,
+			undeployedCount: 0
+		});
+	});
+
+	it('is never-deployed when lastDeployedAt is null (every version undeployed)', () => {
+		expect(historyStatus([v('v2', '2026-01-02T00:00:00Z'), v('v1', '2026-01-01T00:00:00Z')], '2026-01-02T00:00:00Z', null)).toEqual({
+			state: 'never-deployed',
+			deployedVersionId: null,
+			undeployedCount: 2
+		});
+	});
+
+	it('is in-sync when the newest saved version is at-or-before the last deploy', () => {
+		expect(historyStatus([v('v3', '2026-01-03T00:00:00Z'), v('v2', '2026-01-02T00:00:00Z')], '2026-01-03T00:00:00Z', '2026-01-03T00:00:00Z')).toEqual({
+			state: 'in-sync',
+			deployedVersionId: 'v3',
+			undeployedCount: 0
+		});
+	});
+
+	it('marks the newest-at-or-before-deploy version as deployed and counts versions after deploy', () => {
+		// v3 (01-05) is after deploy (01-04) -> undeployed; v2 (01-04) is the newest at-or-before.
+		expect(
+			historyStatus(
+				[v('v3', '2026-01-05T00:00:00Z'), v('v2', '2026-01-04T00:00:00Z'), v('v1', '2026-01-03T00:00:00Z')],
+				'2026-01-05T00:00:00Z',
+				'2026-01-04T00:00:00Z'
+			)
+		).toEqual({ state: 'undeployed', deployedVersionId: 'v2', undeployedCount: 1 });
+	});
+
+	it('counts multiple versions saved since deploy', () => {
+		// All three are after deploy (01-02) -> undeployedCount 3, no deployed marker.
+		expect(
+			historyStatus(
+				[v('v3', '2026-01-05T00:00:00Z'), v('v2', '2026-01-04T00:00:00Z'), v('v1', '2026-01-03T00:00:00Z')],
+				'2026-01-05T00:00:00Z',
+				'2026-01-02T00:00:00Z'
+			)
+		).toEqual({ state: 'undeployed', deployedVersionId: null, undeployedCount: 3 });
+	});
+
+	it('basic undeployed: one version after deploy, deployed marker is the newest at-or-before', () => {
+		expect(
+			historyStatus([v('v2', '2026-01-02T00:00:00Z'), v('v1', '2026-01-01T00:00:00Z')], '2026-01-02T00:00:00Z', '2026-01-01T00:00:00Z')
+		).toEqual({ state: 'undeployed', deployedVersionId: 'v1', undeployedCount: 1 });
+	});
+
+	it('on equal timestamps at-or-before deploy, picks the first-seen (newer) version', () => {
+		// Both share the deploy timestamp; newest-first list -> first-seen is preferred.
+		expect(
+			historyStatus(
+				[v('newer', '2026-01-04T00:00:00Z'), v('older', '2026-01-04T00:00:00Z')],
+				'2026-01-04T00:00:00Z',
+				'2026-01-04T00:00:00Z'
+			)
+		).toEqual({ state: 'in-sync', deployedVersionId: 'newer', undeployedCount: 0 });
+	});
+
+	it('skips versions with an unparseable timestamp for comparison', () => {
+		// 'not-a-date' is ignored; only v1 (01-01) is at-or-before deploy (01-01).
+		expect(
+			historyStatus([v('bad', 'not-a-date'), v('v1', '2026-01-01T00:00:00Z')], '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+		).toEqual({ state: 'in-sync', deployedVersionId: 'v1', undeployedCount: 0 });
+	});
+});

--- a/tests/stack-history.test.ts
+++ b/tests/stack-history.test.ts
@@ -81,3 +81,71 @@ describe('historyStatus', () => {
 		).toEqual({ state: 'in-sync', deployedVersionId: 'v1', undeployedCount: 0 });
 	});
 });
+
+describe('historyStatus - external-deploy detection (deployStartedAt runtime reference)', () => {
+	it('infers the deployed version from deployStartedAt when the pointer is null', () => {
+		// Stack deployed outside Dockhand: versions v1 (01-01) and v2 (01-02) saved,
+		// containers created at 01-03 -> v2 was live when deployed.
+		expect(
+			historyStatus(
+				[v('v2', '2026-01-02T00:00:00Z'), v('v1', '2026-01-01T00:00:00Z')],
+				'2026-01-02T00:00:00Z',
+				null,
+				'2026-01-03T00:00:00Z'
+			)
+		).toEqual({ state: 'in-sync', deployedVersionId: 'v2', undeployedCount: 0 });
+	});
+
+	it('counts versions saved after the external deploy as undeployed', () => {
+		expect(
+			historyStatus(
+				[v('v3', '2026-01-04T00:00:00Z'), v('v2', '2026-01-02T00:00:00Z')],
+				'2026-01-04T00:00:00Z',
+				null,
+				'2026-01-03T00:00:00Z'
+			)
+		).toEqual({ state: 'undeployed', deployedVersionId: 'v2', undeployedCount: 1 });
+	});
+
+	it('is running-unsaved when every saved version post-dates the external deploy', () => {
+		// The running content was never saved as a version.
+		expect(
+			historyStatus(
+				[v('v2', '2026-01-04T00:00:00Z'), v('v1', '2026-01-03T12:00:00Z')],
+				'2026-01-04T00:00:00Z',
+				null,
+				'2026-01-03T00:00:00Z'
+			)
+		).toEqual({ state: 'running-unsaved', deployedVersionId: null, undeployedCount: 2 });
+	});
+
+	it('the lastDeployedAt pointer wins over deployStartedAt when both are set', () => {
+		expect(
+			historyStatus(
+				[v('v2', '2026-01-02T00:00:00Z'), v('v1', '2026-01-01T00:00:00Z')],
+				'2026-01-02T00:00:00Z',
+				'2026-01-02T12:00:00Z',
+				'2026-01-05T00:00:00Z'
+			)
+		).toEqual({ state: 'in-sync', deployedVersionId: 'v2', undeployedCount: 0 });
+	});
+
+	it('is never-deployed when neither pointer nor runtime reference exists', () => {
+		expect(
+			historyStatus(
+				[v('v1', '2026-01-01T00:00:00Z')],
+				'2026-01-01T00:00:00Z',
+				null,
+				null
+			)
+		).toEqual({ state: 'never-deployed', deployedVersionId: null, undeployedCount: 1 });
+	});
+
+	it('deployStartedAt defaults to null (back-compat 3-arg call)', () => {
+		expect(historyStatus([v('v1', '2026-01-01T00:00:00Z')], '2026-01-01T00:00:00Z', null)).toEqual({
+			state: 'never-deployed',
+			deployedVersionId: null,
+			undeployedCount: 1
+		});
+	});
+});

--- a/tests/stack-version-wiring.test.ts
+++ b/tests/stack-version-wiring.test.ts
@@ -1,0 +1,550 @@
+/**
+ * Integration tests for the PURE stack-version-wiring orchestration module
+ * (saveStackVersion / findSafeVersionId / computeRevertedEnvVars /
+ * serializeEnvVars).
+ *
+ * These exercise the REAL module against REAL tmp dirs (node:fs mkdtemp in
+ * os.tmpdir) with INJECTABLE writeLive / recordVersion / advancePointer so the
+ * crash-safe ordering, rollback, and best-effort pointer semantics can be
+ * observed deterministically.
+ *
+ * ## Purity (MEM016) — do NOT import stacks.ts or db.ts here.
+ * A top-level import of either would load better-sqlite3 and crash every test.
+ * The module under test is imported directly; importing it successfully under
+ * bun:test is itself the strongest purity proof. The explicit grep-style purity
+ * check at the bottom re-verifies the module has no stacks.js / db.js /
+ * better-sqlite3 import.
+ */
+import { describe, it, expect, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+	saveStackVersion,
+	findSafeVersionId,
+	computeRevertedEnvVars,
+	serializeEnvVars
+} from '../src/lib/server/stack-version-wiring';
+import { atomicWriteFile, historyPath, listVersions, saveVersion } from '../src/lib/server/stack-versions';
+import type { StackVersion } from '../src/lib/server/stack-versions';
+
+/** Fresh temp dir per test, cleaned up afterwards (mirrors tests/stack-versions.test.ts). */
+const tempDirs: string[] = [];
+function newTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), 'sdv-wiring-'));
+	tempDirs.push(dir);
+	return dir;
+}
+afterEach(() => {
+	while (tempDirs.length) {
+		const d = tempDirs.pop();
+		if (d) rmSync(d, { recursive: true, force: true });
+	}
+});
+
+/** Fixed millisecond-based ISO timestamp helper for deterministic ordering. */
+const ts = (ms: number): string => new Date(ms).toISOString();
+
+/** Is this a valid ISO-8601 timestamp? */
+function validIso(s: string): boolean {
+	if (typeof s !== 'string' || s.length < 19) return false;
+	return !Number.isNaN(Date.parse(s)) && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(s);
+}
+
+/** Type for the pointer-advance values the module passes to advancePointer. */
+type PointerValues = { lastSavedAt?: string; lastDeployedAt?: string };
+
+describe('saveStackVersion — compose', () => {
+	it('records .history/compose.json (id + ISO timestamp), writes the live file, advances the pointer', async () => {
+		const dir = newTempDir();
+		const yaml = 'services:\n  app:\n    image: nginx\n';
+		const livePath = join(dir, 'compose.yaml');
+		let pointerValues: PointerValues | null = null;
+
+		const res = await saveStackVersion({
+			stackDir: dir,
+			type: 'compose',
+			content: yaml,
+			livePath,
+			advancePointer: async (values) => {
+				pointerValues = values;
+			}
+		});
+
+		// .history/compose.json created (newest-first) with id + ISO timestamp.
+		const list = listVersions(dir, 'compose');
+		expect(list.length).toBe(1);
+		expect(list[0].id).toBe(res.id);
+		expect(validIso(list[0].timestamp)).toBe(true);
+		expect(list[0].content).toBe(yaml);
+		// Live file written to the new content.
+		expect(readFileSync(livePath, 'utf8')).toBe(yaml);
+		// Pointer advanced with the returned timestamp.
+		expect(pointerValues).toEqual({ lastSavedAt: res.timestamp });
+		expect(res.liveWritten).toBe(true);
+		expect(res.rolledBack).toBe(false);
+	});
+});
+
+describe('saveStackVersion — env', () => {
+	it('stores ONLY the non-secret Record in .history/env.json, writes the live file, advances the pointer', async () => {
+		const dir = newTempDir();
+		const content = ['# comment', 'FOO=bar', 'DB_PASSWORD=hunter2', 'BAZ=qux'].join('\n');
+		const secretKeys = ['DB_PASSWORD'];
+		const livePath = join(dir, '.env');
+		let pointerValues: PointerValues | null = null;
+
+		const res = await saveStackVersion({
+			stackDir: dir,
+			type: 'env',
+			content,
+			secretKeys,
+			livePath,
+			advancePointer: async (values) => {
+				pointerValues = values;
+			}
+		});
+
+		// .history/env.json stores only the non-secret record.
+		const list = listVersions(dir, 'env');
+		expect(list.length).toBe(1);
+		const stored = list[0].content as Record<string, string>;
+		expect(stored).toEqual({ FOO: 'bar', BAZ: 'qux' });
+		expect('DB_PASSWORD' in stored).toBe(false);
+		// Live file written verbatim.
+		expect(readFileSync(livePath, 'utf8')).toBe(content);
+		// Pointer advanced.
+		expect(pointerValues).toEqual({ lastSavedAt: res.timestamp });
+		expect(res.liveWritten).toBe(true);
+	});
+
+	it('filters a leaked secret key out before store; save does NOT throw', async () => {
+		const dir = newTempDir();
+		const content = ['FOO=bar', 'DB_PASSWORD=hunter2', 'API_KEY=abc'].join('\n');
+		const secretKeys = ['DB_PASSWORD', 'API_KEY'];
+
+		// recordVersion = saveVersion (default); if the secret were NOT filtered it
+		// would trip saveVersion's assertSecretFree guard and throw. It is filtered,
+		// so the save succeeds.
+		const res = await saveStackVersion({
+			stackDir: dir,
+			type: 'env',
+			content,
+			secretKeys
+		});
+
+		const list = listVersions(dir, 'env');
+		expect(list.length).toBe(1);
+		const stored = list[0].content as Record<string, string>;
+		expect(stored).toEqual({ FOO: 'bar' });
+		expect('DB_PASSWORD' in stored).toBe(false);
+		expect('API_KEY' in stored).toBe(false);
+		expect(res.id).toBeTruthy();
+		expect(res.liveWritten).toBe(false); // livePath omitted
+	});
+});
+
+	describe('saveStackVersion — no-op duplicate content', () => {
+		it('identical compose content: no new version, pointer NOT advanced, skipped=true', async () => {
+			const dir = newTempDir();
+			const livePath = join(dir, 'compose.yaml');
+			const yaml = 'services:\n  app:\n    image: nginx\n';
+			const advances: PointerValues[] = [];
+
+			const r1 = await saveStackVersion({
+				stackDir: dir,
+				type: 'compose',
+				content: yaml,
+				livePath,
+				advancePointer: (values) => {
+					advances.push(values);
+				}
+			});
+			expect(r1.skipped).toBe(false);
+
+			const r2 = await saveStackVersion({
+				stackDir: dir,
+				type: 'compose',
+				content: yaml,
+				livePath,
+				advancePointer: (values) => {
+					advances.push(values);
+				}
+			});
+			expect(r2.skipped).toBe(true);
+			// References the pre-existing version; no pointer churn, no duplicate entry.
+			expect(r2.id).toBe(r1.id);
+			expect(r2.timestamp).toBe(r1.timestamp);
+			expect(advances.length).toBe(1);
+			expect(listVersions(dir, 'compose').length).toBe(1);
+		});
+
+		it('env: comment-only change is a no-op (live file keeps the formatting); a value change is not', async () => {
+			const dir = newTempDir();
+			const livePath = join(dir, '.env');
+			const advances: PointerValues[] = [];
+			const advance = (values: PointerValues) => {
+				advances.push(values);
+			};
+
+			const r1 = await saveStackVersion({
+				stackDir: dir,
+				type: 'env',
+				content: 'FOO=bar\n',
+				livePath,
+				advancePointer: advance
+			});
+			expect(r1.skipped).toBe(false);
+
+			// Same parsed vars (plus a comment) -> no-op, but the live file picks
+			// up the new formatting (live write precedes the no-op check).
+			const r2 = await saveStackVersion({
+				stackDir: dir,
+				type: 'env',
+				content: '# note\nFOO=bar\n',
+				livePath,
+				advancePointer: advance
+			});
+			expect(r2.skipped).toBe(true);
+			expect(r2.id).toBe(r1.id);
+			expect(advances.length).toBe(1);
+			expect(listVersions(dir, 'env').length).toBe(1);
+			expect(readFileSync(livePath, 'utf8')).toBe('# note\nFOO=bar\n');
+
+			// A real value change records a new version and advances the pointer.
+			const r3 = await saveStackVersion({
+				stackDir: dir,
+				type: 'env',
+				content: '# note\nFOO=baz\n',
+				livePath,
+				advancePointer: advance
+			});
+			expect(r3.skipped).toBe(false);
+			expect(advances.length).toBe(2);
+			const list = listVersions(dir, 'env');
+			expect(list.length).toBe(2);
+			expect(list[0].content).toEqual({ FOO: 'baz' });
+		});
+
+		it('revert-then-save: an older duplicate is dropped and the new entry is the single representative', async () => {
+			const dir = newTempDir();
+			const livePath = join(dir, 'compose.yaml');
+			const advances: PointerValues[] = [];
+			const advance = (values: PointerValues) => {
+				advances.push(values);
+			};
+
+			// v1: A, v2: B (both saved live).
+			const r1 = await saveStackVersion({
+				stackDir: dir,
+				type: 'compose',
+				content: 'A',
+				livePath,
+				advancePointer: advance
+			});
+			await saveStackVersion({
+				stackDir: dir,
+				type: 'compose',
+				content: 'B',
+				livePath,
+				advancePointer: advance
+			});
+
+			// Revert to A (live file back to A) and SAVE it: not a no-op (newest is
+			// B), so a new entry is recorded AND the older A duplicate is dropped.
+			const r3 = await saveStackVersion({
+				stackDir: dir,
+				type: 'compose',
+				content: 'A',
+				livePath,
+				advancePointer: advance
+			});
+			expect(r3.skipped).toBe(false);
+			expect(r3.id).not.toBe(r1.id);
+			const list = listVersions(dir, 'compose');
+			expect(list.length).toBe(2);
+			expect(list[0].id).toBe(r3.id);
+			expect(list[0].content).toBe('A');
+			expect(list[1].content).toBe('B');
+			// The older A (r1) is gone; the pointer advanced once per actual save.
+			expect(list.some((v) => v.id === r1.id)).toBe(false);
+			expect(advances.length).toBe(3);
+		});
+
+		it('no-op save normalizes a stale duplicate list left by pre-fix code', async () => {
+			const dir = newTempDir();
+			const livePath = join(dir, 'compose.yaml');
+			const t1 = '2026-01-01T00:00:00.000Z';
+			const t2 = '2026-01-02T00:00:00.000Z';
+			const t3 = '2026-01-03T00:00:00.000Z';
+			const advances: PointerValues[] = [];
+
+			// Legacy list: A, B, A (as pre-fix saves would have left it).
+			atomicWriteFile(
+				historyPath(dir, 'compose'),
+				JSON.stringify({
+					versions: [
+						{ id: t1, timestamp: t1, content: 'A' },
+						{ id: t2, timestamp: t2, content: 'B' },
+						{ id: t3, timestamp: t3, content: 'A' }
+					]
+				}, null, 2)
+			);
+
+			// Saving A (== newest) is a NO-OP - but it still collapses the stale
+			// duplicate (t1), and advances no pointer.
+			const r = await saveStackVersion({
+				stackDir: dir,
+				type: 'compose',
+				content: 'A',
+				livePath,
+				advancePointer: (values) => {
+					advances.push(values);
+				}
+			});
+			expect(r.skipped).toBe(true);
+			expect(r.id).toBe(t3);
+			expect(advances.length).toBe(0);
+			const list = listVersions(dir, 'compose');
+			expect(list.map((v) => v.id)).toEqual([t3, t2]);
+			expect(list.some((v) => v.id === t1)).toBe(false);
+		});
+	});
+
+describe('saveStackVersion — failure / rollback / ordering', () => {
+	it('mid-write failure: recordVersion throws -> live file restored, .history unchanged, advancePointer NOT called', async () => {
+		const dir = newTempDir();
+		const livePath = join(dir, '.env');
+
+		// Pre-create the live file with previous content.
+		writeFileSync(livePath, 'PREV=content');
+		// Pre-create a .history file with an existing version.
+		saveVersion(dir, 'env', { PREV: 'content' }, { id: 'v1', timestamp: ts(1_000), maxVersions: 100 });
+		expect(listVersions(dir, 'env').length).toBe(1);
+
+		let pointerCalled = false;
+		let threw = false;
+		try {
+			await saveStackVersion({
+				stackDir: dir,
+				type: 'env',
+				content: 'NEW=content',
+				livePath,
+				advancePointer: async () => {
+					pointerCalled = true;
+				},
+				// Inject a recordVersion that THROWS (simulates a version-write failure).
+				recordVersion: () => {
+					throw new Error('version write failed');
+				}
+			});
+		} catch {
+			threw = true;
+		}
+
+		expect(threw).toBe(true);
+		// Live file RESTORED to the previous content.
+		expect(readFileSync(livePath, 'utf8')).toBe('PREV=content');
+		// .history file UNCHANGED (still only the previous version v1).
+		const list = listVersions(dir, 'env');
+		expect(list.length).toBe(1);
+		expect(list[0].id).toBe('v1');
+		// advancePointer NOT called (it runs after recordVersion, which threw).
+		expect(pointerCalled).toBe(false);
+	});
+
+	it('crash-safe ordering: writeLive precedes recordVersion (live-file-first)', async () => {
+		const dir = newTempDir();
+		const livePath = join(dir, 'compose.yaml');
+		const log: string[] = [];
+
+		await saveStackVersion({
+			stackDir: dir,
+			type: 'compose',
+			content: 'yaml',
+			livePath,
+			writeLive: () => {
+				log.push('writeLive');
+			},
+			recordVersion: () => {
+				log.push('recordVersion');
+				return { id: 'x', timestamp: ts(5_000) };
+			}
+		});
+
+		expect(log).toEqual(['writeLive', 'recordVersion']);
+	});
+});
+
+describe('saveStackVersion — GIT env (livePath omitted)', () => {
+	it('records the version, writes NO live file (writeLive not called), advances the pointer', async () => {
+		const dir = newTempDir();
+		const content = 'FOO=bar\nDB_PASSWORD=hunter2';
+		const secretKeys = ['DB_PASSWORD'];
+		let writeLiveCalled = false;
+		let pointerValues: PointerValues | null = null;
+
+		const res = await saveStackVersion({
+			stackDir: dir,
+			type: 'env',
+			content,
+			secretKeys,
+			// livePath omitted: GIT env, DB is the live source.
+			writeLive: () => {
+				writeLiveCalled = true;
+			},
+			advancePointer: async (values) => {
+				pointerValues = values;
+			}
+		});
+
+		// Version recorded (default recordVersion = saveVersion -> .history/env.json).
+		const list = listVersions(dir, 'env');
+		expect(list.length).toBe(1);
+		expect(list[0].content).toEqual({ FOO: 'bar' });
+		// NO live file written.
+		expect(writeLiveCalled).toBe(false);
+		expect(res.liveWritten).toBe(false);
+		// Pointer advanced.
+		expect(pointerValues).toEqual({ lastSavedAt: res.timestamp });
+	});
+});
+
+describe('findSafeVersionId', () => {
+	it('returns the newest id whose timestamp <= lastDeployedAt', () => {
+		const versions: StackVersion[] = [
+			{ id: 'a', timestamp: ts(1_000), content: 'x' },
+			{ id: 'b', timestamp: ts(2_000), content: 'y' },
+			{ id: 'c', timestamp: ts(3_000), content: 'z' }
+		];
+		// lastDeployedAt between ts(2000) and ts(3000) -> b is the newest <= it.
+		expect(findSafeVersionId(versions, ts(2_500))).toBe('b');
+		// Exactly at a version boundary -> that version.
+		expect(findSafeVersionId(versions, ts(3_000))).toBe('c');
+		// Before the earliest -> the earliest.
+		expect(findSafeVersionId(versions, ts(1_500))).toBe('a');
+	});
+
+	it('returns undefined for null / undefined lastDeployedAt', () => {
+		const versions: StackVersion[] = [{ id: 'a', timestamp: ts(1_000), content: 'x' }];
+		expect(findSafeVersionId(versions, null)).toBeUndefined();
+		expect(findSafeVersionId(versions, undefined)).toBeUndefined();
+	});
+
+	it('returns undefined when no version timestamp is <= lastDeployedAt', () => {
+		const versions: StackVersion[] = [
+			{ id: 'a', timestamp: ts(5_000), content: 'x' },
+			{ id: 'b', timestamp: ts(6_000), content: 'y' }
+		];
+		expect(findSafeVersionId(versions, ts(1_000))).toBeUndefined();
+	});
+
+	it('ties (identical timestamp) are broken by id (larger id wins)', () => {
+		const t = ts(3_000);
+		const versions: StackVersion[] = [
+			{ id: 'a', timestamp: t, content: 'x' },
+			{ id: 'b', timestamp: t, content: 'y' },
+			{ id: 'z', timestamp: t, content: 'w' }
+		];
+		expect(findSafeVersionId(versions, t)).toBe('z');
+	});
+});
+
+describe('computeRevertedEnvVars', () => {
+	it('version non-secret values override current; current secrets preserved verbatim; current non-secrets absent from the version are dropped; no secret lost', () => {
+		const currentVars = [
+			{ key: 'FOO', value: 'c-foo', isSecret: false },
+			{ key: 'BAZ', value: 'c-baz', isSecret: false },
+			{ key: 'EXTRA', value: 'c-extra', isSecret: false }, // not in version -> dropped
+			{ key: 'DB_PASSWORD', value: 'c-secret', isSecret: true }, // preserved
+			{ key: 'API_KEY', value: 'c-key', isSecret: true } // preserved
+		];
+		const versionRecord = { FOO: 'v-foo', BAZ: 'v-baz' };
+
+		const result = computeRevertedEnvVars(currentVars, versionRecord);
+		const byKey: Record<string, { value: string; isSecret?: boolean }> = Object.fromEntries(
+			result.map((v) => [v.key, v])
+		);
+
+		// Version non-secret values override current.
+		expect(byKey.FOO.value).toBe('v-foo');
+		expect(byKey.FOO.isSecret).toBe(false);
+		expect(byKey.BAZ.value).toBe('v-baz');
+		expect(byKey.BAZ.isSecret).toBe(false);
+		// Current secrets preserved verbatim.
+		expect(byKey.DB_PASSWORD.value).toBe('c-secret');
+		expect(byKey.DB_PASSWORD.isSecret).toBe(true);
+		expect(byKey.API_KEY.value).toBe('c-key');
+		expect(byKey.API_KEY.isSecret).toBe(true);
+		// Current non-secret absent from the version is dropped.
+		expect('EXTRA' in byKey).toBe(false);
+		// Exactly 4 entries (2 version non-secrets + 2 preserved secrets).
+		expect(result.length).toBe(4);
+	});
+
+	it('empty version record -> only current secrets survive', () => {
+		const currentVars = [
+			{ key: 'ONLY_NONSECRET', value: 'x', isSecret: false },
+			{ key: 'S', value: 'secret', isSecret: true }
+		];
+		const result = computeRevertedEnvVars(currentVars, {});
+		expect(result.length).toBe(1);
+		expect(result[0].key).toBe('S');
+		expect(result[0].value).toBe('secret');
+		expect(result[0].isSecret).toBe(true);
+	});
+
+	it('empty current + version -> empty result', () => {
+		expect(computeRevertedEnvVars([], {})).toEqual([]);
+	});
+});
+
+describe('serializeEnvVars', () => {
+	it('joins KEY=VALUE lines with \\n', () => {
+		expect(serializeEnvVars({ FOO: 'bar', BAZ: 'qux' })).toBe('FOO=bar\nBAZ=qux');
+	});
+
+	it('empty record -> empty string', () => {
+		expect(serializeEnvVars({})).toBe('');
+	});
+});
+
+describe('module purity (MEM016)', () => {
+	// The module source, resolved relative to this test file.
+	const MODULE_SRC = join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'lib', 'server', 'stack-version-wiring.ts');
+
+	/** Extract every import/require specifier (from 'x', import('x'), require('x')). */
+	function extractImportSpecifiers(src: string): string[] {
+		const specifiers: string[] = [];
+		const fromRe = /from\s+['"]([^'"]+)['"]/g;
+		const dynamicRe = /import\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+		const requireRe = /require\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+		let m: RegExpExecArray | null;
+		while ((m = fromRe.exec(src)) !== null) specifiers.push(m[1]);
+		while ((m = dynamicRe.exec(src)) !== null) specifiers.push(m[1]);
+		while ((m = requireRe.exec(src)) !== null) specifiers.push(m[1]);
+		return specifiers;
+	}
+
+	it('imports ONLY node:fs / node:path / ./stack-versions.js / ./env-parser.js', () => {
+		const src = readFileSync(MODULE_SRC, 'utf8');
+		const specifiers = extractImportSpecifiers(src);
+		// There must be imports at all (node:fs + ./stack-versions.js).
+		expect(specifiers.length).toBeGreaterThanOrEqual(2);
+		const allowed = new Set(['node:fs', 'node:path', './stack-versions.js', './env-parser.js']);
+		for (const s of specifiers) {
+			expect(allowed.has(s), `unexpected import specifier: ${s}`).toBe(true);
+		}
+	});
+
+	it('has NO import of stacks.js / db.js / better-sqlite3', () => {
+		const src = readFileSync(MODULE_SRC, 'utf8');
+		const specifiers = extractImportSpecifiers(src);
+		for (const s of specifiers) {
+			expect(s.includes('stacks.js'), `unexpected stacks.js import: ${s}`).toBe(false);
+			expect(s.endsWith('db.js') || s.includes('/db.js'), `unexpected db.js import: ${s}`).toBe(false);
+			expect(s.includes('better-sqlite3'), `unexpected better-sqlite3 import: ${s}`).toBe(false);
+		}
+	});
+});

--- a/tests/stack-versioning.test.ts
+++ b/tests/stack-versioning.test.ts
@@ -1,0 +1,199 @@
+/**
+ * S01 test-only exit (T4).
+ *
+ * Proves the 0016_add_stack_versioning migration and the stack_sources version
+ * pointers hold up without any user-visible behavior yet:
+ *
+ *   (a) Fresh SQLite — open a bun:sqlite in-memory DB (the app runtime path uses
+ *       better-sqlite3 which bun test cannot load), apply the raw drizzle/00NN_*.sql
+ *       files in order, assert 0016 applies cleanly and stack_sources gained
+ *       last_saved_at / last_deployed_at, then round-trip those pointers on a bare
+ *       internal stack (environment_id = NULL) through the T3 helper's emitted SQL.
+ *   (b) drizzle-pg lockstep parity (CI-runnable, no live PG) — assert the PG 0016
+ *       migration exists, both journals advanced together to a 0016 entry, and the
+ *       PG ALTER targets the same stack_sources columns as the SQLite one. This
+ *       catches the D004 missed-journal-entry silent failure.
+ *
+ * Part (c) of the S01 exit (definitive fresh-Postgres live-apply) is operational and
+ * is exercised by scripts/emergency/fresh-postgres-migrate-check.sh (docker), not
+ * here, because live Postgres is not runnable under bun test.
+ */
+import { describe, test, expect, beforeAll } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+	buildRead,
+	buildUpdate,
+	buildInsert,
+	type StackSourcePointerValues
+} from '../src/lib/server/stack-source-pointers';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+const sqliteMigrationsDir = join(repoRoot, 'drizzle');
+const pgMigrationsDir = join(repoRoot, 'drizzle-pg');
+
+/**
+ * Apply every drizzle/00NN_*.sql file in order against a fresh bun:sqlite DB.
+ * This mirrors what the app's SQLite migrate path produces on a fresh DB, but
+ * uses the raw migration SQL (the app's migrate() uses better-sqlite3, which is
+ * not loadable under bun test).
+ */
+function applySqliteMigrations(db: Database): string[] {
+	const files = readdirSync(sqliteMigrationsDir)
+		.filter((f) => f.endsWith('.sql'))
+		.sort();
+	expect(files.length).toBeGreaterThan(0);
+	for (const file of files) {
+		const content = readFileSync(join(sqliteMigrationsDir, file), 'utf-8');
+		for (const statement of content.split('--> statement-breakpoint')) {
+			const trimmed = statement.trim();
+			if (trimmed) db.exec(trimmed);
+		}
+	}
+	return files;
+}
+
+function stackSourceColumns(db: Database): { name: string; notnull: number }[] {
+	return db.prepare('PRAGMA table_info(stack_sources)').all() as { name: string; notnull: number }[];
+}
+
+/** Run the T3 helper's read SQL verbatim against bun:sqlite (env = null-safe). */
+function readPointer(db: Database, name: string, env: number | null): { last_saved_at: string | null; last_deployed_at: string | null } | null {
+	const { sql, params } = buildRead(name, env);
+	const row = db.prepare(sql).get(...(params as any[])) as
+		| { last_saved_at: string | null; last_deployed_at: string | null }
+		| undefined;
+	return row ?? null;
+}
+
+function updatePointer(db: Database, name: string, env: number | null, updates: StackSourcePointerValues, now: string): number {
+	const { sql, params } = buildUpdate(name, env, updates, now);
+	return db.prepare(sql).run(...(params as any[])).changes;
+}
+
+function insertPointer(db: Database, name: string, env: number | null, updates: StackSourcePointerValues, now: string): number {
+	const { sql, params } = buildInsert(name, env, updates, now);
+	return db.prepare(sql).run(...(params as any[])).changes;
+}
+
+describe('S01 test-only exit (T4)', () => {
+	describe('(a) fresh SQLite apply + pointer round-trip', () => {
+		let db: Database;
+		let appliedFiles: string[];
+
+		beforeAll(() => {
+			db = new Database(':memory:');
+			appliedFiles = applySqliteMigrations(db);
+		});
+
+		test('migration set includes 0016_add_stack_versioning', () => {
+			expect(appliedFiles).toContain('0016_add_stack_versioning.sql');
+		});
+
+		test('0016 applied cleanly: stack_sources gained last_saved_at / last_deployed_at', () => {
+			const cols = stackSourceColumns(db).map((c) => c.name);
+			expect(cols).toContain('last_saved_at');
+			expect(cols).toContain('last_deployed_at');
+		});
+
+		test('pointer columns are nullable (NOT NULL = 0, no default) — NULL = never saved/deployed', () => {
+			const rows = stackSourceColumns(db);
+			for (const col of ['last_saved_at', 'last_deployed_at']) {
+				const info = rows.find((r) => r.name === col);
+				expect(info).toBeDefined();
+				expect(info!.notnull).toBe(0);
+			}
+		});
+
+		test('bare internal stack (environment_id = NULL) pointer round-trip', () => {
+			const name = 'bare-internal-stack';
+			const now = '2026-09-02T00:00:00.000Z';
+
+			// No keyed row yet -> read returns null.
+			expect(readPointer(db, name, null)).toBeNull();
+
+			// Mirror upsertStackSourcePointer: UPDATE first (no-op when the row is
+			// missing), then INSERT to create the bare row.
+			const updated = updatePointer(db, name, null, { lastSavedAt: 'SAVED-1', lastDeployedAt: 'DEPLOYED-1' }, now);
+			expect(updated).toBe(0); // nothing to update yet
+			const inserted = insertPointer(db, name, null, { lastSavedAt: 'SAVED-1', lastDeployedAt: 'DEPLOYED-1' }, now);
+			expect(inserted).toBe(1); // created
+
+			// Read back the round-tripped pointers.
+			const after = readPointer(db, name, null);
+			expect(after).not.toBeNull();
+			expect(after!.last_saved_at).toBe('SAVED-1');
+			expect(after!.last_deployed_at).toBe('DEPLOYED-1');
+
+			// Idempotency: re-running the INSERT must NOT create a duplicate
+			// (name, NULL) row (the key predicate uses environment_id IS NULL).
+			const reinserted = insertPointer(db, name, null, { lastSavedAt: 'SAVED-1', lastDeployedAt: 'DEPLOYED-1' }, now);
+			expect(reinserted).toBe(0);
+			const count = db.prepare('SELECT count(*) AS n FROM stack_sources WHERE stack_name = ? AND environment_id IS NULL').get(name) as { n: number };
+			expect(count.n).toBe(1);
+
+			// Now advance only last_deployed_at on the existing row (COALESCE
+			// preserves the untouched last_saved_at).
+			const advanced = updatePointer(db, name, null, { lastDeployedAt: 'DEPLOYED-2' }, '2026-09-02T01:00:00.000Z');
+			expect(advanced).toBe(1);
+			const final = readPointer(db, name, null);
+			expect(final!.last_saved_at).toBe('SAVED-1');
+			expect(final!.last_deployed_at).toBe('DEPLOYED-2');
+		});
+
+		test('a keyed stack (environment_id set) is isolated from the bare stack', () => {
+			const name = 'keyed-stack';
+			const now = '2026-09-02T00:00:00.000Z';
+			insertPointer(db, name, 7, { lastSavedAt: 'SAVED-K' }, now);
+			const keyed = readPointer(db, name, 7);
+			expect(keyed!.last_saved_at).toBe('SAVED-K');
+			// The same stack_name with env NULL has no row -> isolated.
+			expect(readPointer(db, name, null)).toBeNull();
+		});
+	});
+
+	describe('(b) drizzle-pg lockstep parity (CI-runnable, no live PG)', () => {
+		test('drizzle-pg/0016_add_stack_versioning.sql exists', () => {
+			expect(existsSync(join(pgMigrationsDir, '0016_add_stack_versioning.sql'))).toBe(true);
+		});
+
+		test('both journals advanced together to an idx-16 0016_add_stack_versioning entry (lockstep)', () => {
+			const sqliteJournal = JSON.parse(readFileSync(join(sqliteMigrationsDir, 'meta', '_journal.json'), 'utf-8'));
+			const pgJournal = JSON.parse(readFileSync(join(pgMigrationsDir, 'meta', '_journal.json'), 'utf-8'));
+			const sqliteEntry = sqliteJournal.entries.find((e: { tag: string }) => e.tag === '0016_add_stack_versioning');
+			const pgEntry = pgJournal.entries.find((e: { tag: string }) => e.tag === '0016_add_stack_versioning');
+			expect(sqliteEntry).toBeDefined();
+			expect(pgEntry).toBeDefined();
+			expect(pgEntry.idx).toBe(16);
+			// Lockstep: both dialects advanced to the same index.
+			expect(pgEntry.idx).toBe(sqliteEntry.idx);
+		});
+
+		test('PG 0016 ALTER targets the same stack_sources columns as SQLite 0016', () => {
+			const sqliteSql = readFileSync(join(sqliteMigrationsDir, '0016_add_stack_versioning.sql'), 'utf-8');
+			const pgSql = readFileSync(join(pgMigrationsDir, '0016_add_stack_versioning.sql'), 'utf-8');
+
+			const extractAddedColumns = (sqlText: string): string[] => {
+				const cols: string[] = [];
+				for (const raw of sqlText.split('--> statement-breakpoint')) {
+					const stmt = raw.trim();
+					// Each statement is a single "ALTER TABLE ... ADD [COLUMN] <col> ...".
+					const m = stmt.match(/ADD\s+(?:COLUMN\s+)?['"`]?([a-zA-Z_][a-zA-Z0-9_]*)['"`]?/);
+					if (m) cols.push(m[1]);
+				}
+				return [...new Set(cols)].sort();
+			};
+
+			const sqliteCols = extractAddedColumns(sqliteSql);
+			const pgCols = extractAddedColumns(pgSql);
+			expect(sqliteCols).toEqual(['last_deployed_at', 'last_saved_at']);
+			expect(pgCols).toEqual(sqliteCols);
+			// Both dialects target the same table.
+			expect(sqliteSql).toContain('stack_sources');
+			expect(pgSql).toContain('stack_sources');
+		});
+	});
+});

--- a/tests/stack-versions.test.ts
+++ b/tests/stack-versions.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Unit tests for the pure per-stack version store (src/lib/server/stack-versions).
+ *
+ * Style + discipline follow tests/stack-versioning.test.ts / tests/stack-path-utils.test.ts:
+ * bun:test, isolated temp dirs via fs.mkdtempSync (cleaned in afterEach), and
+ * importing the REAL production module. Importing this module under bun test also
+ * proves the no-better-sqlite3 constraint — the module is PURE (node:fs + node:path
+ * only), so it loads without the better-sqlite3 seed that a stacks.ts/db.ts import
+ * would trigger.
+ */
+import { afterEach, describe, expect, it } from 'bun:test';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import type { StackVersion } from '../src/lib/server/stack-versions';
+import {
+	assertSecretFree,
+	atomicWriteFile,
+	boundVersions,
+	collapseDuplicateVersions,
+	collapseHistoryFile,
+	DEFAULT_MAX_VERSIONS,
+	filterSecretVars,
+	historyPath,
+	listVersions,
+	prune,
+	readHistoryFile,
+	saveVersion
+} from '../src/lib/server/stack-versions';
+import { parseEnvVars } from '../src/lib/server/env-parser';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		// Best-effort: a failure test may have left a read-only dir, so force.
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			// ignore cleanup failure
+		}
+	}
+});
+
+/** Create + register an isolated temp dir for a single test. */
+function newTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), 'stack-versions-'));
+	tempDirs.push(dir);
+	return dir;
+}
+
+/** Deterministic, strictly-increasing ISO timestamps for ordering tests. */
+function ts(i: number): string {
+	return new Date(i * 1000).toISOString();
+}
+
+/** True when `s` is a canonical ISO-8601 timestamp (round-trips via toISOString). */
+function validIso(s: string): boolean {
+	return typeof s === 'string' && Number.isNaN(Date.parse(s)) === false && new Date(s).toISOString() === s;
+}
+
+describe('compose round-trip', () => {
+	it('save then list shows the content and a valid ISO timestamp', () => {
+		const dir = newTempDir();
+		const yaml = 'services:\n  app:\n    image: nginx\n';
+		const res = saveVersion(dir, 'compose', yaml);
+
+		// Default id = timestamp (no collision yet).
+		expect(res.id).toBe(res.timestamp);
+		expect(validIso(res.timestamp)).toBe(true);
+
+		const list = listVersions(dir, 'compose');
+		expect(list.length).toBe(1);
+		expect(list[0].content).toBe(yaml);
+		expect(list[0].id).toBe(res.id);
+		expect(validIso(list[0].timestamp)).toBe(true);
+	});
+});
+
+describe('env round-trip', () => {
+	it('save a non-secret record then list shows the vars', () => {
+		const dir = newTempDir();
+		const vars: Record<string, string> = { FOO: 'bar', BAZ: 'qux' };
+		const res = saveVersion(dir, 'env', vars);
+		expect(validIso(res.timestamp)).toBe(true);
+
+		const list = listVersions(dir, 'env');
+		expect(list.length).toBe(1);
+		expect(list[0].content).toEqual(vars);
+		expect(list[0].id).toBe(res.id);
+	});
+});
+
+describe('bounded-N', () => {
+	it('saveVersion bounds the file to maxVersions (oldest dropped at save)', () => {
+		const dir = newTempDir();
+		for (let i = 1; i <= 21; i++) {
+			saveVersion(dir, 'compose', `v${i}`, { id: `v${i}`, timestamp: ts(i) });
+		}
+		// Default max (20): the 21st save drops the oldest (v1).
+		const all = listVersions(dir, 'compose', 100);
+		expect(all.length).toBe(DEFAULT_MAX_VERSIONS);
+		expect(all[0].id).toBe('v21'); // newest first
+		const ids = new Set(all.map((v) => v.id));
+		expect(ids.has('v1')).toBe(false); // oldest dropped
+		expect(ids.has('v21')).toBe(true);
+	});
+
+	it('listVersions(limit) returns the newest `limit`, dropping the oldest', () => {
+		const dir = newTempDir();
+		// Save WITHOUT bounding so the file holds all 21.
+		for (let i = 1; i <= 21; i++) {
+			saveVersion(dir, 'compose', `v${i}`, { id: `v${i}`, timestamp: ts(i), maxVersions: 100 });
+		}
+		const newest20 = listVersions(dir, 'compose', 20);
+		expect(newest20.length).toBe(20);
+		expect(newest20[0].id).toBe('v21');
+		expect(newest20[19].id).toBe('v2'); // v1 (oldest) dropped
+		const ids = new Set(newest20.map((v) => v.id));
+		expect(ids.has('v1')).toBe(false);
+		expect(ids.has('v2')).toBe(true);
+	});
+});
+
+describe('prune keeps the safe version', () => {
+	it('preserves the safe version even when it is the oldest', () => {
+		const dir = newTempDir();
+		// Seed 25 versions v1..v25 (v1 oldest) without bounding.
+		for (let i = 1; i <= 25; i++) {
+			saveVersion(dir, 'compose', `v${i}`, { id: `v${i}`, timestamp: ts(i), maxVersions: 100 });
+		}
+		// Prune to 10, keeping the OLDEST (v1) as safe.
+		const { pruned } = prune(dir, 'compose', 10, 'v1');
+		expect(pruned).toBe(15); // 25 -> 10
+
+		const all = listVersions(dir, 'compose', 100);
+		expect(all.length).toBe(10);
+		// Safe preserved; oldest NON-safe (v2..v16) dropped first; newest kept.
+		expect([...all.map((v) => v.id)].sort()).toEqual(['v1', 'v17', 'v18', 'v19', 'v20', 'v21', 'v22', 'v23', 'v24', 'v25']);
+	});
+
+	it('drops the oldest non-safe first when the safe version is the newest', () => {
+		const dir = newTempDir();
+		for (let i = 1; i <= 25; i++) {
+			saveVersion(dir, 'compose', `v${i}`, { id: `v${i}`, timestamp: ts(i), maxVersions: 100 });
+		}
+		// Keep the NEWEST (v25) as safe: v25 plus the next-newest 9 non-safe (v16..v24).
+		const { pruned } = prune(dir, 'compose', 10, 'v25');
+		expect(pruned).toBe(15);
+		const ids = new Set(listVersions(dir, 'compose', 100).map((v) => v.id));
+		expect(ids.has('v25')).toBe(true);
+		expect(ids.has('v1')).toBe(false); // oldest dropped
+		expect(ids.has('v16')).toBe(true); // v16 is the 10th-newest kept
+		expect(ids.has('v15')).toBe(false);
+	});
+});
+
+describe('boundVersions (pure)', () => {
+	it('drops the oldest non-safe first, never the safe version', () => {
+		const versions: StackVersion[] = [1, 2, 3, 4, 5].map((i) => ({ id: `v${i}`, timestamp: ts(i), content: `c${i}` }));
+		// maxN=3, safe=v1 (oldest): keep v1 (safe) + v4, v5 (newest 2 non-safe).
+		const bounded = boundVersions(versions, 3, 'v1');
+		expect(bounded.map((v) => v.id).sort()).toEqual(['v1', 'v4', 'v5']);
+	});
+
+	it('within the bound keeps everything (no drop)', () => {
+		const versions: StackVersion[] = [1, 2, 3].map((i) => ({ id: `v${i}`, timestamp: ts(i), content: `c${i}` }));
+		const bounded = boundVersions(versions, 5);
+		expect(bounded.map((v) => v.id)).toEqual(['v1', 'v2', 'v3']);
+	});
+
+	it('never drops the safe version even when it is the oldest', () => {
+		const versions: StackVersion[] = [1, 2, 3, 4].map((i) => ({ id: `v${i}`, timestamp: ts(i), content: `c${i}` }));
+		// maxN=2, safe=v1 (oldest): keep v1 + v4 (newest non-safe).
+		const bounded = boundVersions(versions, 2, 'v1');
+		expect(bounded.map((v) => v.id).sort()).toEqual(['v1', 'v4']);
+	});
+});
+
+describe('id dedup', () => {
+	it('dedups the default id on a timestamp collision', () => {
+		const dir = newTempDir();
+		const fixedTs = '2026-01-01T00:00:00.000Z';
+		const a = saveVersion(dir, 'compose', 'x', { timestamp: fixedTs });
+		const b = saveVersion(dir, 'compose', 'y', { timestamp: fixedTs });
+		expect(a.id).toBe(fixedTs);
+		expect(b.id).toBe(`${fixedTs}-1`); // deduped so ids stay unique
+		const list = listVersions(dir, 'compose', 10);
+		expect(new Set(list.map((v) => v.id)).size).toBe(2);
+	});
+});
+
+describe('atomicWriteFile', () => {
+	it('a successful write leaves the final file equal to the new data with no .tmp leftover', () => {
+		const dir = newTempDir();
+		const filePath = join(dir, 'compose.json');
+		atomicWriteFile(filePath, 'hello');
+		expect(readFileSync(filePath, 'utf8')).toBe('hello');
+		expect(existsSync(filePath + '.tmp')).toBe(false);
+	});
+
+	it('a pre-existing stale .tmp is replaced, never merged', () => {
+		const dir = newTempDir();
+		const filePath = join(dir, 'compose.json');
+		writeFileSync(filePath, 'v1');
+		writeFileSync(filePath + '.tmp', 'garbage');
+		atomicWriteFile(filePath, 'v2');
+		expect(readFileSync(filePath, 'utf8')).toBe('v2');
+		expect(existsSync(filePath + '.tmp')).toBe(false);
+	});
+
+	it('a forced tmp-write failure throws, preserves the prior final, leaves no tmp', () => {
+		const dir = newTempDir();
+		const filePath = join(dir, 'compose.json');
+		writeFileSync(filePath, 'v1'); // prior final content
+		let threw = false;
+		try {
+			chmodSync(dir, 0o555); // read-only: creating the tmp file must fail
+			try {
+				atomicWriteFile(filePath, 'v2');
+			} catch {
+				threw = true;
+			}
+		} finally {
+			chmodSync(dir, 0o755); // restore so afterEach cleanup works
+		}
+		expect(threw).toBe(true);
+		expect(readFileSync(filePath, 'utf8')).toBe('v1'); // prior content preserved
+		expect(existsSync(filePath + '.tmp')).toBe(false); // no tmp left
+	});
+});
+
+describe('missing dir/file', () => {
+	it('listVersions returns [] and readHistoryFile returns empty', () => {
+		const dir = newTempDir(); // exists, but no .history/
+		expect(listVersions(dir, 'compose')).toEqual([]);
+		expect(listVersions(dir, 'env')).toEqual([]);
+		expect(readHistoryFile(dir, 'compose')).toEqual({ versions: [] });
+	});
+
+	it('a stack dir that does not exist at all also yields []', () => {
+		const base = newTempDir();
+		const missing = join(base, 'does-not-exist');
+		expect(listVersions(missing, 'compose')).toEqual([]);
+		expect(readHistoryFile(missing, 'env')).toEqual({ versions: [] });
+	});
+});
+
+describe('malformed history file', () => {
+	it('invalid JSON: readHistoryFile and listVersions throw', () => {
+		const dir = newTempDir();
+		const file = historyPath(dir, 'compose');
+		mkdirSync(dirname(file), { recursive: true });
+		writeFileSync(file, '{ this is not valid json');
+		expect(() => readHistoryFile(dir, 'compose')).toThrow();
+		expect(() => listVersions(dir, 'compose')).toThrow();
+	});
+
+	it('valid JSON with the wrong shape (no versions array): readHistoryFile throws', () => {
+		const dir = newTempDir();
+		const file = historyPath(dir, 'env');
+		mkdirSync(dirname(file), { recursive: true });
+		writeFileSync(file, '{"foo": 1}');
+		expect(() => readHistoryFile(dir, 'env')).toThrow();
+		expect(() => listVersions(dir, 'env')).toThrow();
+	});
+});
+
+describe('assertSecretFree', () => {
+	it('does not throw for a clean payload (no secret keys present)', () => {
+		const vars: Record<string, string> = { FOO: 'bar', BAZ: 'qux' };
+		expect(() => assertSecretFree(vars, ['DB_PASSWORD', 'API_KEY'])).not.toThrow();
+	});
+
+	it('does not throw when secretKeys is empty', () => {
+		const vars: Record<string, string> = { FOO: 'bar' };
+		expect(() => assertSecretFree(vars, [])).not.toThrow();
+	});
+
+	it('throws naming the FIRST leaked key (object key order)', () => {
+		const vars: Record<string, string> = { FOO: 'bar', DB_PASSWORD: 'hunter2', API_KEY: 'abc' };
+		expect(() => assertSecretFree(vars, ['DB_PASSWORD', 'API_KEY'])).toThrow(/DB_PASSWORD/);
+	});
+});
+
+describe('filterSecretVars', () => {
+	it('removes only the secret keys and preserves every non-secret key', () => {
+		const vars: Record<string, string> = { FOO: 'bar', DB_PASSWORD: 'hunter2', BAZ: 'qux', API_KEY: 'abc' };
+		expect(filterSecretVars(vars, ['DB_PASSWORD', 'API_KEY'])).toEqual({ FOO: 'bar', BAZ: 'qux' });
+	});
+
+	it('returns an empty object when every key is secret', () => {
+		expect(filterSecretVars({ DB_PASSWORD: 'x', API_KEY: 'y' }, ['DB_PASSWORD', 'API_KEY'])).toEqual({});
+	});
+
+	it('does not mutate the input object', () => {
+		const vars: Record<string, string> = { FOO: 'bar', DB_PASSWORD: 'hunter2' };
+		const filtered = filterSecretVars(vars, ['DB_PASSWORD']);
+		expect(vars).toEqual({ FOO: 'bar', DB_PASSWORD: 'hunter2' }); // input unchanged
+		expect(vars.DB_PASSWORD).toBe('hunter2');
+		expect(filtered).not.toBe(vars); // a new object, not the input
+	});
+});
+
+describe('end-to-end env secret-free', () => {
+	it('parseEnvVars -> filterSecretVars -> saveVersion stores ONLY the non-secret keys', () => {
+		const dir = newTempDir();
+		const raw = ['# a comment line', 'FOO=bar', 'DB_PASSWORD=hunter2', 'BAZ=qux', 'API_KEY=abc123'].join('\n');
+		const secretKeys = ['DB_PASSWORD', 'API_KEY'];
+		const filtered = filterSecretVars(parseEnvVars(raw), secretKeys);
+		expect(filtered).toEqual({ FOO: 'bar', BAZ: 'qux' });
+
+		saveVersion(dir, 'env', filtered, { secretKeys });
+
+		// Read the saved .history/env.json back via listVersions.
+		const list = listVersions(dir, 'env');
+		expect(list.length).toBe(1);
+		const stored = list[0].content as Record<string, string>;
+		// Contains ONLY the non-secret keys ...
+		expect(stored).toEqual({ FOO: 'bar', BAZ: 'qux' });
+		// ... and NONE of the secret keys.
+		for (const k of secretKeys) expect(k in stored).toBe(false);
+	});
+});
+
+describe('saveVersion env with a leaked secret', () => {
+	it('rejects a leaked secret (assertSecretFree throws) and stores nothing', () => {
+		const dir = newTempDir();
+		const secretKeys = ['DB_PASSWORD'];
+		const vars: Record<string, string> = { FOO: 'bar', DB_PASSWORD: 'hunter2' };
+		expect(() => saveVersion(dir, 'env', vars, { secretKeys })).toThrow(/DB_PASSWORD/);
+		expect(listVersions(dir, 'env')).toEqual([]); // nothing stored
+	});
+
+	it('the guard is env-only: compose content is stored as-is even with secretKeys', () => {
+		const dir = newTempDir();
+		saveVersion(dir, 'compose', 'services:\n', { secretKeys: ['DB_PASSWORD'] });
+		expect(listVersions(dir, 'compose').length).toBe(1);
+	});
+		it('cross-list dedup: saving content equal to an OLDER version drops that older duplicate', () => {
+			const dir = newTempDir();
+			const t1 = '2026-01-01T00:00:00.000Z';
+			const t2 = '2026-01-02T00:00:00.000Z';
+			const t3 = '2026-01-03T00:00:00.000Z';
+			// t1: A, t2: B, then (revert-then-save) A again -> t1 dropped, t3 kept.
+			saveVersion(dir, 'compose', 'A', { timestamp: t1, id: t1 });
+			saveVersion(dir, 'compose', 'B', { timestamp: t2, id: t2 });
+			saveVersion(dir, 'compose', 'A', { timestamp: t3, id: t3 });
+			const list = listVersions(dir, 'compose');
+			expect(list.length).toBe(2);
+			expect(list[0].id).toBe(t3);
+			expect(list[0].content).toBe('A');
+			expect(list[1].id).toBe(t2);
+			// t1 is gone - no two identical entries.
+			expect(list.some((v) => v.id === t1)).toBe(false);
+		});
+
+		it('cross-list dedup: the SAFE (deployed) version survives even when its content matches', () => {
+			const dir = newTempDir();
+			const t1 = '2026-01-01T00:00:00.000Z';
+			const t3 = '2026-01-03T00:00:00.000Z';
+			saveVersion(dir, 'compose', 'A', { timestamp: t1, id: t1 });
+			// t1 is the deployed anchor; a new save of the same content appends next
+			// to it instead of dropping it.
+			saveVersion(dir, 'compose', 'A', { timestamp: t3, id: t3, safe: t1 });
+			const list = listVersions(dir, 'compose');
+			expect(list.length).toBe(2);
+			expect(list.some((v) => v.id === t1)).toBe(true);
+			expect(list.some((v) => v.id === t3)).toBe(true);
+		});
+
+		it('cross-list dedup applies to env Records (key/value equality)', () => {
+			const dir = newTempDir();
+			const t1 = '2026-01-01T00:00:00.000Z';
+			const t2 = '2026-01-02T00:00:00.000Z';
+			const t3 = '2026-01-03T00:00:00.000Z';
+			saveVersion(dir, 'env', { FOO: 'bar' }, { timestamp: t1, id: t1 });
+			saveVersion(dir, 'env', { FOO: 'bar', BAZ: 'qux' }, { timestamp: t2, id: t2 });
+			// Re-save {FOO: bar} -> the t1 duplicate is dropped; t2 (different) kept.
+			saveVersion(dir, 'env', { FOO: 'bar' }, { timestamp: t3, id: t3 });
+			const list = listVersions(dir, 'env');
+			expect(list.length).toBe(2);
+			expect(list[0].id).toBe(t3);
+			expect(list[0].content).toEqual({ FOO: 'bar' });
+			expect(list[1].id).toBe(t2);
+		});
+
+	describe('distinct-content collapse', () => {
+		it('collapses the WHOLE list: an older duplicate of any content is dropped on the next save, not just the incoming content', () => {
+			const dir = newTempDir();
+			const t1 = '2026-01-01T00:00:00.000Z';
+			const t2 = '2026-01-02T00:00:00.000Z';
+			const t3 = '2026-01-03T00:00:00.000Z';
+			const t4 = '2026-01-04T00:00:00.000Z';
+			// Legacy list (as pre-fix code would have left it): A, B, A.
+			saveVersion(dir, 'compose', 'A', { timestamp: t1, id: t1 });
+			saveVersion(dir, 'compose', 'B', { timestamp: t2, id: t2 });
+			// Simulate the pre-fix entry by writing the raw file directly.
+			atomicWriteFile(
+				historyPath(dir, 'compose'),
+				JSON.stringify({
+					versions: [
+						{ id: t1, timestamp: t1, content: 'A' },
+						{ id: t2, timestamp: t2, content: 'B' },
+						{ id: t3, timestamp: t3, content: 'A' }
+					]
+				}, null, 2)
+			);
+			// Save C: the t1 entry is dropped even though C !== A - the list is a
+			// distinct-content timeline, newest representative wins.
+			saveVersion(dir, 'compose', 'C', { timestamp: t4, id: t4 });
+			const list = listVersions(dir, 'compose');
+			expect(list.map((v) => v.id)).toEqual([t4, t3, t2]);
+			expect(list.some((v) => v.id === t1)).toBe(false);
+		});
+
+		it('pure helper: keeps the newest per content, preserves a SAFE duplicate, reports changed', () => {
+			const t1 = '2026-01-01T00:00:00.000Z';
+			const t2 = '2026-01-02T00:00:00.000Z';
+			const t3 = '2026-01-03T00:00:00.000Z';
+			const v1 = { id: t1, timestamp: t1, content: 'A' };
+			const v2 = { id: t2, timestamp: t2, content: 'B' };
+			const v3 = { id: t3, timestamp: t3, content: 'A' };
+			const r = collapseDuplicateVersions([v1, v2, v3], t1);
+			// t1 is the safe anchor: kept even though the newer v3 holds the same
+			// content. t2 differs from everything kept. v3 is the newest A.
+			expect(r.collapsed.map((v) => v.id)).toEqual([t1, t2, t3]);
+			expect(r.changed).toBe(false);
+			// Without the safe anchor, t1 is the older duplicate of v3 and drops.
+			const r2 = collapseDuplicateVersions([v1, v2, v3]);
+			expect(r2.collapsed.map((v) => v.id)).toEqual([t2, t3]);
+			expect(r2.changed).toBe(true);
+			// Clean list -> unchanged (no rewrite churn).
+			expect(collapseDuplicateVersions(r2.collapsed).changed).toBe(false);
+		});
+
+		it('collapseHistoryFile rewrites only when the list actually changes', () => {
+			const dir = newTempDir();
+			const t1 = '2026-01-01T00:00:00.000Z';
+			const t2 = '2026-01-02T00:00:00.000Z';
+			const t3 = '2026-01-03T00:00:00.000Z';
+			atomicWriteFile(
+				historyPath(dir, 'compose'),
+				JSON.stringify({
+					versions: [
+						{ id: t1, timestamp: t1, content: 'A' },
+						{ id: t2, timestamp: t2, content: 'B' },
+						{ id: t3, timestamp: t3, content: 'A' }
+					]
+				}, null, 2)
+			);
+			expect(collapseHistoryFile(dir, 'compose')).toBe(true);
+			expect(listVersions(dir, 'compose').map((v) => v.id)).toEqual([t3, t2]);
+			// Second pass on the now-clean list: no-op, no rewrite.
+			expect(collapseHistoryFile(dir, 'compose')).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Proposed change

   Adds per-stack/per-environment versioning for the **compose YAML** and **env vars**: a bounded, content-deduplicated history with one-click revert, plus saved-vs-deployed ("current") indicators in the stack editor.

   Addresses the feature request in [Finsys/dockhand#12](https://github.com/Finsys/dockhand/issues/12) — *Add versioning for compose and .env files*.

   **Branch state:** single implementation-only commit on top of `main` (`v1.0.46`) — no unrelated file changes.

   **What's included:**

   - **Bounded version history** in `.history/{compose,env}.json` — compose stored verbatim, env as secret-free Records (secrets stripped by name and asserted pre-store).
   - **Crash-safe save ordering** (live file first, rollback on version-write failure) under a per-stack lock (`withStackLock`).
   - **No-op save detection** (identical-to-newest skips recording and pointer churn) and **distinct-content collapse**: each content appears at most once (newest entry is the representative); the deployed (safe) anchor is never collapsed or pruned; a
 no-op save opportunistically normalizes stale lists.
   - **`stack_sources.last_saved_at` / `last_deployed_at`** ISO-8601 pointers (migration **0016** in both `drizzle/` and `drizzle-pg/`, in lockstep). A revert sets the saved pointer to the reverted version's timestamp so the current indicator matches
 the live content.
   - **Authenticated, OpenAPI-documented history API** (`GET/POST /api/stacks/[name]/history?env=N&type=compose|env`) returning `versions` + `currentVersionId` computed by matching the live source content per type (pointer match as fallback when the
 live source is missing).
   - **`StackHistoryPanel`** UI wired into both editor tabs: saved-vs-deployed indicator, per-type current badge, unsaved-changes chip on dirty editors, revert with in-place re-read (env re-fetches `GET /env`).
   - **Internal stacks now get history:** the edit modal submits the *resolved* compose path (including the internal default), so the save detects the internal-default path and routes it through the versioned save — only genuinely external paths take
 the custom-path write. Previously an internal stack saved through the custom-path branch ended up with no history at all.
   - **Env version recording** on both save paths: `PUT /env/raw` (internal/adopted) and `PUT /env` (git stacks, where the DB is the live source).
   - **Regenerated OpenAPI spec** (`src/lib/openapi.generated.json`, `static/openapi.json`).

   **Integration note:** the versioned compose save builds on the #1515 compose-path return already in `main` — the save returns the actually-written path so callers persist it even when no explicit `composePath` was supplied. The `stacks.ts` delta is
 purely additive orchestration plus the internal-default routing above; existing save behavior for external/custom paths is unchanged.

   **How to test:**

   1. Edit a stack's compose and env in the editor tab → history entries appear; the saved indicator shows the newest version, the deployed indicator the last deploy.
   2. Revert to an older version → live content re-reads in place, pointers move, and the current badge tracks the live content.
   3. Re-save identical content → no new entry (no-op), list opportunistically normalized.
   4. `GET /api/stacks/{name}/history?env=N&type=compose|env` returns `versions` + `currentVersionId` per type.

   **Migration:** `0016_add_stack_versioning` (SQLite + PostgreSQL), slotted after `0015_deploy_run_index`; both `drizzle/` and `drizzle-pg/` kept in lockstep.

   Related: https://github.com/Finsys/dockhand/issues/12 — *Add versioning for compose and .env files*

   **Screenshots**:

Main view with history buttons:

<img width="2484" height="484" alt="main_stack_view" src="https://github.com/user-attachments/assets/927903d2-e561-4ad1-bca0-a8b8047aae2e" />

Compose history:
<img width="331" height="203" alt="compose_history" src="https://github.com/user-attachments/assets/5551fd40-6015-4af8-9fb7-65c74aa8169d" />

.env history:
<img width="327" height="191" alt="env_history" src="https://github.com/user-attachments/assets/707f0189-1930-4f24-8990-f7d67141e1e2" />

And the thing that requires confirmation is actual placement of the buttons:
<img width="2052" height="194" alt="buttons_view" src="https://github.com/user-attachments/assets/2e070196-66d2-4f83-b9ce-2323c263ef65" />

@jotka - can you comment on this which placement is better?

   ## Type of change

   What type of change does this PR introduce to Dockhand?
   NOTE: Please check only one box!

   - [ ] Bug fix: non-breaking change which fixes an issue.
   - [x] New feature / Enhancement: non-breaking change which adds functionality.
   - [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
   - [ ] Other. Please explain: