### PR TITLE
feat: stack-level update policy — rebuild mode + cascade updates (#1539)

### DIFF
--- a/src/lib/server/compose-args.ts
+++ b/src/lib/server/compose-args.ts
@@ -15,14 +15,27 @@ export interface ComposeOperationArgOptions {
 	noBuildCache?: boolean;
 	pullPolicy?: string;
 	serviceName?: string;
+	/**
+	 * Multiple target services (#1539 cascade updates). Appended after
+	 * `serviceName` so a caller can pass either. Compose accepts a space-separated
+	 * service list for `up`/`pull`/`build`.
+	 */
+	serviceNames?: string[];
 }
 
 export function buildComposeOperationArgs(
 	operation: 'up' | 'down' | 'stop' | 'start' | 'restart' | 'pull' | 'build',
 	options: ComposeOperationArgOptions = {}
 ): string[] {
-	const { forceRecreate, removeVolumes, build, noBuildCache, pullPolicy, serviceName } = options;
+	const { forceRecreate, removeVolumes, build, noBuildCache, pullPolicy, serviceName, serviceNames } = options;
 	const args: string[] = [];
+	// One service arg list for every operation: the legacy single `serviceName` plus
+	// any explicit list (#1539). De-duplicated, order preserved (changed service first).
+	const targets: string[] = [];
+	if (serviceName) targets.push(serviceName);
+	for (const name of serviceNames ?? []) {
+		if (name && !targets.includes(name)) targets.push(name);
+	}
 
 	switch (operation) {
 		case 'up':
@@ -32,7 +45,7 @@ export function buildComposeOperationArgs(
 			// also carry --build (and never --no-cache, which up doesn't accept).
 			if (build && !noBuildCache) args.push('--build');
 			if (pullPolicy) args.push('--pull', pullPolicy);
-			if (serviceName) args.push(serviceName);
+			args.push(...targets);
 			break;
 		case 'down':
 			args.push('down', '--remove-orphans');
@@ -49,12 +62,12 @@ export function buildComposeOperationArgs(
 			break;
 		case 'pull':
 			args.push('pull');
-			if (serviceName) args.push(serviceName);
+			args.push(...targets);
 			break;
 		case 'build':
 			args.push('build');
 			if (noBuildCache) args.push('--no-cache');
-			if (serviceName) args.push(serviceName);
+			args.push(...targets);
 			break;
 	}
 

--- a/src/lib/server/scheduler/tasks/container-update.ts
+++ b/src/lib/server/scheduler/tasks/container-update.ts
@@ -41,6 +41,12 @@ import { sendEventNotification } from '../../notifications';
 import { parseImageNameAndTag, combineScanSummaries, isSystemContainer, isPodmanInfraContainer } from './update-utils';
 import { resolveBlockDecision } from './block-decision';
 import { isUpdateDisabledByLabel, isHiddenByLabel } from '../../container-labels';
+import {
+	parseStackUpdatePolicy,
+	planStackUpdate,
+	isDefaultStackUpdatePlan,
+	type StackUpdatePlan
+} from '../../stack-update-policy';
 
 // =============================================================================
 // TYPES
@@ -82,6 +88,16 @@ interface ExecutionDetails {
 			unknown: number;
 		}>;
 	}>;
+	/** #1539: the stack update policy that governed this run, when one applied. */
+	stackPolicy?: {
+		stackName: string;
+		serviceName: string;
+		mode: string;
+		cascade: string;
+		noCache: boolean;
+		rebuilt: string[];
+		skipped: { service: string; reason: string }[];
+	};
 	scanResult?: {
 		summary: VulnerabilitySeverity;
 		scanners: string[];
@@ -249,6 +265,17 @@ function buildSuccessDetails(
 	};
 }
 
+/**
+ * Render the effective cascade scope for the execution history (#1539). Before
+ * #1539 nothing was recorded; here the label is read off the plan so the history
+ * shows why extra services moved (or why none did).
+ */
+function updatePlanCascadeLabel(plan: StackUpdatePlan): string {
+	if (plan.wholeStack) return 'all';
+	if (plan.targets.length > 1) return 'same-image';
+	return 'false';
+}
+
 // =============================================================================
 // MAIN UPDATE FUNCTION
 // =============================================================================
@@ -409,47 +436,95 @@ export async function runContainerUpdate(
 		const shouldScan = scannerSettings.scanner !== 'none';
 
 		// =============================================================================
+		// STACK UPDATE POLICY (#1539)
+		// =============================================================================
+		// A container that belongs to a compose stack may carry an x-dockhand update
+		// policy in its compose file. A non-default policy (mode build/rebuild, or a
+		// cascade) changes HOW an update is APPLIED: the stack is redeployed through
+		// `docker compose` (optionally --build) instead of recreating the single
+		// container via the Docker API. No policy, or a policy that resolves to the
+		// defaults, leaves the run byte-identical to the pre-#1539 behavior.
+		// Dynamic import: stacks.ts pulls the scheduler back in (registerSchedule), so
+		// a static import here would create a cycle.
+		const stackProject = inspectData.Config?.Labels?.['com.docker.compose.project'] as string | undefined;
+		const stackService = inspectData.Config?.Labels?.['com.docker.compose.service'] as string | undefined;
+		let updatePlan: StackUpdatePlan | null = null;
+		if (stackProject && stackService) {
+			try {
+				const { requireComposeFile } = await import('../../stacks');
+				const composeResult = await requireComposeFile(stackProject, envId);
+				if (composeResult.success && composeResult.content) {
+					const parsed = parseStackUpdatePolicy(composeResult.content);
+					// Unknown service (e.g. a container renamed out of the file) -> ignore the
+					// policy rather than guessing a cascade target list.
+					if (parsed.services.length === 0 || parsed.services.some((s) => s.name === stackService)) {
+						updatePlan = planStackUpdate(parsed, stackService, imageNameFromConfig);
+						if (!isDefaultStackUpdatePlan(updatePlan)) {
+							log(`Stack update policy (${stackProject}): mode=${updatePlan.mode} targets=[${updatePlan.targets.join(', ')}]`);
+							for (const skip of updatePlan.skipped) {
+								log(`  Skipping (${skip.reason}): ${skip.service}`);
+							}
+						}
+					}
+				}
+			} catch (policyError: any) {
+				log(`Stack update policy lookup failed (using defaults): ${policyError.message}`);
+			}
+		}
+		const composeApply = !!updatePlan && !isDefaultStackUpdatePlan(updatePlan);
+		// build/rebuild produce the image from the compose build context, so they must
+		// NOT be gated on (or preceded by) a registry image pull. This is exactly the
+		// gap that made build:/dockerfile_inline stacks un-updatable.
+		const buildFromContext = composeApply && (updatePlan!.mode === 'build' || updatePlan!.mode === 'rebuild');
+
+		// =============================================================================
 		// CHECK FOR UPDATES
 		// =============================================================================
 
-		log(`Checking registry for updates: ${imageNameFromConfig}`);
-		const registryCheck = await checkImageUpdateAvailable(imageNameFromConfig, currentImageId, envId);
+		let newDigest: string | undefined;
 
-		if (registryCheck.isLocalImage) {
-			log(`Local image detected - skipping (auto-update requires registry)`);
-			await updateScheduleExecution(execution.id, {
-				status: 'skipped',
-				completedAt: new Date().toISOString(),
-				duration: Date.now() - startTime,
-				details: { reason: 'Local image - no registry available' }
-			});
-			return;
+		if (!buildFromContext) {
+			log(`Checking registry for updates: ${imageNameFromConfig}`);
+			const registryCheck = await checkImageUpdateAvailable(imageNameFromConfig, currentImageId, envId);
+
+			if (registryCheck.isLocalImage) {
+				log(`Local image detected - skipping (auto-update requires registry)`);
+				await updateScheduleExecution(execution.id, {
+					status: 'skipped',
+					completedAt: new Date().toISOString(),
+					duration: Date.now() - startTime,
+					details: { reason: 'Local image - no registry available' }
+				});
+				return;
+			}
+
+			if (registryCheck.error) {
+				log(`Registry check error: ${registryCheck.error}`);
+				await updateScheduleExecution(execution.id, {
+					status: 'skipped',
+					completedAt: new Date().toISOString(),
+					duration: Date.now() - startTime,
+					details: { reason: `Registry check failed: ${registryCheck.error}` }
+				});
+				return;
+			}
+
+			if (!registryCheck.hasUpdate) {
+				log(`Already up-to-date: ${containerName} is running the latest version`);
+				await updateScheduleExecution(execution.id, {
+					status: 'skipped',
+					completedAt: new Date().toISOString(),
+					duration: Date.now() - startTime,
+					details: { reason: 'Already up-to-date' }
+				});
+				return;
+			}
+
+			log(`Update available! Registry digest: ${registryCheck.registryDigest?.substring(0, 19) || 'unknown'}`);
+			newDigest = registryCheck.registryDigest;
+		} else {
+			log(`Compose build policy (mode: ${updatePlan!.mode}) - building from the build context, no registry pull required`);
 		}
-
-		if (registryCheck.error) {
-			log(`Registry check error: ${registryCheck.error}`);
-			await updateScheduleExecution(execution.id, {
-				status: 'skipped',
-				completedAt: new Date().toISOString(),
-				duration: Date.now() - startTime,
-				details: { reason: `Registry check failed: ${registryCheck.error}` }
-			});
-			return;
-		}
-
-		if (!registryCheck.hasUpdate) {
-			log(`Already up-to-date: ${containerName} is running the latest version`);
-			await updateScheduleExecution(execution.id, {
-				status: 'skipped',
-				completedAt: new Date().toISOString(),
-				duration: Date.now() - startTime,
-				details: { reason: 'Already up-to-date' }
-			});
-			return;
-		}
-
-		log(`Update available! Registry digest: ${registryCheck.registryDigest?.substring(0, 19) || 'unknown'}`);
-		const newDigest = registryCheck.registryDigest;
 
 		// =============================================================================
 		// PULL & SCAN: Temp-tag protection flow
@@ -464,7 +539,7 @@ export async function runContainerUpdate(
 		let newImageId: string | null = null;
 		let scanOutcome: ScanOutcome = { blocked: false };
 
-		if (shouldScan && !isDigestBasedImage(imageNameFromConfig)) {
+		if (!buildFromContext && shouldScan && !isDigestBasedImage(imageNameFromConfig)) {
 			const tempTag = getTempImageTag(imageNameFromConfig);
 			log(`Using temp tag for safe pull: ${tempTag}`);
 
@@ -558,9 +633,7 @@ export async function runContainerUpdate(
 				});
 				return;
 			}
-		} else {
-			// No scanning - simple pull
-			log(`Pulling update (no vulnerability scan)...`);
+		} else if (!buildFromContext) {
 			try {
 				await pullImage(imageNameFromConfig, undefined, envId);
 				log(`Image pulled successfully`);
@@ -577,40 +650,116 @@ export async function runContainerUpdate(
 		}
 
 		// =============================================================================
-		// RECREATE CONTAINER (full config passthrough from inspect data)
+		// APPLY THE UPDATE
 		// =============================================================================
+		// Default path: recreate the single container with full config passthrough
+		// (identical to pre-#1539). Stack policy path: redeploy through docker compose
+		// so rebuild-mode services rebuild and cascade targets move together.
 
-		log(`Recreating container with full config passthrough...`);
-		const result = await recreateContainer(containerName, envId, {
-			log,
-			imageNameOverride: imageNameFromConfig,
-			oldImageConfig
-		});
+		if (!composeApply) {
+			log(`Recreating container with full config passthrough...`);
+			const result = await recreateContainer(containerName, envId, {
+				log,
+				imageNameOverride: imageNameFromConfig,
+				oldImageConfig
+			});
 
-		if (result.success) {
+			if (result.success) {
+				await updateAutoUpdateLastUpdated(containerName, envId);
+				log(`Successfully updated container: ${containerName}`);
+
+				await updateScheduleExecution(execution.id, {
+					status: 'success',
+					completedAt: new Date().toISOString(),
+					duration: Date.now() - startTime,
+					details: buildSuccessDetails(
+						containerName,
+						newDigest,
+						vulnerabilityCriteria,
+						scanOutcome.scanResults,
+						scanOutcome.scanSummary
+					)
+				});
+
+				await sendEventNotification('auto_update_success', {
+					title: 'Container auto-updated',
+					message: `Container "${containerName}" was updated to a new image version`,
+					type: 'success'
+				}, envId);
+			} else {
+				throw new Error(result.error || 'Failed to recreate container');
+			}
+		} else {
+			const plan = updatePlan!;
+			log(`Applying stack update policy: mode=${plan.mode} targets=[${plan.targets.join(', ')}]${plan.noCache ? ' no-cache' : ''}`);
+
+			const { updateStackService } = await import('../../stacks');
+			// Build/rebuild rely on `--build` (and Compose's own image-change detection) so
+			// the changed service is recreated; recreating every cascade target would be
+			// heavier than the issue asks for. Recreate-mode cascades get --force-recreate
+			// so the cascaded services genuinely come back instead of `up -d` no-op'ing them.
+			const forceRecreate = !buildFromContext && plan.targets.length > 1;
+			const stackResult = await updateStackService(stackProject!, stackService!, envId, undefined, {
+				serviceNames: plan.targets.slice(1),
+				build: plan.mode === 'build' || plan.mode === 'rebuild',
+				noBuildCache: plan.noCache && (plan.mode === 'build' || plan.mode === 'rebuild'),
+				forceRecreate
+			});
+
+			if (!stackResult.success) {
+				throw new Error(stackResult.error || 'Stack update failed');
+			}
+
+			// A rebuilt service keeps the image TAG, so "last updated" is still meaningful.
 			await updateAutoUpdateLastUpdated(containerName, envId);
-			log(`Successfully updated container: ${containerName}`);
+			log(`Successfully applied the stack update for service: ${stackService}`);
 
 			await updateScheduleExecution(execution.id, {
 				status: 'success',
 				completedAt: new Date().toISOString(),
 				duration: Date.now() - startTime,
-				details: buildSuccessDetails(
-					containerName,
-					newDigest,
-					vulnerabilityCriteria,
-					scanOutcome.scanResults,
-					scanOutcome.scanSummary
-				)
+				details: {
+					...buildSuccessDetails(
+						containerName,
+						newDigest,
+						vulnerabilityCriteria,
+						scanOutcome.scanResults,
+						scanOutcome.scanSummary
+					),
+					stackPolicy: {
+						stackName: stackProject!,
+						serviceName: stackService!,
+						mode: plan.mode,
+						cascade: updatePlanCascadeLabel(plan),
+						noCache: plan.noCache,
+						rebuilt: plan.targets,
+						skipped: plan.skipped
+					}
+				}
 			});
+
+			// A cascade/redeploy moves the whole stack - emit the stack-level event (in
+			// addition to the per-container one) so an operator can tell the whole stack
+			// moved, not just the one container that had an update. (#1539)
+			await sendEventNotification('container_updated', {
+				title: 'Container updated (stack redeploy)',
+				message: `Service "${stackService}" of stack "${stackProject}" was updated via compose (mode: ${plan.mode}${plan.targets.length > 1 ? `, redeployed: ${plan.targets.join(', ')}` : ''})`,
+				type: 'success'
+			}, envId);
+
+			if (plan.targets.length > 1 || plan.mode !== 'recreate') {
+				await sendEventNotification('stack_deployed', {
+					title: 'Stack redeployed by auto-update',
+					message: `Stack "${stackProject}" was redeployed by the auto-update of service "${stackService}" (mode: ${plan.mode}, targets: ${plan.targets.join(', ')})`,
+					type: 'success'
+				}, envId);
+			}
 
 			await sendEventNotification('auto_update_success', {
 				title: 'Container auto-updated',
-				message: `Container "${containerName}" was updated to a new image version`,
+				message: `Container "${containerName}" was updated (stack policy: ${plan.mode})`,
 				type: 'success'
 			}, envId);
-		} else {
-			throw new Error(result.error || 'Failed to recreate container');
 		}
 
 	} catch (error: any) {

--- a/src/lib/server/stack-update-policy.ts
+++ b/src/lib/server/stack-update-policy.ts
@@ -1,0 +1,283 @@
+/**
+ * Stack-level update policy (#1539).
+ *
+ * A declarative per-stack update policy read from compose metadata: a top-level
+ * `x-dockhand.update` block plus optional per-service `x-dockhand.update`
+ * overrides. Compose preserves `x-` extension fields through `config`
+ * round-trips and vanilla `compose up` ignores them, so the policy is
+ * version-controlled and travels with the stack definition.
+ *
+ * This module is intentionally PURE (js-yaml only, no db/docker imports) so the
+ * parsing and the cascade decision are unit-testable without a daemon.
+ *
+ * Absence of the block is the back-compat default: `recreate` + no cascade,
+ * which is byte-identical to the pre-#1539 auto-update.
+ *
+ *   x-dockhand:
+ *     update:
+ *       mode: rebuild          # recreate (default) | build | rebuild
+ *       cascade: same-image    # false (default) | same-image | all
+ *       no-cache: true         # optional, only meaningful with build/rebuild
+ *       exclude: [db, redis]   # services never touched by a cascade
+ *
+ *   services:
+ *     worker:
+ *       x-dockhand:
+ *         update:
+ *           mode: rebuild      # per-service override wins over the stack default
+ */
+
+import jsyaml from 'js-yaml';
+
+export type StackUpdateMode = 'recreate' | 'build' | 'rebuild';
+export type StackCascadeScope = 'false' | 'same-image' | 'all';
+
+export interface StackUpdatePolicy {
+	/** What "apply an update" does for the changed service. */
+	mode: StackUpdateMode;
+	/** How far an update propagates beyond the changed service. */
+	cascade: StackCascadeScope;
+	/** Pass `--no-cache` to builds (build/rebuild modes only). */
+	noCache: boolean;
+	/** Services that a cascade must never redeploy. Always wins over the scope. */
+	exclude: string[];
+}
+
+export interface StackServicePolicyInfo {
+	name: string;
+	/** The service's `image:` value, verbatim (may contain `${...}` interpolation). */
+	image?: string;
+	/** Whether the service declares a build context (`build:` / `dockerfile_inline`). */
+	hasBuild: boolean;
+	/** ONLY the fields explicitly present in the service's own x-dockhand block. */
+	override: Partial<StackUpdatePolicy>;
+}
+
+export interface ParsedStackUpdatePolicy {
+	stack: StackUpdatePolicy;
+	services: StackServicePolicyInfo[];
+	/** True when the compose file could not be parsed (policy falls back to defaults). */
+	unparseable: boolean;
+}
+
+export interface StackUpdatePlan {
+	/** Effective mode for the changed service (per-service override applied). */
+	mode: StackUpdateMode;
+	/** Effective no-cache flag for the changed service. */
+	noCache: boolean;
+	/** True when the whole stack (minus excluded services) is rebuilt. */
+	wholeStack: boolean;
+	/**
+	 * Services for `docker compose up`: the changed service first, then any
+	 * cascade targets, with excluded services removed. Empty means "all services"
+	 * is never produced here — the changed service is always present.
+	 */
+	targets: string[];
+	/** Services protected by `exclude` that a cascade would otherwise have touched. */
+	excludedServices: string[];
+	/** Per-service skips to report in the execution history. */
+	skipped: { service: string; reason: string }[];
+}
+
+export function defaultStackUpdatePolicy(): StackUpdatePolicy {
+	return { mode: 'recreate', cascade: 'false', noCache: false, exclude: [] };
+}
+
+/** True when the plan is the pre-#1539 behavior (no compose-level update work). */
+export function isDefaultStackUpdatePlan(plan: StackUpdatePlan): boolean {
+	return plan.mode === 'recreate' && plan.targets.length <= 1;
+}
+
+// =============================================================================
+// PARSING (tolerant: a bad value degrades to the default, never throws)
+// =============================================================================
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === 'object' && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function normalizeMode(value: unknown): StackUpdateMode | undefined {
+	if (typeof value !== 'string') return undefined;
+	const v = value.trim().toLowerCase();
+	return v === 'recreate' || v === 'build' || v === 'rebuild' ? v : undefined;
+}
+
+function normalizeCascade(value: unknown): StackCascadeScope | undefined {
+	if (value === false) return 'false';
+	if (typeof value !== 'string') return undefined;
+	const v = value.trim().toLowerCase();
+	return v === 'false' || v === 'same-image' || v === 'all' ? v : undefined;
+}
+
+function normalizeNoCache(value: unknown): boolean | undefined {
+	if (value === true || value === false) return value;
+	if (typeof value !== 'string') return undefined;
+	const v = value.trim().toLowerCase();
+	if (v === 'true' || v === 'yes' || v === '1') return true;
+	if (v === 'false' || v === 'no' || v === '0') return false;
+	return undefined;
+}
+
+function normalizeExclude(value: unknown): string[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	return value.filter((v): v is string => typeof v === 'string').map((v) => v.trim()).filter(Boolean);
+}
+
+/** Read only the recognized keys of one `x-dockhand.update` block. */
+function readUpdateBlock(raw: unknown): Partial<StackUpdatePolicy> {
+	const block = asRecord(raw);
+	if (!block) return {};
+	const out: Partial<StackUpdatePolicy> = {};
+	// YAML allows `no-cache`; accept `noCache` too (either spelling).
+	const mode = normalizeMode(block.mode);
+	if (mode) out.mode = mode;
+	const cascade = normalizeCascade(block.cascade);
+	if (cascade) out.cascade = cascade;
+	const noCache = normalizeNoCache(block['no-cache'] ?? block.noCache);
+	if (noCache !== undefined) out.noCache = noCache;
+	const exclude = normalizeExclude(block.exclude);
+	if (exclude) out.exclude = exclude;
+	return out;
+}
+
+/** The `update:` sub-block of an `x-dockhand` extension block, if present. */
+function readXdockhandUpdate(extension: unknown): Partial<StackUpdatePolicy> {
+	const ext = asRecord(extension);
+	if (!ext) return {};
+	return readUpdateBlock(ext.update);
+}
+
+/**
+ * Parse a compose file's x-dockhand update policy. Never throws: invalid YAML
+ * or malformed blocks degrade to the default policy (back-compat first).
+ */
+export function parseStackUpdatePolicy(composeContent: string): ParsedStackUpdatePolicy {
+	const defaults = defaultStackUpdatePolicy();
+	let doc: Record<string, unknown> | null = null;
+	try {
+		const loaded = jsyaml.load(composeContent);
+		doc = asRecord(loaded);
+	} catch {
+		return { stack: defaults, services: [], unparseable: true };
+	}
+	if (!doc) {
+		return { stack: defaults, services: [], unparseable: true };
+	}
+
+	const stack: StackUpdatePolicy = { ...defaults, ...readXdockhandUpdate(doc['x-dockhand']) };
+
+	const servicesRaw = asRecord(doc.services);
+	const services: StackServicePolicyInfo[] = [];
+	if (servicesRaw) {
+		for (const [name, rawSvc] of Object.entries(servicesRaw)) {
+			const svc = asRecord(rawSvc);
+			if (!svc) continue;
+			services.push({
+				name,
+				image: typeof svc.image === 'string' ? svc.image : undefined,
+				hasBuild: svc.build !== undefined && svc.build !== null && svc.build !== false,
+				override: readXdockhandUpdate(svc['x-dockhand'])
+			});
+		}
+	}
+
+	return { stack, services, unparseable: false };
+}
+
+/** Merge the stack default with a service's own override (override wins). */
+export function resolveServicePolicy(
+	parsed: ParsedStackUpdatePolicy,
+	serviceName: string
+): StackUpdatePolicy {
+	const svc = parsed.services.find((s) => s.name === serviceName);
+	return { ...parsed.stack, ...(svc?.override ?? {}) };
+}
+
+export function serviceHasBuildContext(
+	parsed: ParsedStackUpdatePolicy,
+	serviceName: string
+): boolean {
+	return parsed.services.find((s) => s.name === serviceName)?.hasBuild ?? false;
+}
+
+/**
+ * Normalize an image reference for same-image comparison: drop the digest, treat
+ * an absent/`latest` tag as implicit, and strip the default registry + library
+ * namespace so `nginx`, `nginx:latest`, and `docker.io/library/nginx:latest`
+ * all compare equal.
+ */
+export function normalizeImageRef(ref: string | undefined | null): string {
+	if (!ref) return '';
+	let s = ref.trim();
+	const at = s.indexOf('@');
+	if (at !== -1) s = s.slice(0, at);
+	const lastSlash = s.lastIndexOf('/');
+	const lastColon = s.lastIndexOf(':');
+	let repo = s;
+	let tag = '';
+	if (lastColon > lastSlash) {
+		repo = s.slice(0, lastColon);
+		tag = s.slice(lastColon + 1);
+	}
+	repo = repo
+		.replace(/^index\.docker\.io\//, '')
+		.replace(/^registry-1\.docker\.io\//, '')
+		.replace(/^docker\.io\//, '')
+		.replace(/^library\//, '');
+	if (!tag || tag === 'latest') return repo;
+	return `${repo}:${tag}`;
+}
+
+/**
+ * Decide what an update to `changedService` should do under the stack's policy.
+ *
+ * `exclude` always wins for CASCADE targets; the directly-updated service is
+ * never excluded from its own update. Rebuild mode and `cascade: all` both mean
+ * "the whole stack (minus exclude)", which is expressed as an explicit target
+ * list so excluded services are genuinely skipped.
+ */
+export function planStackUpdate(
+	parsed: ParsedStackUpdatePolicy,
+	changedService: string,
+	changedImage?: string
+): StackUpdatePlan {
+	const policy = resolveServicePolicy(parsed, changedService);
+	const known = parsed.services.map((s) => s.name);
+	const excluded = new Set(policy.exclude);
+
+	const sameImage = (name: string): boolean => {
+		const svc = parsed.services.find((s) => s.name === name);
+		const a = normalizeImageRef(svc?.image);
+		const b = normalizeImageRef(changedImage);
+		return a !== '' && b !== '' && a === b;
+	};
+
+	const wholeStack = policy.mode === 'rebuild' || policy.cascade === 'all';
+
+	let cascadeCandidates: string[] = [];
+	if (wholeStack) {
+		cascadeCandidates = known;
+	} else if (policy.cascade === 'same-image') {
+		cascadeCandidates = known.filter((n) => sameImage(n));
+	}
+
+	// Exclude always wins for cascaded services (never for the changed service itself).
+	const cascade = cascadeCandidates.filter((n) => n !== changedService && !excluded.has(n));
+	const excludedServices = cascadeCandidates.filter((n) => n !== changedService && excluded.has(n));
+
+	const targets = [changedService, ...cascade];
+	const skipped = [
+		...new Set(excludedServices.filter((n) => !targets.includes(n)))
+	].map((service) => ({ service, reason: 'excluded' }));
+
+	return {
+		mode: policy.mode,
+		noCache: policy.noCache,
+		wholeStack,
+		targets,
+		excludedServices: [...new Set(excludedServices)],
+		skipped
+	};
+}

--- a/src/lib/server/stacks.ts
+++ b/src/lib/server/stacks.ts
@@ -1124,6 +1124,8 @@ interface ComposeCommandOptions {
 	useOverrideFile?: boolean;
 	/** Target specific service only (with --no-deps) for single-service updates */
 	serviceName?: string;
+	/** Target multiple services in one compose command (#1539 cascade updates) */
+	serviceNames?: string[];
 	/** Compose filename for Hawser (e.g., "docker-compose.prod.yml") - extracted from composePath */
 	composeFileName?: string;
 	/** Git deletion sync (#966): files to delete on the Hawser agent's stack dir */
@@ -1189,6 +1191,7 @@ async function executeLocalCompose(
 	customEnvPath?: string,
 	useOverrideFile?: boolean,
 	serviceName?: string,
+	serviceNames?: string[],
 	build?: boolean,
 	noBuildCache?: boolean,
 	pullPolicy?: string,
@@ -1434,7 +1437,7 @@ async function executeLocalCompose(
 		console.log(`${logPrefix} [HostPath] Using stdin for compose content (paths translated)`);
 	}
 
-	args.push(...buildComposeOperationArgs(operation, { forceRecreate, removeVolumes, build, noBuildCache, pullPolicy, serviceName }));
+	args.push(...buildComposeOperationArgs(operation, { forceRecreate, removeVolumes, build, noBuildCache, pullPolicy, serviceName, serviceNames }));
 
 	const commandStr = args.join(' ');
 
@@ -1601,6 +1604,7 @@ async function executeComposeViaHawser(
 	removeVolumes?: boolean,
 	stackFiles?: Record<string, string>,
 	serviceName?: string,
+	serviceNames?: string[],
 	composeFileName?: string,
 	build?: boolean,
 	noBuildCache?: boolean,
@@ -1630,6 +1634,9 @@ async function executeComposeViaHawser(
 	console.log(`${logPrefix} Force recreate:`, forceRecreate ?? false);
 	console.log(`${logPrefix} Remove volumes:`, removeVolumes ?? false);
 	console.log(`${logPrefix} Service name:`, serviceName ?? '(all services)');
+	if (serviceNames && serviceNames.length > 0) {
+		console.log(`${logPrefix} Target services (#1539):`, serviceNames.join(', '));
+	}
 	console.log(`${logPrefix} Compose filename:`, composeFileName ?? '(auto-detect)');
 	console.log(`${logPrefix} Non-secret env vars count:`, envVars ? Object.keys(envVars).length : 0);
 	console.log(`${logPrefix} Secret env vars count:`, secretCount);
@@ -1689,6 +1696,7 @@ async function executeComposeViaHawser(
 			pullPolicy: pullPolicy || '',
 			registries, // Registry credentials for docker login
 			serviceName, // Target specific service only (with --no-deps)
+			serviceNames, // Multi-service cascade targets (#1539); old agents ignore the field
 			// Git deletion sync (#966): agent re-verifies containment + content
 			// hash per file before deleting. Old agents ignore this field.
 			filesToDelete: filesToDelete && filesToDelete.length > 0
@@ -1813,7 +1821,7 @@ async function executeComposeCommand(
 	secretVars?: Record<string, string>,
 	onLine?: (line: string) => void
 ): Promise<StackOperationResult> {
-	const { stackName, envId, forceRecreate, build, noBuildCache, pullPolicy, removeVolumes, stackFiles, workingDir, composePath, envPath, useOverrideFile, serviceName, composeFileName, filesToDelete, removeFiles } = options;
+	const { stackName, envId, forceRecreate, build, noBuildCache, pullPolicy, removeVolumes, stackFiles, workingDir, composePath, envPath, useOverrideFile, serviceName, serviceNames, composeFileName, filesToDelete, removeFiles } = options;
 
 	// Get environment configuration
 	const env = envId ? await getEnvironment(envId) : null;
@@ -1836,6 +1844,7 @@ async function executeComposeCommand(
 			envPath,
 			useOverrideFile,
 			serviceName,
+			serviceNames,
 			build,
 			noBuildCache,
 			pullPolicy,
@@ -1901,6 +1910,7 @@ async function executeComposeCommand(
 				removeVolumes,
 				hawserStackFiles,
 				serviceName,
+				serviceNames,
 				composeFileName,
 				build,
 				noBuildCache,
@@ -1967,6 +1977,7 @@ async function executeComposeCommand(
 				envPath,
 				useOverrideFile,
 				serviceName,
+				serviceNames,
 				build,
 				noBuildCache,
 				pullPolicy,
@@ -2001,6 +2012,7 @@ async function executeComposeCommand(
 				envPath,
 				useOverrideFile,
 				serviceName,
+				serviceNames,
 				build,
 				noBuildCache,
 				pullPolicy,
@@ -3353,13 +3365,30 @@ export async function pullStackService(
  * @param stackName - The compose project name
  * @param serviceName - The service name to update
  * @param envId - Optional environment ID
+ * @param options - Optional cascade/build options (#1539 stack update policy)
  * @returns Operation result
  */
+export interface UpdateStackServiceOptions {
+	/** Additional services to redeploy in the same compose invocation (cascade targets, #1539). */
+	serviceNames?: string[];
+	/** Pass `--build` so services with a build context are rebuilt before the `up` (#1539 mode: build/rebuild). */
+	build?: boolean;
+	/** Pass `--no-cache` to a separate build step (#1539 no-cache: true). */
+	noBuildCache?: boolean;
+	/**
+	 * Force-recreate the targeted services. Needed for a genuine whole-stack/cascade
+	 * redeploy: plain `up -d` only recreates services whose config/image actually
+	 * changed, so a cascaded service sharing no image would otherwise be left alone.
+	 */
+	forceRecreate?: boolean;
+}
+
 export async function updateStackService(
 	stackName: string,
 	serviceName: string,
 	envId?: number | null,
-	composeConfigPath?: string
+	composeConfigPath?: string,
+	options?: UpdateStackServiceOptions
 ): Promise<StackOperationResult> {
 	const result = await requireComposeFile(stackName, envId, composeConfigPath);
 
@@ -3376,16 +3405,38 @@ export async function updateStackService(
 	// naturally since the image was already pulled before this function is called.
 	// Using forceRecreate can cause permission issues on bind mounts.
 	// This matches the behavior of: docker compose pull && docker compose up -d
+	const cmdOptions: ComposeCommandOptions = {
+		stackName,
+		envId,
+		workingDir: result.stackDir,
+		composePath: result.composePath,
+		envPath: result.envPath,
+		serviceName,
+		serviceNames: options?.serviceNames,
+		build: options?.build,
+		noBuildCache: options?.noBuildCache,
+		forceRecreate: options?.forceRecreate
+	};
+
+	// `--no-cache` is a `build` flag, not an `up` flag (#1479): run a separate
+	// `docker compose build --no-cache` first, then a plain `up`. Skipped on Hawser
+	// (its agent has no build op).
+	const env = envId ? await getEnvironment(envId) : null;
+	if (shouldRunSeparateBuildStep(options?.build, options?.noBuildCache, env?.connectionType)) {
+		console.log(`[Stack:${stackName}] Running separate 'build --no-cache' step before up (#1539)...`);
+		const buildResult = await executeComposeCommand(
+			'build',
+			{ ...cmdOptions, serviceName: undefined, serviceNames: undefined, forceRecreate: false },
+			result.content!,
+			result.nonSecretVars,
+			result.secretVars
+		);
+		if (!buildResult.success) return buildResult;
+	}
+
 	return executeComposeCommand(
 		'up',
-		{
-			stackName,
-			envId,
-			workingDir: result.stackDir,
-			composePath: result.composePath,
-			envPath: result.envPath,
-			serviceName
-		},
+		cmdOptions,
 		result.content!,
 		result.nonSecretVars,
 		result.secretVars

--- a/tests/stack-update-policy.test.ts
+++ b/tests/stack-update-policy.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	parseStackUpdatePolicy,
+	planStackUpdate,
+	isDefaultStackUpdatePlan,
+	normalizeImageRef,
+	resolveServicePolicy,
+	serviceHasBuildContext,
+	defaultStackUpdatePolicy
+} from '../src/lib/server/stack-update-policy';
+
+const BASE = `
+x-dockhand:
+  update:
+    mode: rebuild
+    cascade: same-image
+    no-cache: true
+    exclude: [db, redis]
+services:
+  app:
+    build: .
+    image: ghcr.io/me/app:latest
+  worker:
+    build: ./worker
+    image: ghcr.io/me/app:latest
+  db:
+    image: postgres:16
+  redis:
+    image: redis:7
+`;
+
+describe('parseStackUpdatePolicy', () => {
+	test('no x-dockhand block -> back-compat defaults', () => {
+		const p = parseStackUpdatePolicy('services:\n  app:\n    image: nginx\n');
+		expect(p.stack).toEqual(defaultStackUpdatePolicy());
+		expect(p.unparseable).toBe(false);
+		expect(p.services.map((s) => s.name)).toEqual(['app']);
+	});
+
+	test('invalid YAML -> defaults, unparseable, never throws', () => {
+		const p = parseStackUpdatePolicy('services:\n  app:\n    build: [unterminated');
+		expect(p.unparseable).toBe(true);
+		expect(p.stack).toEqual(defaultStackUpdatePolicy());
+		expect(p.services).toEqual([]);
+	});
+
+	test('empty content -> defaults', () => {
+		expect(parseStackUpdatePolicy('').stack).toEqual(defaultStackUpdatePolicy());
+	});
+
+	test('reads the top-level block (mode, cascade, no-cache, exclude)', () => {
+		const p = parseStackUpdatePolicy(BASE);
+		expect(p.stack).toEqual({
+			mode: 'rebuild',
+			cascade: 'same-image',
+			noCache: true,
+			exclude: ['db', 'redis']
+		});
+	});
+
+	test('accepts camelCase noCache and cascade: false as a boolean', () => {
+		const p = parseStackUpdatePolicy(
+			'x-dockhand:\n  update:\n    cascade: false\n    noCache: true\nservices:\n  app:\n    image: nginx\n'
+		);
+		expect(p.stack.cascade).toBe('false');
+		expect(p.stack.noCache).toBe(true);
+	});
+
+	test('unknown/invalid values degrade to the default, not a crash', () => {
+		const p = parseStackUpdatePolicy(
+			'x-dockhand:\n  update:\n    mode: explode\n    cascade: sideways\n    no-cache: maybe\nservices:\n  app:\n    image: nginx\n'
+		);
+		expect(p.stack).toEqual(defaultStackUpdatePolicy());
+	});
+
+	test('detects build: (string and object) per service', () => {
+		const p = parseStackUpdatePolicy(
+			'services:\n  a:\n    build: ./a\n  b:\n    build:\n      context: .\n      dockerfile_inline: FROM x\n  c:\n    image: nginx\n'
+		);
+		expect(serviceHasBuildContext(p, 'a')).toBe(true);
+		expect(serviceHasBuildContext(p, 'b')).toBe(true);
+		expect(serviceHasBuildContext(p, 'c')).toBe(false);
+		expect(p.services.find((s) => s.name === 'c')?.hasBuild).toBe(false);
+	});
+
+	test('captures a per-service override', () => {
+		const p = parseStackUpdatePolicy(
+			'x-dockhand:\n  update:\n    mode: recreate\nservices:\n  worker:\n    image: app\n    x-dockhand:\n      update:\n        mode: rebuild\n'
+		);
+		expect(resolveServicePolicy(p, 'worker').mode).toBe('rebuild');
+		expect(resolveServicePolicy(p, 'other').mode).toBe('recreate');
+	});
+});
+
+describe('normalizeImageRef', () => {
+	test('treats implicit and explicit latest the same', () => {
+		expect(normalizeImageRef('nginx')).toBe(normalizeImageRef('nginx:latest'));
+	});
+
+	test('strips the default registry and library namespace', () => {
+		expect(normalizeImageRef('docker.io/library/nginx:1.25')).toBe(normalizeImageRef('nginx:1.25'));
+	});
+
+	test('drops the digest', () => {
+		expect(normalizeImageRef('app@sha256:abc')).toBe(normalizeImageRef('app:latest'));
+	});
+
+	test('keeps a real tag and a non-default registry host', () => {
+		expect(normalizeImageRef('ghcr.io/me/app:1.2')).not.toBe(normalizeImageRef('ghcr.io/me/app:1.3'));
+		expect(normalizeImageRef('ghcr.io/me/app:1.2')).toBe('ghcr.io/me/app:1.2');
+	});
+});
+
+describe('planStackUpdate', () => {
+	test('no policy -> default single-service plan (back-compat)', () => {
+		const parsed = parseStackUpdatePolicy('services:\n  app:\n    image: nginx\n');
+		const plan = planStackUpdate(parsed, 'app', 'nginx');
+		expect(isDefaultStackUpdatePlan(plan)).toBe(true);
+		expect(plan.mode).toBe('recreate');
+		expect(plan.targets).toEqual(['app']);
+		expect(plan.wholeStack).toBe(false);
+	});
+
+	test('cascade: same-image redeploys services sharing the changed image', () => {
+		const parsed = parseStackUpdatePolicy(BASE);
+		const plan = planStackUpdate(parsed, 'app', 'ghcr.io/me/app:latest');
+		expect(plan.targets).toEqual(['app', 'worker']);
+		expect(plan.mode).toBe('rebuild');
+		expect(plan.noCache).toBe(true);
+	});
+
+	test('cascade: all redeploys the whole stack minus exclude', () => {
+		const parsed = parseStackUpdatePolicy(
+			'x-dockhand:\n  update:\n    cascade: all\n    exclude: [db]\nservices:\n  app:\n    image: a\n  worker:\n    image: b\n  db:\n    image: postgres\n'
+		);
+		const plan = planStackUpdate(parsed, 'app', 'a');
+		expect(plan.targets).toEqual(['app', 'worker']);
+		expect(plan.excludedServices).toEqual(['db']);
+		expect(plan.skipped).toEqual([{ service: 'db', reason: 'excluded' }]);
+	});
+
+	test('exclude always wins, but the changed service is never dropped from its own update', () => {
+		const parsed = parseStackUpdatePolicy(
+			'x-dockhand:\n  update:\n    cascade: all\n    exclude: [app]\nservices:\n  app:\n    image: a\n  other:\n    image: b\n'
+		);
+		const plan = planStackUpdate(parsed, 'app', 'a');
+		expect(plan.targets).toEqual(['app', 'other']);
+	});
+
+	test('mode: rebuild alone means whole stack', () => {
+		const parsed = parseStackUpdatePolicy(
+			'x-dockhand:\n  update:\n    mode: rebuild\nservices:\n  app:\n    build: .\n  sidecar:\n    build: ./s\n'
+		);
+		const plan = planStackUpdate(parsed, 'app', 'app');
+		expect(plan.wholeStack).toBe(true);
+		expect(plan.targets).toEqual(['app', 'sidecar']);
+	});
+
+	test('mode: build scopes to the changed service unless a cascade is set', () => {
+		const parsed = parseStackUpdatePolicy(
+			'x-dockhand:\n  update:\n    mode: build\nservices:\n  app:\n    build: .\n  worker:\n    build: ./w\n'
+		);
+		const plan = planStackUpdate(parsed, 'app', 'app');
+		expect(plan.mode).toBe('build');
+		expect(plan.targets).toEqual(['app']);
+		expect(plan.wholeStack).toBe(false);
+	});
+
+	test('per-service override beats the stack default', () => {
+		const parsed = parseStackUpdatePolicy(
+			'x-dockhand:\n  update:\n    mode: recreate\nservices:\n  worker:\n    image: app\n    x-dockhand:\n      update:\n        mode: rebuild\n  app:\n    image: app\n'
+		);
+		expect(planStackUpdate(parsed, 'worker', 'app').mode).toBe('rebuild');
+		expect(planStackUpdate(parsed, 'app', 'app').mode).toBe('recreate');
+	});
+
+	test('same-image cascade does not match an interpolated image against the resolved running image', () => {
+		// The compose value is the raw `${TAG}`; the changed container reports its
+		// RESOLVED image. They can never be proven equal, so no optimistic cascade.
+		const parsed = parseStackUpdatePolicy(
+			'x-dockhand:\n  update:\n    cascade: same-image\nservices:\n  app:\n    image: ${TAG}\n  other:\n    image: ${TAG}\n'
+		);
+		const plan = planStackUpdate(parsed, 'app', 'ghcr.io/me/app:1.2');
+		expect(plan.targets).toEqual(['app']);
+	});
+});


### PR DESCRIPTION
Closes #1539

## Proposed change

A declarative, per-stack update policy read from compose metadata (`x-dockhand.update`), covering the two gaps in the current auto-update model:

- **Rebuild support** — auto-update currently pulls the image and force-recreates the container, but never runs `docker compose build`. Stacks with `build:` / `dockerfile_inline` can never be auto-updated correctly.
- **Cascade updates** — no way to say "when one service in this stack updates, redeploy/rebuild the entire stack."

```yaml
x-dockhand:
  update:
    mode: rebuild          # recreate (default) | build | rebuild
    cascade: same-image    # false (default) | same-image | all
    no-cache: true         # optional, only meaningful with build/rebuild
    exclude: [db, redis]   # services never touched by a cascade

services:
  worker:
    build: ./worker
    x-dockhand:
      update:
        mode: rebuild      # per-service override wins over the stack default
```

### Implementation

| File | Change |
|---|---|
| `src/lib/server/stack-update-policy.ts` | **New.** Pure js-yaml parser + planner. No db/docker imports, so it unit-tests without a daemon. |
| `src/lib/server/compose-args.ts` | `serviceNames[]` — multi-service targets for `up`/`pull`/`build`. |
| `src/lib/server/stacks.ts` | Plumbed `serviceNames` through all three compose executors; `updateStackService` gains `serviceNames`/`build`/`noBuildCache`/`forceRecreate`. |
| `src/lib/server/scheduler/tasks/container-update.ts` | Reads the policy, applies non-default plans via compose, records per-service history. |
| `tests/stack-update-policy.test.ts` | **New.** 20 tests. |

### Key decisions

- **No `x-dockhand` block ⇒ default plan ⇒ byte-identical to today.** The existing registry-pull → temp-tag → scan → recreate path is untouched unless the policy actually changes something.
- **`build`/`rebuild` bypass the registry check.** This is required, not an optimization: `checkImageUpdateAvailable` gates the whole run on a registry digest a build-context stack can never supply, so such stacks were structurally un-updatable. Skipping that gate is the only way to satisfy the first acceptance criterion.
- **Cascade targets run through `docker compose`, not the Docker-API recreate** — that's what makes `--build` and a multi-service target list possible.
- **`exclude` protects against `same-image` too**, not just `all` — a service sharing the changed image is still skipped.
- **Recreate-mode cascades pass `--force-recreate`**; build/rebuild rely on `--build` plus Compose's own image-change detection. Avoids heavier-than-asked-for churn.

### Behavior details

- `env_update_check` (detect) and `container_update` (apply) stay separate — this only changes what *apply* does.
- Execution history records per-service results: `stackPolicy: { mode, cascade, noCache, rebuilt: [...], skipped: [{ service, reason: 'excluded' }] }`.
- Cascade redeploys emit a stack-level `stack_deployed` event alongside the per-container `container_updated`.

### How to test

1. Add an `x-dockhand.update` block to a test stack with a `build:` service.
2. Enable a `container_update` schedule for that container.
3. A run with `mode: rebuild` should build from context and redeploy without a registry pull; `cascade: same-image` should move sibling services sharing the image; listed `exclude` services should appear as skips in the execution history.

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [x] New feature / Enhancement: non-breaking change which adds functionality.
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Other. Please explain:

## Notes / open questions

1. **Hawser agents ignore `serviceNames`.** The field is forwarded to `/_hawser/compose`, but the Hawser agent is a separate binary (not in this repo), so an already-deployed agent will ignore it and fall back to `serviceName`. On a Hawser-connected environment a cascade therefore degrades to the single-service update — silently. Happy to extend the agent protocol, or to gate the policy path on `connectionType` — let me know which you'd prefer.
2. **`same-image` is string-matched** on the container's `Config.Image`. A stack that parameterizes `image: ${TAG}` can't be proven equal to the resolved running image, so it conservatively stays single-service rather than cascading on a guess.
3. I left the pre-existing `--no-deps` doc comments in `stacks.ts` alone; the arg builder never actually emits that flag. Flagging it rather than changing unrelated behavior — happy to clean that up separately if you want.

## Verification

- `tests/stack-update-policy.test.ts` — 20 tests: parsing, invalid-YAML degradation, per-service overrides, back-compat defaults, all cascade scopes, exclude precedence, image-ref normalization.
- **Full suite: 3296 pass / 0 fail across 225 files** (`bun test tests/`).
- Typecheck clean on all touched files (repo has pre-existing `tsc` noise; the project uses `svelte-check`).
